### PR TITLE
Structured symbol names

### DIFF
--- a/defmt.x.in
+++ b/defmt.x.in
@@ -11,36 +11,8 @@ SECTIONS
     /* Format implementations for primitives like u8 */
     *(.defmt.prim.*);
 
-    /* ERROR logging level */
-    _defmt_error_start = .;
-    *(.defmt.error.*);
-    _defmt_error_end = .;
-
-    /* WARN logging level */
-    _defmt_warn_start = .;
-    *(.defmt.warn.*);
-    _defmt_warn_end = .;
-
-    /* INFO logging level */
-    _defmt_info_start = .;
-    *(.defmt.info.*);
-    _defmt_info_end = .;
-
-    /* DEBUG logging level */
-    _defmt_debug_start = .;
-    *(.defmt.debug.*);
-    _defmt_debug_end = .;
-
-    /* TRACE logging level */
-    _defmt_trace_start = .;
-    *(.defmt.trace.*);
-    _defmt_trace_end = .;
-
-    /* Format/write! strings */
-    *(.defmt.fmt.*);
-
-    /* User interned strings (Str) */
-    *(.defmt.str.*);
+    /* Everything user-defined */
+    *(.defmt.sym.*);
 
     /* $DEFMT_VERSION may contain special chars, so we quote the symbol name */
     /* Note that the quotes actually become part of the symbol name though! */

--- a/defmt.x.in
+++ b/defmt.x.in
@@ -12,7 +12,7 @@ SECTIONS
     *(.defmt.prim.*);
 
     /* Everything user-defined */
-    *(.defmt.sym.*);
+    *(.defmt.*);
 
     /* $DEFMT_VERSION may contain special chars, so we quote the symbol name */
     /* Note that the quotes actually become part of the symbol name though! */

--- a/elf2table/Cargo.toml
+++ b/elf2table/Cargo.toml
@@ -9,6 +9,8 @@ version = "0.1.0"
 anyhow = "1.0.32"
 defmt-decoder = { path = "../decoder" }
 gimli = "0.22.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dependencies.object]
 version = "0.21.0"

--- a/elf2table/src/symbol.rs
+++ b/elf2table/src/symbol.rs
@@ -1,0 +1,56 @@
+use defmt_decoder::Tag;
+use serde::Deserialize;
+
+#[derive(Deserialize, PartialEq, Eq, Hash)]
+pub struct Symbol {
+    /// Name of the Cargo package in which the symbol is being instantiated. Used for avoiding
+    /// symbol name collisions.
+    package: String,
+
+    /// Unique identifier that disambiguates otherwise equivalent invocations in the same crate.
+    disambiguator: u64,
+
+    /// Symbol categorization. Known values:
+    /// * `defmt_prim` for primitive formatting strings that are placed at the start of the `.defmt`
+    ///   section.
+    /// * `defmt_fmt`, `defmt_str` for interned format strings and string literals.
+    /// * `defmt_trace`, `defmt_debug`, `defmt_info`, `defmt_warn`, `defmt_error` for logging
+    ///   messages used at the different log levels.
+    /// * Anything starting with `defmt_` is reserved for use by defmt, other prefixes are free for
+    ///   use by third-party apps (but they all should use a prefix!).
+    tag: String,
+
+    /// Symbol data for use by the host tooling. Interpretation depends on `tag`.
+    data: String,
+}
+
+pub enum SymbolTag<'a> {
+    /// `defmt_*` tag that we can interpret.
+    Defmt(Tag),
+
+    /// Non-`defmt_*` tag for custom tooling.
+    Custom(&'a str),
+}
+
+impl Symbol {
+    pub fn demangle(raw: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(raw)
+    }
+
+    pub fn tag(&self) -> SymbolTag<'_> {
+        match &*self.tag {
+            "defmt_prim" | "defmt_fmt" => SymbolTag::Defmt(Tag::Fmt),
+            "defmt_str" => SymbolTag::Defmt(Tag::Str),
+            "defmt_trace" => SymbolTag::Defmt(Tag::Trace),
+            "defmt_debug" => SymbolTag::Defmt(Tag::Debug),
+            "defmt_info" => SymbolTag::Defmt(Tag::Info),
+            "defmt_warn" => SymbolTag::Defmt(Tag::Warn),
+            "defmt_error" => SymbolTag::Defmt(Tag::Error),
+            _ => SymbolTag::Custom(&self.tag),
+        }
+    }
+
+    pub fn data(&self) -> &str {
+        &self.data
+    }
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,6 +12,8 @@ proc-macro = true
 defmt-parser = { path = "../parser" }
 quote = "1.0.7"
 proc-macro2 = "1.0.18"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dependencies.syn]
 features = ["full"]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,7 @@
+mod symbol;
+
 use core::fmt::Write as _;
-use proc_macro::{Span, TokenStream};
+use proc_macro::TokenStream;
 
 use defmt_parser::Fragment;
 use proc_macro2::{Ident as Ident2, Span as Span2, TokenStream as TokenStream2};
