### PR TITLE
Parse trailing commas in most macros

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -499,7 +499,7 @@ impl Parse for Log {
             rest: if input.is_empty() {
                 None
             } else {
-                Some((input.parse()?, Punctuated::parse_separated_nonempty(input)?))
+                Some((input.parse()?, Punctuated::parse_terminated(input)?))
             },
         })
     }
@@ -627,7 +627,7 @@ impl Parse for Write {
             rest: if input.is_empty() {
                 None
             } else {
-                Some((input.parse()?, Punctuated::parse_separated_nonempty(input)?))
+                Some((input.parse()?, Punctuated::parse_terminated(input)?))
             },
         })
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,3 +52,26 @@ fn log_levels() {
     binfmt::warn!("test warn");
     binfmt::error!("test error");
 }
+
+#[test]
+fn trailing_comma() {
+    binfmt::trace!("test trace",);
+    binfmt::debug!("test debug",);
+    binfmt::info!("test info",);
+    binfmt::warn!("test warn",);
+    binfmt::error!("test error",);
+
+    binfmt::trace!("test trace {:?}", 0,);
+    binfmt::debug!("test debug {:?}", 0,);
+    binfmt::info!("test info {:?}", 0,);
+    binfmt::warn!("test warn {:?}", 0,);
+    binfmt::error!("test error {:?}", 0,);
+
+    // Don't run this code, just check that it builds.
+    #[allow(unreachable_code, unused_variables)]
+    if false {
+        let fmt: binfmt::Formatter = panic!();
+        binfmt::write!(fmt, "test write",);
+        binfmt::write!(fmt, "test write {:?}", 0,);
+    }
+}


### PR DESCRIPTION
Notable exception: `intern!`. But I think it makes sense to have that *just* accept a single string literal token.

Fixes https://github.com/ferrous-systems/binfmt/issues/44