### PR TITLE
probe-run: add `--list-chips` flag 

### DIFF
--- a/probe-run/src/main.rs
+++ b/probe-run/src/main.rs
@@ -41,14 +41,16 @@ fn main() -> Result<(), anyhow::Error> {
     notmain().map(|code| process::exit(code))
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(StructOpt)]
 #[structopt(name = "probe-run")]
 struct Opts {
     #[structopt(long)]
     list_chips: bool,
-    #[structopt(long, required_unless = "list_chips")]
+    // note: default_value is a hacky way to avoid errors when --list_chips is passed –
+    // `required_if("list_chips", "true")` does not kick in for some reason
+    #[structopt(long, default_value = "nop")]
     chip: String,
-    #[structopt(name = "ELF", parse(from_os_str), required_unless = "list_chips")]
+    #[structopt(name = "ELF", parse(from_os_str), default_value = "nop")]
     elf: PathBuf,
 }
 


### PR DESCRIPTION
closes https://github.com/knurling-rs/binfmt/issues/95

output looks like this (shortened):

```
stm32f4 series
    Variants:
        STM32F401CBUx
        STM32F401CBYx
        STM32F401CCUx
        STM32F401CCYx
        STM32F401CDUx
        STM32F401CDYx
        STM32F401CEUx
        STM32F401CEYx
        STM32F401RBTx
        STM32F401RCTx
        STM32F401RDTx
        STM32F401RETx
        STM32F401VBHx
        STM32F401VBTx
        STM32F401VCHx
        STM32F401VCTx
        STM32F401VDHx
        STM32F401VDTx
        STM32F401VEHx
        STM32F401VETx
        STM32F405OEYx
       [...]
ht32f61352 series
    Variants:
        HT32F61352
        HT32F61352_48LQFN
        HT32F61352_64LQFP
Generic Cortex-M0
    Variants:
        cortex-m0
Generic Cortex-M4
    Variants:
        cortex-m4
Generic Cortex-M3
    Variants:
        cortex-m3
Generic Cortex-M33
    Variants:
        cortex-m33
Generic Riscv
    Variants:
        riscv
```