### PR TITLE
Disable nightly, macOS, and Windows CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
       matrix:
         rust:
           - stable
-          - nightly
+          #- nightly
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          #- macOS-latest
+          #- windows-latest
+          # FIXME: Reenable macOS, Windows, and nightly once binfmt is open-sourced.
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Saves a lot of CI cost. We'll reenable them once binfmt is open-sourced.