### PR TITLE
Extend formatters: implement boolean compression

### DIFF
--- a/book/src/ser-bool.md
+++ b/book/src/ser-bool.md
@@ -1,20 +1,49 @@
 # Bool
 
-Booleans are grouped in bytes, bitflags-style.
+
+Booleans are compressed in bytes, bitflags-style.
 
 ``` rust
 binfmt::error!("x: {:bool}, y: {:bool}, z: {:bool}", false, false, true);
-// on the wire: [1, 0b100]
-//  string index ^  ^^^^^ the booleans: `0bzyx`
+// on the wire: [1, 0b001]
+//  string index ^  ^^^^^ the booleans: `0bxyz`
 ```
 
 When mixed with other data, the first `{:bool}` allocates an output byte that
 fits up to 7 more bools.
 
+`{:bool}`s in the formatting string are batched together as follows: Any non-`{:bool}` arguments are emitted as-is, while `{:bool}` arguments are collected into a byte and emitted when 8 `{:bool}`s have been collected. This means that for every set of 8 `{:bool}`s, the byte containing them will be serialized at the position of their last member.
+If more than 0 but less than 8 `{:bool}`s have been encountered at the end of the log frame, a byte containing them will be emitted last.
+
 ``` rust
 binfmt::error!("x: {:bool}, y: {:u8}, z: {:bool}", false, 0xff, true);
-// on the wire: [1, 0b10, 0xff]
-//  string index ^  ^^^^^ ^^^^ u8
+// on the wire: [1, 0xff, 0b01]
+//  string index ^  ^^^^^ ^^^^ the booleans: `0bxz`
 //                  |
-//                  the booleans: `0bzx`
+//                  u8
+```
+
+⚠️ If the final parameter is not a `{:bool}` but there are yet to be compressed `{:bool}`s present in the format string beforehand, the final output byte containing all compressed booleans will be at the end.
+
+``` rust
+binfmt::error!("x: {:bool}, y: {:u8}", false, 0xff);
+// on the wire: [1, 0xff, 0b0,]
+//  string index ^  ^^^^^ ^^^^ the booleans: `0bx`
+//                  |
+//                  u8
+```
+
+⚠️ If some `{:bool}`s are nested inside a struct, they will still be compressed as if they were passed as regular arguments.
+
+``` rust
+struct Flags {
+         a: bool,
+         b: bool,
+}
+
+binfmt::error!("x: {:bool}, {:?}", false, Flags { a: true, b: false });
+// on the wire: [1, 2, 0b010,]
+//  string index ^  ^  ^^^^ all booleans: `0bxab`
+//                  |
+//                  index of "Flags { a: {:bool}, b: {:bool}} "
 ```

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -15,7 +15,7 @@ fn main() -> ! {
     binfmt::info!("World!");
     binfmt::info!("The answer is {:u8}", 42);
     binfmt::info!("Hello {0:u8} {0:u8}!", 42);
-    binfmt::info!("Hello {1:u16} {0:u8}", 42u8, 256u16);
+    binfmt::info!("Hello {1:u16} {0:u8} {:bool}", 42u8, 256u16, false);
     binfmt::info!("🍕 slice {:[u8]}", [3, 14]);
     binfmt::info!("🍕 array {:[u8; 3]}", [3, 14, 1]);
     binfmt::info!("float like a butterfly {:f32}", 5.67f32);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -91,6 +91,13 @@ impl Format for &[u8] {
     }
 }
 
+impl Format for bool {
+    fn format(&self, fmt: &mut Formatter) {
+        let t = internp!("{:bool}");
+        fmt.write(&[t, *self as u8]);
+    }
+}
+
 macro_rules! arrays {
     ( $($len:literal $fmt:literal,)+ ) => { $(
         impl Format for [u8; $len] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub use binfmt_macros::winfo;
 #[doc(hidden)] // documented as the `Format` trait instead
 pub use binfmt_macros::Format;
 
-/// Global logger acquire-release mechanism.
+/// Global logger acquire-release mechanism
 ///
 /// # Safety contract
 ///
@@ -161,13 +161,21 @@ pub struct Formatter {
     writer: NonNull<dyn Write>,
     #[cfg(target_arch = "x86_64")]
     bytes: Vec<u8>,
+    bool_flags: u8, // the current group of consecutive bools
+    bools_left: u8, // the number of bits that we can still set in bool_flag
 }
+
+/// the maximum number of booleans that can be compressed together
+const MAX_NUM_BOOL_FLAGS: u8 = 8;
 
 impl Formatter {
     /// Only for testing on x86_64
     #[cfg(target_arch = "x86_64")]
     pub fn new() -> Self {
-        Self { bytes: vec![] }
+        Self { bytes: vec![],
+               bool_flags: 0,
+               bools_left: MAX_NUM_BOOL_FLAGS,
+             }
     }
 
     /// Only for testing on x86_64
@@ -199,7 +207,10 @@ impl Formatter {
     #[cfg(not(target_arch = "x86_64"))]
     #[doc(hidden)]
     pub unsafe fn from_raw(writer: NonNull<dyn Write>) -> Self {
-        Self { writer }
+        Self { writer,
+               bool_flags:0,
+               bools_left: MAX_NUM_BOOL_FLAGS,
+             }
     }
 
     /// Implementation detail
@@ -329,6 +340,34 @@ impl Formatter {
         } else {
             self.write(&[s.address as u8 | (1 << 7), (s.address >> 7) as u8])
         }
+    }
+
+    /// Implementation detail
+    pub fn bool(&mut self, b: &bool) {
+        let b_u8 = *b as u8;
+        // set n'th bool flag
+        self.bool_flags = (self.bool_flags << 1) | b_u8;
+        self.bools_left -= 1;
+
+        // if we've filled max compression space, flush and begin anew
+        if self.bools_left == 0 {
+            self.flush_and_reset_bools();
+        }
+    }
+
+    /// The last pass in a formatting run: clean up & flush leftovers
+    pub fn finalize(&mut self) {
+        if self.bools_left < MAX_NUM_BOOL_FLAGS {
+            // there are bools in compression that haven't been flushed yet
+            self.flush_and_reset_bools();
+        }
+    }
+
+    fn flush_and_reset_bools(&mut self) {
+        let flags = self.bool_flags;
+        self.u8(&flags);
+        self.bools_left = MAX_NUM_BOOL_FLAGS;
+        self.bool_flags = 0;
     }
 }
 


### PR DESCRIPTION
resolves https://github.com/ferrous-systems/binfmt/issues/29 .

happy to hear feedback esp. on the decoder changes, surely there's a more idiomatic way to do this.

as always, will squash before merging :)