### PR TITLE
qemu-run: pass `-monitor none` to fix Ctrl+C

### DIFF
--- a/qemu-run/src/main.rs
+++ b/qemu-run/src/main.rs
@@ -34,6 +34,8 @@ fn notmain() -> Result<Option<i32>, anyhow::Error> {
             "-machine",
             "lm3s6965evb",
             "-nographic",
+            "-monitor",
+            "none",
             "-semihosting-config",
             "enable=on,target=native",
             "-kernel",


### PR DESCRIPTION
I don't quite understand how this works, but this fixes #37 