### PR TITLE
elf2table: discard loc-info from linker GC-ed symbols

### DIFF
--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -111,6 +111,10 @@ impl Table {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+
+    pub fn symbols<'s>(&'s self) -> impl Iterator<Item = &'s str> + 's {
+        self.entries.values().map(|s| &**s)
+    }
 }
 
 /// A log frame

--- a/defmt.x.in
+++ b/defmt.x.in
@@ -8,15 +8,6 @@ SECTIONS
 {
   .defmt (INFO) :
   {
-    /* this section starts at address 1 */
-    /* we use this fact when extract file locations from the DWARF information.
-       symbols that appear in source code but won't make it to the final program
-       (e.g. `if false { error!("foo")}`) will be given an address of 0 in DWARF
-       to differentiate those "ghost" symbols from symbols that will be used, we
-       have the latter start at address 1
-    */
-    . = 1;
-
     /* Format implementations for primitives like u8 */
     *(.defmt.prim.*);
 

--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -113,7 +113,7 @@ impl fmt::Debug for Location {
 pub type Locations = BTreeMap<u64, Location>;
 
 pub fn get_locations(elf: &[u8], table: &Table) -> Result<Locations, anyhow::Error> {
-    let syms = table.symbols().collect::<Vec<_>>();
+    let live_syms = table.symbols().collect::<Vec<_>>();
     let object = object::File::parse(elf)?;
     let endian = if object.is_little_endian() {
         gimli::RunTimeEndian::Little
@@ -241,7 +241,7 @@ pub fn get_locations(elf: &[u8], table: &Table) -> Result<Locations, anyhow::Err
                             .next()
                             .ok_or_else(|| anyhow!("{} is missing `@` suffix", linkage_name))?;
 
-                        if syms.contains(&linkage_name) {
+                        if live_syms.contains(&linkage_name) {
                             let addr = exprloc2address(unit.encoding(), &loc)?;
                             let file = file_index_to_path(file_index, &unit, &dwarf)?;
                             let module = segments.join("::");

--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -112,7 +112,8 @@ impl fmt::Debug for Location {
 
 pub type Locations = BTreeMap<u64, Location>;
 
-pub fn get_locations(elf: &[u8]) -> Result<Locations, anyhow::Error> {
+pub fn get_locations(elf: &[u8], table: &Table) -> Result<Locations, anyhow::Error> {
+    let syms = table.symbols().collect::<Vec<_>>();
     let object = object::File::parse(elf)?;
     let endian = if object.is_little_endian() {
         gimli::RunTimeEndian::Little
@@ -181,6 +182,7 @@ pub fn get_locations(elf: &[u8]) -> Result<Locations, anyhow::Error> {
                 let mut decl_file = None;
                 let mut decl_line = None; // line number
                 let mut name = None;
+                let mut linkage_name = None;
                 let mut location = None;
 
                 while let Some(attr) = attrs.next()? {
@@ -209,27 +211,49 @@ pub fn get_locations(elf: &[u8]) -> Result<Locations, anyhow::Error> {
                             }
                         }
 
+                        gimli::constants::DW_AT_linkage_name => {
+                            if let gimli::AttributeValue::DebugStrRef(off) = attr.value() {
+                                linkage_name = Some(off);
+                            }
+                        }
+
                         _ => {}
                     }
                 }
 
-                if let (Some(name_index), Some(file_index), Some(line), Some(loc)) =
-                    (name, decl_file, decl_line, location)
+                if let (
+                    Some(name_index),
+                    Some(linkage_name_index),
+                    Some(file_index),
+                    Some(line),
+                    Some(loc),
+                ) = (name, linkage_name, decl_file, decl_line, location)
                 {
-                    let endian_slice = dwarf.string(name_index)?;
-                    let name = core::str::from_utf8(&endian_slice)?;
+                    let name_slice = dwarf.string(name_index)?;
+                    let name = core::str::from_utf8(&name_slice)?;
+                    let linkage_name_slice = dwarf.string(linkage_name_index)?;
+                    let linkage_name = core::str::from_utf8(&linkage_name_slice)?;
 
                     if name == "DEFMT_LOG_STATEMENT" {
-                        let addr = exprloc2address(unit.encoding(), &loc)?;
-                        let file = file_index_to_path(file_index, &unit, &dwarf)?;
-                        let module = segments.join("::");
+                        // remove the `@` suffix
+                        let linkage_name = linkage_name
+                            .splitn(2, '@')
+                            .next()
+                            .ok_or_else(|| anyhow!("{} is missing `@` suffix", linkage_name))?;
 
-                        let loc = Location { file, line, module };
+                        if syms.contains(&linkage_name) {
+                            let addr = exprloc2address(unit.encoding(), &loc)?;
+                            let file = file_index_to_path(file_index, &unit, &dwarf)?;
+                            let module = segments.join("::");
 
-                        if addr != 0 {
+                            let loc = Location { file, line, module };
+
                             if let Some(old) = map.insert(addr, loc.clone()) {
                                 bail!("BUG in DWARF variable filter: index collision for addr 0x{:08x} (old = {:?}, new = {:?})", addr, old, loc);
                             }
+                        } else {
+                            // this symbol was GC-ed by the linker (but remains in the DWARF info)
+                            // so we discard it (its `addr` info is also wrong which causes collisions)
                         }
                     }
                 }


### PR DESCRIPTION
should fix #156 