### PR TITLE
Fix bool unpacking with nested structs

### DIFF
--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #![no_main]
 
-use defmt::Format;
 use core::sync::atomic::{AtomicU32, Ordering};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
+use defmt::Format;
 
 use defmt_semihosting as _; // global logger
 use panic_halt as _; // panicking behavior
@@ -111,6 +111,23 @@ fn main() -> ! {
     defmt::info!("e6={:?}", Err::<u8, u16>(256u16));
 
     defmt::info!("e7={:?}", Some(X { y: Y { z: 42 } }));
+
+    #[derive(Format)]
+    struct Flags {
+        a: bool,
+        b: bool,
+        c: bool,
+    }
+
+    defmt::info!(
+        "{:bool} {:?}",
+        true,
+        Flags {
+            a: true,
+            b: false,
+            c: true
+        }
+    );
 
     loop {
         debug::exit(debug::EXIT_SUCCESS)


### PR DESCRIPTION
Fixes #74

Can be reviewed commit-by-commit.

I went for a simpler but slightly cursed solution here, so we aren't flattening all arguments into a single list, but instead use the equivalent of `Arc<AtomicBool>` to represent bools that we still have to unpack. One `Arc` is retained in the `bools_tbd` list, and filled in by the unpacking function.