### PR TITLE
add "bstr" format, for readable ASCII byte strings

### DIFF
--- a/book/src/primitives.md
+++ b/book/src/primitives.md
@@ -29,4 +29,5 @@ The available types are:
 - `:f32`, 32-bit floating point type
 - `:[u8; N]`, byte array
 - `:[u8]`, byte slice
+- `:bstr`, byte slice represented as ASCII string
 - `:str`, string slice

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -777,7 +777,7 @@ impl Codegen {
                 defmt_parser::Type::Bool => {
                     exprs.push(quote!(_fmt_.bool(#arg)));
                 }
-                defmt_parser::Type::Slice => {
+                defmt_parser::Type::Slice | defmt_parser::Type::BStr => {
                     exprs.push(quote!(_fmt_.slice(#arg)));
                 }
                 defmt_parser::Type::Array(len) => {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -40,6 +40,8 @@ pub enum Type {
     Str,
     /// Interned string index.
     IStr,
+    /// Byte slice formatted as ASCII string.
+    BStr,
     U8,
     U16,
     U24,
@@ -121,6 +123,7 @@ fn parse_param(mut s: &str) -> Result<Param, Cow<'static, str>> {
         "bool" => Type::Bool,
         "str" => Type::Str,
         "istr" => Type::IStr,
+        "bstr" => Type::BStr,
         "[u8]" => Type::Slice,
         "?" => Type::Format,
         "[?]" => Type::FormatSlice,
@@ -356,6 +359,14 @@ mod tests {
             Ok(vec![Fragment::Parameter(Parameter {
                 index: 0,
                 ty: Type::Str,
+            })])
+        );
+
+        assert_eq!(
+            parse("{:bstr}"),
+            Ok(vec![Fragment::Parameter(Parameter {
+                index: 0,
+                ty: Type::BStr,
             })])
         );
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,6 +16,8 @@ fn str() {
 
     let world = defmt::intern!("world");
     defmt::info!("Hello, {:istr}", world);
+
+    defmt::info!("Hello, {:bstr}", &b"world"[..]);
 }
 
 #[test]


### PR DESCRIPTION
As I wrote in issue #142, ASCII/mixed byte strings are very common in embedded, and usually we don't want to make a UTF8 check roundtrip just for logging purposes.

The only question here is the format for the unprintable/non-ASCII bytes, I chose `<FF>` since it's easier to read in large quantities than `\xFF` but I'm fine with any change you request.
