### PR TITLE
ci: set a 10 minute timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           #- windows-latest
           # FIXME: Reenable macOS, Windows, and nightly once binfmt is open-sourced.
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The default timeout is something ridiculous, let's limit how much money we can burn if something ends up in an infinite loop.