### PR TITLE
turn x86 in a test-only target

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 ---
 
 TODO
-- [ ] decoder
-- [ ] terminal printer
-- [ ] float support
 - [ ] test in QEMU
 - [ ] work on macro interface
 
@@ -24,6 +21,7 @@ TODO
 - Custom linking (linker script) is required
 - Single, global logger instance
 - The `@` character is not allowed in strings but otherwise UTF-8 is supported &#x1F44D
+- No x86 support. This architecture is exclusively used for testing at the moment.
 - ???
 
 ## Intended use

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -165,9 +165,8 @@ fn parse_args<'t>(bytes: &mut &[u8], format: &str, table: &'t Table) -> Result<V
                 args.push(Arg::Uxx(data as u64));
             }
 
-            Type::BitField(_) => {}
-            Type::Bool => {}
-            // {:?}
+            Type::BitField(_) => todo!(),
+            Type::Bool => todo!(),
             Type::Format => {
                 let index = leb128::read::unsigned(bytes).map_err(drop)?;
                 let (level, format) = table.get(index as usize)?;
@@ -194,7 +193,7 @@ fn parse_args<'t>(bytes: &mut &[u8], format: &str, table: &'t Table) -> Result<V
                 let data = bytes.read_i8().map_err(drop)?;
                 args.push(Arg::Ixx(data as i64));
             }
-            Type::Str => {}
+            Type::Str => todo!(),
             Type::U16 => {
                 let data = bytes.read_u16::<LE>().map_err(drop)?;
                 args.push(Arg::Uxx(data as u64));
@@ -213,7 +212,7 @@ fn parse_args<'t>(bytes: &mut &[u8], format: &str, table: &'t Table) -> Result<V
                 let data = bytes.read_u32::<LE>().map_err(drop)?;
                 args.push(Arg::F32(f32::from_bits(data)));
             }
-            Type::Slice => {}
+            Type::Slice => todo!(),
         }
     }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -2,11 +2,40 @@ use crate::{Formatter, Str};
 
 pub use common::Level;
 
+#[cfg(target_arch = "x86_64")]
+thread_local! {
+    static I: core::sync::atomic::AtomicUsize =
+        core::sync::atomic::AtomicUsize::new(0);
+    static T: core::sync::atomic::AtomicU64 =
+        core::sync::atomic::AtomicU64::new(0);
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn fetch_string_index() -> usize {
+    I.with(|i| i.load(core::sync::atomic::Ordering::Relaxed))
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn fetch_add_string_index() -> usize {
+    I.with(|i| i.fetch_add(1, core::sync::atomic::Ordering::Relaxed))
+}
+
+#[cfg(target_arch = "x86_64")]
+pub fn fetch_timestamp() -> u64 {
+    T.with(|i| i.load(core::sync::atomic::Ordering::Relaxed))
+}
+
 pub fn threshold() -> Level {
     // TODO add Cargo features
     Level::Info
 }
 
+#[cfg(target_arch = "x86_64")]
+pub fn acquire() -> Option<Formatter> {
+    None
+}
+
+#[cfg(not(target_arch = "x86_64"))]
 pub fn acquire() -> Option<Formatter> {
     extern "Rust" {
         fn _binfmt_acquire() -> Option<Formatter>;
@@ -14,6 +43,10 @@ pub fn acquire() -> Option<Formatter> {
     unsafe { _binfmt_acquire() }
 }
 
+#[cfg(target_arch = "x86_64")]
+pub fn release(_: Formatter) {}
+
+#[cfg(not(target_arch = "x86_64"))]
 pub fn release(fmt: Formatter) {
     extern "Rust" {
         fn _binfmt_release(fmt: Formatter);
@@ -21,6 +54,12 @@ pub fn release(fmt: Formatter) {
     unsafe { _binfmt_release(fmt) }
 }
 
+#[cfg(target_arch = "x86_64")]
+pub fn timestamp() -> u64 {
+    T.with(|i| i.fetch_add(1, core::sync::atomic::Ordering::Relaxed))
+}
+
+#[cfg(not(target_arch = "x86_64"))]
 pub fn timestamp() -> u64 {
     extern "Rust" {
         fn _binfmt_timestamp() -> u64;
@@ -28,7 +67,7 @@ pub fn timestamp() -> u64 {
     unsafe { _binfmt_timestamp() }
 }
 
-pub fn str(address: &'static u8) -> Str {
+pub fn str(address: usize) -> Str {
     Str {
         // NOTE address is limited to 14 bits in the linker script
         #[cfg(not(test))]


### PR DESCRIPTION
adds `winfo!` which does the same as `info!` but takes a `Formatter` argument
like `write!`

Now you can test the macros on x86. You cannot test `info!` directly (because of
global state) but `winfo!` does the same on `Formatter`

``` rust
struct S {
    x: u8,
}

fn main() {
    let mut f = binfmt::Formatter::new();
    binfmt::winfo!(&mut f, "The answer is {:?}", S { x: 42 });
    println!("{:?}", f.bytes());
    // output:   [0, 0, 1, 42]
    // 'answer is'^  ^  ^  ^^ `S.x`
    //       timestamp  'S {{ x: {:u8} }}

    // note: no timestamp
    let mut f = binfmt::Formatter::new();
    binfmt::write!(&mut f, "The answer is {:u8}", 42);
    println!("{:?}", f.bytes());
    //    output: [2, 42]
    // 'answer is' ^  ^^ arg0
}
```