### PR TITLE
macros. implement other logging levels

### DIFF
--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -12,8 +12,13 @@ panic-halt = "0.2.0"
 binfmt = { path = ".." }
 
 [features]
-binfmt-on = []
-default = ["binfmt-on"]
+binfmt-default = [] # log at INFO, or TRACE, level and up
+binfmt-trace = []   # log at TRACE level and up
+binfmt-debug = []   # log at DEBUG level and up
+binfmt-info = []    # log at INFO level and up
+binfmt-warn = []    # log at WARN level and up
+binfmt-error = []   # log at ERROR level
+default = ["binfmt-default"]
 
 # optimize code in both profiles
 [profile.dev]

--- a/firmware/src/bin/log.rs
+++ b/firmware/src/bin/log.rs
@@ -13,6 +13,12 @@ fn main() -> ! {
     binfmt::info!("World!");
     binfmt::info!("The answer is {:u8}", 42);
 
+    binfmt::trace!("log trace");
+    binfmt::debug!("log debug");
+    binfmt::info!("log info");
+    binfmt::warn!("log warn");
+    binfmt::error!("log error");
+
     #[derive(Format)]
     struct S {
         x: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use core::{mem::MaybeUninit, ptr::NonNull};
 pub use binfmt_macros::intern;
 #[doc(hidden)]
 pub use binfmt_macros::winfo;
-pub use binfmt_macros::{info, write, Format};
+pub use binfmt_macros::{info, trace, debug, warn, error, write, Format};
 
 use crate as binfmt;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -42,3 +42,13 @@ fn leb() {
         [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 1]
     );
 }
+
+#[test]
+fn log_levels() {
+    // just make sure they build OK for now
+    binfmt::trace!("test trace");
+    binfmt::debug!("test debug");
+    binfmt::info!("test info");
+    binfmt::warn!("test warn");
+    binfmt::error!("test error");
+}


### PR DESCRIPTION
paired with @jonas-schievink 

Add `trace`, `debug`, `warn` and `error` log levels and fix log level handling.
Also adds a tiny compile test to at least ensure future US won't break anything.
Extends `firmware` to demonstrate different log levels.

To manually check, play around with the `default = ["binfmt-xx"]` setting in `firmware/Cargo.toml` and run emulation in `firmware`.

resolves https://github.com/ferrous-systems/binfmt/issues/17
fixes https://github.com/ferrous-systems/binfmt/issues/16

will squash after approval :)