### PR TITLE
do not optimize the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,6 @@ members = [
   "firmware/*",
 ]
 
-# optimize code in both profiles
-[profile.dev]
-codegen-units = 1
-debug = 1
-debug-assertions = true # !
-incremental = false
-opt-level = 'z' # !
-overflow-checks = false
-
 [profile.release]
 codegen-units = 1
 debug = 1


### PR DESCRIPTION
now that there's only a single workspace std code is also getting optimized when
using the dev profile but that's way too slow compared to optimizing no_std code
so let's disable the dev profile's opts