### PR TITLE
Use `object` crate instead of `xmas-elf`

### DIFF
--- a/elf2table/Cargo.toml
+++ b/elf2table/Cargo.toml
@@ -6,5 +6,9 @@ edition = "2018"
 
 [dependencies]
 decoder = { path = "../decoder" }
-xmas-elf = "0.7.0"
 anyhow = "1.0.32"
+
+[dependencies.object]
+version = "0.21.0"
+default-features = false
+features = ["read_core", "elf", "std"]

--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -2,35 +2,21 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 pub use decoder::Table;
-use xmas_elf::{sections::SectionData, symbol_table::Entry as _, ElfFile};
+use object::{File, Object, ObjectSection};
 
 /// Parses an ELF file and returns the decoded `defmt` table
 ///
 /// This function returns `None` if the ELF file contains no `.defmt` section
-pub fn parse(elf: &ElfFile) -> Result<Option<Table>, anyhow::Error> {
-    // find the index of the `.defmt` section
-    let defmt_shndx = if let Some(shndx) = elf
-        .section_iter()
-        .zip(0..)
-        .filter_map(|(sect, shndx)| {
-            if sect.get_name(elf) == Ok(".defmt") {
-                Some(shndx)
-            } else {
-                None
-            }
-        })
-        .next()
-    {
-        shndx
-    } else {
-        return Ok(None);
-    };
+pub fn parse(elf: &[u8]) -> Result<Option<Table>, anyhow::Error> {
+    let elf = File::parse(elf)?;
 
-    let symtab = elf
-        .find_section_by_name(".symtab")
-        .ok_or_else(|| anyhow!("`.symtab` section not found"))?;
+    // find the index of the `.defmt` section
+    let defmt_shndx = elf
+        .section_by_name(".defmt")
+        .ok_or_else(|| anyhow!("`.defmt` section is missing"))?
+        .index();
 
     let mut map = BTreeMap::new();
     let mut version = None;
@@ -44,39 +30,35 @@ pub fn parse(elf: &ElfFile) -> Result<Option<Table>, anyhow::Error> {
     let mut warn_end = None;
     let mut error_start = None;
     let mut error_end = None;
-    match symtab.get_data(elf).map_err(anyhow::Error::msg)? {
-        // NOTE assuming 32-bit target
-        SectionData::SymbolTable32(entries) => {
-            for entry in entries {
-                let name = entry.get_name(&elf);
+    for (_, entry) in elf.symbols() {
+        let name = match entry.name() {
+            Some(name) => name,
+            None => continue,
+        };
 
-                // not in the `.defmt` section because it's not tied to the address of any symbol
-                // in `.defmt`
-                if name == Ok("_defmt_version_") {
-                    version = Some(entry.value() as usize);
-                }
+        // not in the `.defmt` section because it's not tied to the address of any symbol
+        // in `.defmt`
+        if name == "_defmt_version_" {
+            version = Some(entry.address() as usize);
+        }
 
-                if entry.shndx() == defmt_shndx {
-                    let name = name.map_err(anyhow::Error::msg)?;
-                    match name {
-                        "_defmt_trace_start" => trace_start = Some(entry.value() as usize),
-                        "_defmt_trace_end" => trace_end = Some(entry.value() as usize),
-                        "_defmt_debug_start" => debug_start = Some(entry.value() as usize),
-                        "_defmt_debug_end" => debug_end = Some(entry.value() as usize),
-                        "_defmt_info_start" => info_start = Some(entry.value() as usize),
-                        "_defmt_info_end" => info_end = Some(entry.value() as usize),
-                        "_defmt_warn_start" => warn_start = Some(entry.value() as usize),
-                        "_defmt_warn_end" => warn_end = Some(entry.value() as usize),
-                        "_defmt_error_start" => error_start = Some(entry.value() as usize),
-                        "_defmt_error_end" => error_end = Some(entry.value() as usize),
-                        _ => {
-                            map.insert(entry.value() as usize, name.to_string());
-                        }
-                    }
+        if entry.section_index() == Some(defmt_shndx) {
+            match name {
+                "_defmt_trace_start" => trace_start = Some(entry.address() as usize),
+                "_defmt_trace_end" => trace_end = Some(entry.address() as usize),
+                "_defmt_debug_start" => debug_start = Some(entry.address() as usize),
+                "_defmt_debug_end" => debug_end = Some(entry.address() as usize),
+                "_defmt_info_start" => info_start = Some(entry.address() as usize),
+                "_defmt_info_end" => info_end = Some(entry.address() as usize),
+                "_defmt_warn_start" => warn_start = Some(entry.address() as usize),
+                "_defmt_warn_end" => warn_end = Some(entry.address() as usize),
+                "_defmt_error_start" => error_start = Some(entry.address() as usize),
+                "_defmt_error_end" => error_end = Some(entry.address() as usize),
+                _ => {
+                    map.insert(entry.address() as usize, name.to_string());
                 }
             }
         }
-        _ => bail!("`.symtab` section does not contain a symbol table"),
     }
 
     // unify errors

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -9,4 +9,3 @@ publish = false
 anyhow = "1.0.32"
 decoder = { path = "../decoder" }
 elf2table = { path = "../elf2table" }
-xmas-elf = "0.7.0"

--- a/qemu-run/src/main.rs
+++ b/qemu-run/src/main.rs
@@ -6,7 +6,6 @@ use std::{
 
 use anyhow::{anyhow, bail};
 use decoder::Table;
-use xmas_elf::ElfFile;
 
 fn main() -> Result<(), anyhow::Error> {
     notmain().map(|opt_code| {
@@ -25,8 +24,7 @@ fn notmain() -> Result<Option<i32>, anyhow::Error> {
 
     let path = &args[0];
     let bytes = fs::read(path)?;
-    let elf = ElfFile::new(&bytes).map_err(anyhow::Error::msg)?;
-    let table = elf2table::parse(&elf)?.ok_or_else(|| anyhow!("`.defmt` section not found"))?;
+    let table = elf2table::parse(&bytes)?.ok_or_else(|| anyhow!("`.defmt` section not found"))?;
 
     let mut child = Command::new("qemu-system-arm")
         .args(&[


### PR DESCRIPTION
Reasons for doing this:

* Better documentation
* More ergonomic API
* `object` is used by the standard library, so it is known to work well
* `object` is maintained by the gimli crew, which we also want to use (#19), and integration of these two should be easy
* `object` provides the same API for ELF, PE, and MachO files, so if we want to support more than just ELF in the future it will be easier