### PR TITLE
Extend decoder and printer to handle slices, strings and bools

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,16 @@ binfmt::error!("Data: {:[u8]}!", [0, 1, 2]);
 //   LEB128(length) ^
 ```
 
+#### String values
+Strings that are passed directly (i.e. not as indices of interned strings) as format string parameters (`{:str}`) must be prefixed with their LEB128 encoded length. This behavior is analogous to that of Slices.
+
+``` rust
+binfmt::error!("Hello, {:str}!", [b'w', b'o', b'r', b'l', b'd']);
+// on the wire: [1, 5, 199, 111, 114, 108, 100]
+//  string index ^  ^  ^^^^^^^^^^^^^^^^^^^^^^^ the slice data (byte literals are ascii chars)
+//   LEB128(length) ^
+```
+
 #### Arrays
 
 For arrays (`{:[u8; N]}`) the length is not serialized.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -23,7 +23,7 @@ pub enum Type {
     I16,
     I32,
     I8,
-    Str,
+    Str, // used for string values (i.e. passed directly; not as interned string indices)
     U16,
     U24,
     U32,


### PR DESCRIPTION
pairing with @jonas-schievink 

note: branched off of https://github.com/ferrous-systems/binfmt/pull/4