### PR TITLE
add panic-probe

### DIFF
--- a/firmware/nrf52/Cargo.toml
+++ b/firmware/nrf52/Cargo.toml
@@ -13,7 +13,7 @@ cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 embedded-hal = "0.2.4"
 nrf52840-hal = "0.10.0"
-panic-halt = "0.2.0"
+panic-probe = { path = "../panic-probe" }
 
 [features]
 binfmt-default = []

--- a/firmware/nrf52/src/bin/panic.rs
+++ b/firmware/nrf52/src/bin/panic.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+use binfmt_rtt as _; // <- global logger
+use cortex_m_rt::entry;
+use nrf52840_hal as _; // <- memory layout
+use panic_probe as _; // <- panicking behavior
+
+#[binfmt::timestamp]
+fn timestamp() -> u64 {
+    0
+}
+
+#[entry]
+fn main() -> ! {
+    binfmt::info!("main");
+
+    panic!()
+}

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "panic-probe"
+version = "0.1.0"
+authors = ["Jorge Aparicio <jorge.aparicio@ferrous-systems.com>"]
+edition = "2018"
+
+[dependencies]
+cortex-m = "0.6.3"
+cortex-m-rt = "0.6.12"

--- a/firmware/panic-probe/src/lib.rs
+++ b/firmware/panic-probe/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+
+use core::panic::PanicInfo;
+
+use cortex_m::asm;
+use cortex_m_rt::{exception, ExceptionFrame};
+
+#[panic_handler]
+fn abort(_: &PanicInfo) -> ! {
+    // trigger a `HardFault`
+    asm::udf()
+}
+
+#[exception]
+fn HardFault(_: &ExceptionFrame) -> ! {
+    loop {
+        // make `probe-run` print the backtrace and exit
+        asm::bkpt()
+    }
+}


### PR DESCRIPTION
this panic handler makes `probe-run` exit with exit-code=134 (SIGABRT)
closes #41 

``` console
$ cd nrf52
$ cargo rb panic
0.000000 INFO main
stack backtrace:
   0: 0x000002be - __bkpt
   1: 0x000002bc - panic_probe::__cortex_m_rt_HardFault
   2: 0x0000036a - HardFault
      <exception entry>
   3: 0x000002d0 - __udf
   4: 0x000002b2 - cortex_m::asm::udf
   5: 0x000002a8 - rust_begin_unwind
   6: 0x0000025a - core::panicking::panic_fmt
   7: 0x00000250 - core::panicking::panic
   8: 0x00000162 - panic::__cortex_m_rt_main
   9: 0x00000108 - main
  10: 0x00000286 - Reset
$ echo $?
134
```