### PR TITLE
Encode and format `f32`

### DIFF
--- a/book/src/primitives.md
+++ b/book/src/primitives.md
@@ -21,6 +21,7 @@ The available types are:
 - `:bool`, boolean
 - `:{i,u}{8,16,32}`, standard integer types
 - `:{i,u}24`, 32-bit integer truncated to 24 bits
+- `:f32`, 32-bit floating point type
 - `:[u8; N]`, byte array
 - `:[u8]`, byte slice
 - `:str`, string slice

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -17,6 +17,7 @@ fn main() -> ! {
     binfmt::info!("Hello {0:u8} {0:u8}!", 42);
     binfmt::info!("Hello {1:u16} {0:u8}", 42u8, 256u16);
     binfmt::info!("🍕 {:[u8]}", [3,14]);
+    binfmt::info!("float like a butterfly {:f32}", 5.67f32);
 
     binfmt::trace!("log trace");
     binfmt::debug!("log debug");

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -365,7 +365,7 @@ fn as_native_type(ty: &Type) -> Option<String> {
             Some(ident) => {
                 let s = ident.to_string();
                 match &*s {
-                    "u8" | "u16" | "u32" | "i8" | "i16" | "i32" | "bool" => Some(s),
+                    "u8" | "u16" | "u32" | "i8" | "i16" | "i32" | "f32" | "bool" => Some(s),
                     _ => None,
                 }
             }
@@ -701,7 +701,7 @@ impl Codegen {
                     exprs.push(quote!(_fmt_.slice(#arg)));
                 }
                 binfmt_parser::Type::F32 => {
-                    todo!();
+                    exprs.push(quote!(_fmt_.f32(#arg)));
                 }
             }
             pats.push(arg);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -50,6 +50,15 @@ impl Format for u32 {
     }
 }
 
+impl Format for f32 {
+    fn format(&self, fmt: &mut Formatter) {
+        // to_bits then to_le_bytes
+        let t = internp!("{:f32}");
+        fmt.u8(&t);
+        fmt.f32(self);
+    }
+}
+
 impl Format for Str {
     fn format(&self, fmt: &mut Formatter) {
         let t = internp!("{:str}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,12 @@ impl Formatter {
         self.write(&b.to_le_bytes())
     }
 
+    /// Implementation detail
+    #[doc(hidden)]
+    pub fn f32(&mut self, b: &f32) {
+        self.write(&f32::to_bits(*b).to_le_bytes())
+    }
+
     #[doc(hidden)]
     pub fn str(&mut self, s: &str) {
         self.leb64(s.len() as u64);

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -344,16 +344,27 @@ fn format_primitives() {
     );
 
     cfi(
+        5.13f32,
+        &[
+            inc(index, 5), // "{:f32}"
+            246,
+            40,
+            164,
+            64,
+        ],
+    );
+
+    cfi(
         42i8,
         &[
-            inc(index, 5), // "{:i8}"
+            inc(index, 6), // "{:i8}"
             42,
         ],
     );
     cfi(
         -42i8,
         &[
-            inc(index, 6), // "{:i8}"
+            inc(index, 7), // "{:i8}"
             -42i8 as u8,
         ],
     );
@@ -361,7 +372,7 @@ fn format_primitives() {
     cfi(
         None::<u8>,
         &[
-            inc(index, 7), // "<option-format-string>"
+            inc(index, 8), // "<option-format-string>"
             0,             // None discriminant
         ],
     );
@@ -369,9 +380,9 @@ fn format_primitives() {
     cfi(
         Some(42u8),
         &[
-            inc(index, 8), // "<option-format-string>"
+            inc(index, 9), // "<option-format-string>"
             1,             // Some discriminant
-            inc(index, 9), // "{:u8}"
+            inc(index, 10), // "{:u8}"
             42,            // Some.0 field
         ],
     );


### PR DESCRIPTION
(partially?) resolves https://github.com/ferrous-systems/binfmt/issues/53 – no support for `f64` for now