### PR TITLE
CI: run qemu examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "--deny warnings"
   NO_STD_TARGET: thumbv7em-none-eabi  # firmware uses atomics
+  QEMU_TARGET: thumbv7m-none-eabi
 
 jobs:
   test:
@@ -40,7 +40,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
     - name: Build
-      run: cargo build
+      run: RUSTFLAGS='--deny warnings' cargo build
       # NOTE order is important; running `mdbook` at the end = duplicate crate errors
     - name: Run book tests
       working-directory: book
@@ -58,9 +58,31 @@ jobs:
         toolchain: stable
         override: true
         target: ${{ env.NO_STD_TARGET }}
-    - name: Build QEMU examples
-      working-directory: firmware/qemu
-      run: cargo build --verbose --target ${{ env.NO_STD_TARGET }} --bins
+    - name: Install dependencies
+      run: rustup +stable target add ${{ env.NO_STD_TARGET }}
     - name: Build nRF52 examples
       working-directory: firmware/nrf52
-      run: cargo build --verbose --target ${{ env.NO_STD_TARGET }} --bins
+      run: RUSTFLAGS='--deny warnings' cargo build --verbose --target ${{ env.NO_STD_TARGET }} --bins
+
+  qemu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        target: ${{ env.QEMU_TARGET }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get update && sudo apt-get install qemu
+        rustup +stable target add ${{ env.QEMU_TARGET }}
+    - name: Build QEMU examples
+      working-directory: firmware/qemu
+      run: RUSTFLAGS='--deny warnings' cargo build --verbose --target ${{ env.QEMU_TARGET }} --bins
+    - name: Run QEMU examples
+      working-directory: firmware/qemu
+      run: |
+        cargo rb log
+        cargo rrb log

--- a/firmware/nrf52/README.md
+++ b/firmware/nrf52/README.md
@@ -5,4 +5,11 @@ Sample project that targets the nRF52840. Should work with any development board
 ``` console
 $ # runs the binary named `log` (see `src/bin`)
 $ cargo rb log
+(...)
+flashing program ..
+DONE
+resetting device
+0.000016 INFO Hello!
+0.000106 INFO World!
+(...)
 ```

--- a/firmware/qemu/README.md
+++ b/firmware/qemu/README.md
@@ -10,11 +10,22 @@ Firmware configured to run on QEMU to try out defmt end-to-end (encoder + decode
 Run the examples with:
 
 ``` console
-$ # alias for cargo-run --bin
+$ # alias for cargo-run --bin as set in .cargo/config
 $ cargo rb log
-(..)
-
-$ # alias for cargo-run --release --bin
-$ cargo rrb log
-(..)
+(...)
+0.000000 INFO Hello!
+0.000001 INFO World!
+(...)
 ```
+
+or
+``` console
+$ # alias for cargo-run --release --bin as set in .cargo/config
+$ cargo rrb log
+(...)
+0.000000 INFO Hello!
+0.000001 INFO World!
+(...)
+```
+
+Note the difference in log levels for debug and release; for details see the [Logging level filtering](../README.md#logging-level-filtering) documentation.

--- a/qemu-run/src/main.rs
+++ b/qemu-run/src/main.rs
@@ -44,7 +44,8 @@ fn notmain() -> Result<Option<i32>, anyhow::Error> {
             ])
             .arg(path)
             .stdout(Stdio::piped())
-            .spawn()?,
+            .spawn()
+            .expect("Error running qemu-system-arm; perhaps you haven't installed it yet?"),
     );
 
     let mut stdout = child


### PR DESCRIPTION
make the CI run qemu examples

as a drive-by:
- improve qemu-run error msg
- extend descriptioion in READMEwip; opening as PR to test CI changes