@@ -582,9 +584,9 @@ pub fn internp(ts: TokenStream) -> TokenStream {
         .into();
     }
 
-    // NOTE(no random id) these won't collide because they are limited in use
-    let section = format!(".defmt.prim.{}", ls);
-    let sym = ls;
+    let sym = symbol::Symbol::new("prim", &ls).mangle();
+    let section = format!(".defmt.prim.{}", sym);
+
     quote!(match () {
         #[cfg(target_arch = "x86_64")]
         () => {
@@ -640,9 +642,9 @@ pub fn write(ts: TokenStream) -> TokenStream {
 }
 
 fn mksym(string: &str, section: &str, is_log_statement: bool) -> TokenStream2 {
-    let id = format!("{:?}", Span::call_site());
-    let section = format!(".defmt.{}.{}", section, string);
-    let sym = format!("{}@{}", string, id);
+    let sym = symbol::Symbol::new(section, string).mangle();
+    let section = format!(".defmt.sym.{}", sym);
+
     // NOTE we rely on this variable name when extracting file location information from the DWARF
     // without it we have no other mean to differentiate static variables produced by `info!` vs
     // produced by `intern!` (or `internp`)

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -643,7 +643,7 @@ pub fn write(ts: TokenStream) -> TokenStream {
 
 fn mksym(string: &str, section: &str, is_log_statement: bool) -> TokenStream2 {
     let sym = symbol::Symbol::new(section, string).mangle();
-    let section = format!(".defmt.sym.{}", sym);
+    let section = format!(".defmt.{}", sym);
 
     // NOTE we rely on this variable name when extracting file location information from the DWARF
     // without it we have no other mean to differentiate static variables produced by `info!` vs

--- a/macros/src/symbol.rs
+++ b/macros/src/symbol.rs
@@ -1,0 +1,54 @@
+use std::collections::hash_map::DefaultHasher;
+use std::env;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use proc_macro::Span;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Symbol<'a> {
+    /// Name of the Cargo package in which the symbol is being instantiated. Used for avoiding
+    /// symbol name collisions.
+    package: String,
+
+    /// Unique identifier that disambiguates otherwise equivalent invocations in the same crate.
+    disambiguator: u64,
+
+    /// Symbol categorization. Known values:
+    /// * `defmt_prim` for primitive formatting strings that are placed at the start of the `.defmt`
+    ///   section.
+    /// * `defmt_fmt`, `defmt_str` for interned format strings and string literals.
+    /// * `defmt_trace`, `defmt_debug`, `defmt_info`, `defmt_warn`, `defmt_error` for logging
+    ///   messages used at the different log levels.
+    /// * Anything starting with `defmt_` is reserved for use by defmt, other prefixes are free for
+    ///   use by third-party apps (but they all should use a prefix!).
+    tag: String,
+
+    /// Symbol data for use by the host tooling. Interpretation depends on `tag`.
+    data: &'a str,
+}
+
+impl<'a> Symbol<'a> {
+    pub fn new(tag: &'a str, data: &'a str) -> Self {
+        Self {
+            // `CARGO_PKG_NAME` is set to the invoking package's name.
+            package: env::var("CARGO_PKG_NAME").unwrap(),
+            disambiguator: {
+                // We want a deterministic, but unique-per-macro-invocation identifier. For that we
+                // hash the call site `Span`'s debug representation, which contains a counter that
+                // should disambiguate macro invocations within a crate.
+                let s = format!("{:?}", Span::call_site());
+                let mut hasher = DefaultHasher::new();
+                s.hash(&mut hasher);
+                hasher.finish()
+            },
+            tag: format!("defmt_{}", tag),
+            data,
+        }
+    }
+
+    pub fn mangle(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}

--- a/macros/src/symbol.rs
+++ b/macros/src/symbol.rs
@@ -33,7 +33,7 @@ impl<'a> Symbol<'a> {
     pub fn new(tag: &'a str, data: &'a str) -> Self {
         Self {
             // `CARGO_PKG_NAME` is set to the invoking package's name.
-            package: env::var("CARGO_PKG_NAME").unwrap(),
+            package: env::var("CARGO_PKG_NAME").unwrap_or("<unknown>".to_string()),
             disambiguator: {
                 // We want a deterministic, but unique-per-macro-invocation identifier. For that we
                 // hash the call site `Span`'s debug representation, which contains a counter that

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,6 +1,5 @@
-use core::ops::Range;
-
 use std::borrow::Cow;
+use std::ops::Range;
 
 /// A `{{:parameter}}` in a format string.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Let's use JSON in symbol names, why not?!

This encodes the following extra data in symbol names:
* `CARGO_PKG_NAME` of the crate invoking the macro
* A disambiguator, for telling apart identical invocations within a crate (what used to be the symbol version after the `@` character)
* A "tag", which classifies the symbol, replacing the trace, info, warn, etc. subsections, and which also allows (in theory) to transfer data for custom host tooling (eg. for data and state machine visualization)

Because we now stop using `@`, this should close #171 

This still needs more testing, I think, but the QEMU binary seems to work.

Closes #108