### PR TITLE
enhance bitfield compression

### DIFF
--- a/book/src/ser-bitfield.md
+++ b/book/src/ser-bitfield.md
@@ -9,3 +9,13 @@ defmt::error!("l: {0:0..8}, m: {0:8..12}, h: {0:12..16}", x /*: u16*/);
 // on the wire: [1, 1, 2]
 //  string index ^  ^^^^ `u16::to_le_bytes(x)`
 ```
+
+Leading or trailing bytes that are not needed to display a bitfield are removed during serialization:
+
+``` rust
+# extern crate defmt;
+defmt::error!("m: {0:8..12}", 0b0110_0011_0000_1111_u32);
+// on the wire: [1, 0b0110_0011]
+//  string index ^  ^^^^^^^^^^ argument truncated into u8:
+//                             leading and trailing byte are irrelevant
+```

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
 use byteorder::{ReadBytesExt, LE};
 use colored::Colorize;
 
-use defmt_parser::{Fragment, Level, Type};
+use defmt_parser::{Fragment, Level, Parameter, Type};
 
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
@@ -371,6 +371,76 @@ pub fn decode<'t>(
     Ok((frame, consumed))
 }
 
+/// deduplicate the bitfields in `params` by merging them into a new one with range min..max
+/// Note that `params` must be sorted by index!
+fn merge_bitfields(params: &mut Vec<Parameter>) {
+    // TODO refactor when `drain_filter()` is stable: current implementation re-inserts in place (messy)
+    // sorry about the wonky vars but accessing enum fields is too messy to just use a Param{}
+    let mut curr_bitfield_range: Option<Range<u8>> = None;
+    let mut curr_bitfield_index = 0;
+    let mut i = 0; // index of param being currently read. does not increase monotonically
+                          // since param length changes as we remove and re-add bitfields
+    let initial_num_params = params.len();
+    let mut num_params_read = 0;
+    while num_params_read < initial_num_params {
+        match &params[i].ty {
+            Type::BitField(range) => {
+                let range_start = range.start;
+                let range_end = range.end;
+                params.remove(i);
+
+                match &mut curr_bitfield_range {
+                    Some(r) => {
+                        if range_start < r.start {
+                            r.start = range_start;
+                        }
+                        if range_end > r.end {
+                            r.end = range_end;
+                        }
+                    }
+                    None => {
+                        curr_bitfield_range = Some(Range {
+                            start: range_start,
+                            end: range_end,
+                        })
+                    }
+                }
+            }
+            _ => {
+                // only move i forward if we haven't read a bitfield since reading a bitfield
+                // *removes* a param and thus shortens the list length
+                i += 1;
+            }
+        }
+
+        num_params_read += 1;
+
+        let end_of_params_reached = num_params_read == initial_num_params;
+        let mut next_index = curr_bitfield_index;
+        if ! end_of_params_reached {
+            next_index = params[i].index;
+        }
+
+        if end_of_params_reached || next_index != curr_bitfield_index {
+            // flush our current bitfield if there is one
+            if let Some(range) = curr_bitfield_range {
+                params.insert(
+                    curr_bitfield_index,
+                    Parameter {
+                        index: curr_bitfield_index,
+                        ty: Type::BitField(range),
+                    },
+                );
+
+                i += 1; // we've re-inserted, increase the index
+            }
+
+            curr_bitfield_range = None;
+            curr_bitfield_index = next_index;
+        }
+    }
+}
+
 struct Decoder<'t, 'b> {
     table: &'t Table,
     bytes: &'b [u8],
@@ -401,6 +471,27 @@ impl<'t, 'b> Decoder<'t, 'b> {
         self.bools_tbd.clear();
 
         Ok(())
+    }
+
+    /// Sort and deduplicate `params` so that they can be interpreted correctly during decoding
+    fn prepare_params(&self, params: &mut Vec<Parameter>) {
+        // sort & dedup to ensure that format string args can be addressed by index too
+        params.sort_by(|a, b| {
+            if a.index == b.index {
+                match (&a.ty, &b.ty) {
+                    (Type::BitField(a_range), Type::BitField(b_range)) => {
+                        a_range.start.cmp(&b_range.start)
+                    }
+                    _ => Ordering::Equal,
+                }
+            } else {
+                a.index.cmp(&b.index)
+            }
+        });
+
+        merge_bitfields(params);
+
+        params.dedup_by(|a, b| a.index == b.index);
     }
 
     /// Gets a format string from
@@ -452,33 +543,7 @@ impl<'t, 'b> Decoder<'t, 'b> {
             })
             .collect::<Vec<_>>();
 
-        // sort & dedup to ensure that format string args can be addressed by index too
-        params.sort_by(|a, b| {
-            if a.index == b.index {
-                match (&a.ty, &b.ty) {
-                    (Type::BitField(a_range), Type::BitField(b_range)) => {
-                        b_range.end.cmp(&a_range.end)
-                    }
-                    _ => Ordering::Equal,
-                }
-            } else {
-                a.index.cmp(&b.index)
-            }
-        });
-
-        params.dedup_by(|a, b| {
-            if a.index == b.index {
-                match (&a.ty, &b.ty) {
-                    (Type::BitField(a_range), Type::BitField(b_range)) => a_range.end < b_range.end,
-                    /* reusing an arg for bitfield- and non bitfield params is not allowed */
-                    (Type::BitField(_), _) => unreachable!(),
-                    (_, Type::BitField(_)) => unreachable!(),
-                    _ => true,
-                }
-            } else {
-                false
-            }
-        });
+        self.prepare_params(&mut params);
 
         for param in &params {
             match &param.ty {
@@ -652,25 +717,31 @@ impl<'t, 'b> Decoder<'t, 'b> {
                     args.push(Arg::F32(f32::from_bits(data)));
                 }
                 Type::BitField(range) => {
-                    let data: u64;
+                    let mut data: u64;
+                    let lowest_byte = range.start / 8;
+                    // -1 because `range` is range-exclusive
+                    let highest_byte = (range.end - 1) / 8;
+                    let size_after_truncation = highest_byte - lowest_byte + 1; // in octets
 
-                    match range.end {
-                        0..=8 => {
+                    match size_after_truncation {
+                        1 => {
                             data = self.bytes.read_u8()? as u64;
                         }
-                        0..=16 => {
+                        2 => {
                             data = self.bytes.read_u16::<LE>()? as u64;
                         }
-                        0..=24 => {
+                        3 => {
                             data = self.bytes.read_u24::<LE>()? as u64;
                         }
-                        0..=32 => {
+                        4 => {
                             data = self.bytes.read_u32::<LE>()? as u64;
                         }
                         _ => {
                             unreachable!();
                         }
                     }
+
+                    data <<= lowest_byte * 8;
 
                     args.push(Arg::Uxx(data));
                 }
@@ -800,9 +871,18 @@ fn zigzag_decode(unsigned: u64) -> i64 {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+<<<<<<< HEAD
     use super::{Frame, Level, Table};
     use super::*;
     use crate::Arg;
+=======
+
+    use defmt_common::Level;
+    use defmt_parser::{Parameter, Type};
+
+    use super::{Frame, Table};
+    use crate::{Arg, merge_bitfields};
+>>>>>>> 44e988c... create merge_bitfields(), add tests, fix bug
 
     // helper function to initiate decoding and assert that the result is as expected.
     //
@@ -1282,6 +1362,53 @@ mod tests {
     }
 
     #[test]
+    fn bitfields_across_boundaries_diff_indices() {
+        let bytes = [
+            0, // index
+            2, // timestamp
+            0b1101_0010,
+            0b0110_0011, // u16
+            0b1111_1111, // truncated u16
+        ];
+        decode_and_expect(
+            "bitfields {0:0..7} {0:9..14} {1:8..10}",
+            &bytes,
+            "0.000002 INFO bitfields 0b1010010 0b10001 0b11",
+        );
+    }
+
+    #[test]
+    fn bitfields_truncated_front() {
+        let bytes = [
+            0,           // index
+            2,           // timestamp
+            0b0110_0011, // truncated(!) u16
+        ];
+        decode_and_expect(
+            "bitfields {0:9..14}",
+            &bytes,
+            "0.000002 INFO bitfields 0b10001",
+        );
+    }
+
+    #[test]
+    fn bitfields_non_truncated_u32() {
+        let bytes = [
+            0,           // index
+            2,           // timestamp
+            0b0110_0011, // -
+            0b0000_1111, //  |
+            0b0101_1010, //  | u32
+            0b1100_0011, // -
+        ];
+        decode_and_expect(
+            "bitfields {0:0..2} {0:28..31}",
+            &bytes,
+            "0.000002 INFO bitfields 0b11 0b100",
+        );
+    }
+
+    #[test]
     fn slice() {
         let bytes = [
             0, // index
@@ -1377,4 +1504,64 @@ mod tests {
         let frame = super::decode(&bytes, &table).unwrap().0;
         assert_eq!(frame.display(false).to_string(), "0.000001 INFO x=None");
     }
+
+    #[test]
+    fn merge_bitfields_simple() {
+        let mut params = vec![
+        Parameter {
+            index: 0,
+            ty: Type::BitField(0..3),
+        },
+        Parameter {
+            index: 0,
+            ty: Type::BitField(4..7),
+        }];
+
+        merge_bitfields(&mut params);
+        assert_eq!(params, vec![Parameter {index: 0, ty: Type::BitField(0..7)}]);
+    }
+
+    #[test]
+    fn merge_bitfields_overlap() {
+        let mut params = vec![
+        Parameter {
+            index: 0,
+            ty: Type::BitField(1..3),
+        },
+        Parameter {
+            index: 0,
+            ty: Type::BitField(2..5),
+        }];
+
+        merge_bitfields(&mut params);
+        assert_eq!(params, vec![Parameter {index: 0, ty: Type::BitField(1..5)}]);
+    }
+
+    #[test]
+    fn merge_bitfields_multiple_indices() {
+        let mut params = vec![
+        Parameter {
+            index: 0,
+            ty: Type::BitField(0..3),
+        },
+        Parameter {
+            index: 1,
+            ty: Type::BitField(1..3),
+        },
+        Parameter {
+            index: 1,
+            ty: Type::BitField(4..5),
+        }];
+
+        merge_bitfields(&mut params);
+        assert_eq!(params, vec![Parameter {index: 0, ty: Type::BitField(0..3)},
+                                Parameter {index: 1, ty: Type::BitField(1..5)}]);
+    }
+
+    fn merge_bitfields_non_consecutive_indices() {
+        todo!();
+    }
+
+    // TODO add test to assert that unsorted lists are recognized and rejected
+    // TODO if there are any bitfield tests that are just about merging, refactor them into here?
 }

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -5,6 +5,7 @@
 
 use core::fmt::{self, Write as _};
 use std::cmp::Ordering;
+use core::ops::Range;
 use std::collections::BTreeMap;
 use std::{
     error::Error,
@@ -18,7 +19,7 @@ use std::{
 use byteorder::{ReadBytesExt, LE};
 use colored::Colorize;
 
-use defmt_parser::{Fragment, Level, Parameter, Type};
+use defmt_parser::{Fragment, Level, Parameter, Type, get_max_bitfield_range};
 
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
@@ -371,74 +372,64 @@ pub fn decode<'t>(
     Ok((frame, consumed))
 }
 
-/// deduplicate the bitfields in `params` by merging them into a new one with range min..max
-/// Note that `params` must be sorted by index!
+/// Note that this will not change the Bitfield params in place, i.e. if `params` was sorted before
+/// a call to this function, it won't be afterwards.
 fn merge_bitfields(params: &mut Vec<Parameter>) {
-    // TODO refactor when `drain_filter()` is stable: current implementation re-inserts in place (messy)
-    // sorry about the wonky vars but accessing enum fields is too messy to just use a Param{}
-    let mut curr_bitfield_range: Option<Range<u8>> = None;
-    let mut curr_bitfield_index = 0;
-    let mut i = 0; // index of param being currently read. does not increase monotonically
-                          // since param length changes as we remove and re-add bitfields
-    let initial_num_params = params.len();
-    let mut num_params_read = 0;
-    while num_params_read < initial_num_params {
-        match &params[i].ty {
-            Type::BitField(range) => {
-                let range_start = range.start;
-                let range_end = range.end;
-                params.remove(i);
+    if params.len() == 0 {
+        return;
+    }
 
-                match &mut curr_bitfield_range {
-                    Some(r) => {
-                        if range_start < r.start {
-                            r.start = range_start;
-                        }
-                        if range_end > r.end {
-                            r.end = range_end;
+    let mut merged_bitfields = Vec::new();
+
+    let max_index: usize = *params
+        .iter()
+        .map(|param| &param.index)
+        .max()
+        .unwrap();
+
+    for index in 0..=max_index {
+        let mut bitfields_with_index = params
+            .iter()
+            .filter(|param| match (param.index, &param.ty) {
+                (i, Type::BitField(_)) if i == index => true,
+                _ => false,
+            })
+            .peekable();
+
+        if bitfields_with_index.peek().is_some() {
+            let (smallest, largest) = get_max_bitfield_range(bitfields_with_index).unwrap();
+
+            // create new merged bitfield for this index
+            merged_bitfields.push(Parameter {
+                index: index,
+                ty: Type::BitField(Range {
+                    start: smallest,
+                    end: largest,
+                }),
+            });
+
+            // remove old bitfields with this index
+            // TODO refactor when `drain_filter()` is stable
+            let mut i = 0;
+            while i != params.len() {
+                match &params[i].ty {
+                    Type::BitField(_) => {
+                        if params[i].index == index {
+                            params.remove(i);
+                        } else {
+                            i += 1; // we haven't removed a bitfield -> move i forward
                         }
                     }
-                    None => {
-                        curr_bitfield_range = Some(Range {
-                            start: range_start,
-                            end: range_end,
-                        })
+                    _ => {
+                        i += 1; // we haven't removed a bitfield -> move i forward
                     }
                 }
             }
-            _ => {
-                // only move i forward if we haven't read a bitfield since reading a bitfield
-                // *removes* a param and thus shortens the list length
-                i += 1;
-            }
-        }
-
-        num_params_read += 1;
-
-        let end_of_params_reached = num_params_read == initial_num_params;
-        let mut next_index = curr_bitfield_index;
-        if ! end_of_params_reached {
-            next_index = params[i].index;
-        }
-
-        if end_of_params_reached || next_index != curr_bitfield_index {
-            // flush our current bitfield if there is one
-            if let Some(range) = curr_bitfield_range {
-                params.insert(
-                    curr_bitfield_index,
-                    Parameter {
-                        index: curr_bitfield_index,
-                        ty: Type::BitField(range),
-                    },
-                );
-
-                i += 1; // we've re-inserted, increase the index
-            }
-
-            curr_bitfield_range = None;
-            curr_bitfield_index = next_index;
         }
     }
+
+    // add merged bitfields to unsorted params
+    params.append(&mut merged_bitfields);
 }
 
 struct Decoder<'t, 'b> {
@@ -475,22 +466,11 @@ impl<'t, 'b> Decoder<'t, 'b> {
 
     /// Sort and deduplicate `params` so that they can be interpreted correctly during decoding
     fn prepare_params(&self, params: &mut Vec<Parameter>) {
-        // sort & dedup to ensure that format string args can be addressed by index too
-        params.sort_by(|a, b| {
-            if a.index == b.index {
-                match (&a.ty, &b.ty) {
-                    (Type::BitField(a_range), Type::BitField(b_range)) => {
-                        a_range.start.cmp(&b_range.start)
-                    }
-                    _ => Ordering::Equal,
-                }
-            } else {
-                a.index.cmp(&b.index)
-            }
-        });
-
+        // deduplicate bitfields by merging them by index
         merge_bitfields(params);
 
+        // sort & dedup to ensure that format string args can be addressed by index too
+        params.sort_by(|a, b| a.index.cmp(&b.index));
         params.dedup_by(|a, b| a.index == b.index);
     }
 
@@ -871,18 +851,9 @@ fn zigzag_decode(unsigned: u64) -> i64 {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-<<<<<<< HEAD
     use super::{Frame, Level, Table};
     use super::*;
-    use crate::Arg;
-=======
-
-    use defmt_common::Level;
-    use defmt_parser::{Parameter, Type};
-
-    use super::{Frame, Table};
     use crate::{Arg, merge_bitfields};
->>>>>>> 44e988c... create merge_bitfields(), add tests, fix bug
 
     // helper function to initiate decoding and assert that the result is as expected.
     //
@@ -1347,6 +1318,23 @@ mod tests {
     }
 
     #[test]
+    fn bitfields_mixed() {
+        let bytes = [
+            0, // index
+            2, // timestamp
+            0b1111_0000,
+            0b1110_0101, // u16 bitfields
+            42,          // u8
+            0b1111_0001, // u8 bitfields
+        ];
+        decode_and_expect(
+            "#0: {0:7..12}, #1: {1:u8}, #2: {2:0..5}",
+            &bytes,
+            "0.000002 INFO #0: 0b1011, #1: 42, #2: 0b10001",
+        );
+    }
+
+    #[test]
     fn bitfields_across_boundaries() {
         let bytes = [
             0, // index
@@ -1508,60 +1496,121 @@ mod tests {
     #[test]
     fn merge_bitfields_simple() {
         let mut params = vec![
-        Parameter {
-            index: 0,
-            ty: Type::BitField(0..3),
-        },
-        Parameter {
-            index: 0,
-            ty: Type::BitField(4..7),
-        }];
+            Parameter {
+                index: 0,
+                ty: Type::BitField(0..3),
+            },
+            Parameter {
+                index: 0,
+                ty: Type::BitField(4..7),
+            },
+        ];
 
         merge_bitfields(&mut params);
-        assert_eq!(params, vec![Parameter {index: 0, ty: Type::BitField(0..7)}]);
+        assert_eq!(
+            params,
+            vec![Parameter {
+                index: 0,
+                ty: Type::BitField(0..7)
+            }]
+        );
     }
 
     #[test]
     fn merge_bitfields_overlap() {
         let mut params = vec![
-        Parameter {
-            index: 0,
-            ty: Type::BitField(1..3),
-        },
-        Parameter {
-            index: 0,
-            ty: Type::BitField(2..5),
-        }];
+            Parameter {
+                index: 0,
+                ty: Type::BitField(1..3),
+            },
+            Parameter {
+                index: 0,
+                ty: Type::BitField(2..5),
+            },
+        ];
 
         merge_bitfields(&mut params);
-        assert_eq!(params, vec![Parameter {index: 0, ty: Type::BitField(1..5)}]);
+        assert_eq!(
+            params,
+            vec![Parameter {
+                index: 0,
+                ty: Type::BitField(1..5)
+            }]
+        );
     }
 
     #[test]
     fn merge_bitfields_multiple_indices() {
         let mut params = vec![
-        Parameter {
-            index: 0,
-            ty: Type::BitField(0..3),
-        },
-        Parameter {
-            index: 1,
-            ty: Type::BitField(1..3),
-        },
-        Parameter {
-            index: 1,
-            ty: Type::BitField(4..5),
-        }];
+            Parameter {
+                index: 0,
+                ty: Type::BitField(0..3),
+            },
+            Parameter {
+                index: 1,
+                ty: Type::BitField(1..3),
+            },
+            Parameter {
+                index: 1,
+                ty: Type::BitField(4..5),
+            },
+        ];
 
         merge_bitfields(&mut params);
-        assert_eq!(params, vec![Parameter {index: 0, ty: Type::BitField(0..3)},
-                                Parameter {index: 1, ty: Type::BitField(1..5)}]);
+        assert_eq!(
+            params,
+            vec![
+                Parameter {
+                    index: 0,
+                    ty: Type::BitField(0..3)
+                },
+                Parameter {
+                    index: 1,
+                    ty: Type::BitField(1..5)
+                }
+            ]
+        );
     }
 
-    fn merge_bitfields_non_consecutive_indices() {
-        todo!();
-    }
+    #[test]
+    fn merge_bitfields_overlap_non_consecutive_indices() {
+        let mut params = vec![
+            Parameter {
+                index: 0,
+                ty: Type::BitField(0..3),
+            },
+            Parameter {
+                index: 1,
+                ty: Type::U8,
+            },
+            Parameter {
+                index: 2,
+                ty: Type::BitField(1..4),
+            },
+            Parameter {
+                index: 2,
+                ty: Type::BitField(4..5),
+            },
+        ];
 
-    // TODO add test to assert that unsorted lists are recognized and rejected
-    // TODO if there are any bitfield tests that are just about merging, refactor them into here?
+        merge_bitfields(&mut params);
+        // note: current implementation appends merged bitfields to the end. this is not a must
+        assert_eq!(
+            params,
+            vec![
+                Parameter {
+                    index: 1,
+                    ty: Type::U8
+                },
+                Parameter {
+                    index: 0,
+                    ty: Type::BitField(0..3)
+                },
+                Parameter {
+                    index: 2,
+                    ty: Type::BitField(1..5)
+                }
+            ]
+        );
+    }
 }

--- a/firmware/nrf52/src/bin/exception.rs
+++ b/firmware/nrf52/src/bin/exception.rs
@@ -3,9 +3,9 @@
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use defmt_rtt as _; // <- global logger
 use cortex_m::{asm, peripheral::SCB};
 use cortex_m_rt::{entry, exception};
+use defmt_rtt as _; // <- global logger
 use nrf52840_hal as _; // <- memory layout
 use panic_probe as _; // <- panicking behavior
 

--- a/firmware/nrf52/src/bin/hello.rs
+++ b/firmware/nrf52/src/bin/hello.rs
@@ -3,9 +3,9 @@
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use defmt_rtt as _; // <- global logger
 use cortex_m::asm;
 use cortex_m_rt::entry;
+use defmt_rtt as _; // <- global logger
 use nrf52840_hal as _; // <- memory layout
 use panic_probe as _; // <- panicking behavior
 

--- a/firmware/nrf52/src/bin/log.rs
+++ b/firmware/nrf52/src/bin/log.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #![no_main]
 
-use defmt::Format;
-use defmt_rtt as _; // <- global logger
 use cortex_m::asm;
 use cortex_m_rt::entry;
+use defmt::Format;
+use defmt_rtt as _; // <- global logger
 use embedded_hal::timer::CountDown as _;
 use nrf52840_hal::{
     target::{self, TIMER0},

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -723,25 +723,8 @@ impl Codegen {
                     exprs.push(quote!(_fmt_.usize(#arg)));
                 }
                 defmt_parser::Type::BitField(_) => {
-                    // TODO reused in decoder::parse_args(), can we share this somehow without Cargo bug troubles?
-                    // TODO -> move this to parser!
                     let all_bitfields = parsed_params.iter().filter(|param| param.index == i);
-                    let largest_bit_index = all_bitfields
-                        .clone()
-                        .map(|param| match &param.ty {
-                            defmt_parser::Type::BitField(range) => range.end,
-                            _ => unreachable!(),
-                        })
-                        .max()
-                        .unwrap();
-
-                    let smallest_bit_index = all_bitfields
-                        .map(|param| match &param.ty {
-                            defmt_parser::Type::BitField(range) => range.start,
-                            _ => unreachable!(),
-                        })
-                        .min()
-                        .unwrap();
+                    let (smallest_bit_index, largest_bit_index) = defmt_parser::get_max_bitfield_range(all_bitfields).unwrap();
 
                     // indices of the lowest and the highest octet which contains bitfield-relevant data
                     let lowest_byte = smallest_bit_index / 8;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -223,6 +223,35 @@ fn push_literal<'f>(
     Ok(())
 }
 
+/// returns Some(smallest_bit_index, largest_bit_index) contained in `params` if
+///         `params` contains any bitfields.
+///         None otherwise
+pub fn get_max_bitfield_range<'a, I>(params: I) -> Option<(u8, u8)>
+where
+    I: Iterator<Item = &'a Parameter> + Clone,
+{
+    let largest_bit_index = params
+        .clone()
+        .map(|param| match &param.ty {
+            Type::BitField(range) => range.end,
+            _ => unreachable!(),
+        })
+        .max();
+
+    let smallest_bit_index = params
+        .map(|param| match &param.ty {
+            Type::BitField(range) => range.start,
+            _ => unreachable!(),
+        })
+        .min();
+
+    match (smallest_bit_index, largest_bit_index) {
+        (Some(smallest), Some(largest)) => Some((smallest, largest)),
+        (None, None) => None,
+        _ => unreachable!(),
+    }
+}
+
 pub fn parse<'f>(format_string: &'f str) -> Result<Vec<Fragment<'f>>, Cow<'static, str>> {
     let mut fragments = Vec::new();
 

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -231,10 +231,48 @@ fn bitfields_across_octets() {
     assert_eq!(
         f.bytes(),
         &[
-            index, // bitfields {0:7..12}, {1:0..5}",
+            index, // bitfields {0:0..7} {0:9..14}",
             timestamp,
             0b1101_0010,
             0b0110_0011, // u16
+        ]
+    );
+}
+
+#[test]
+fn bitfields_truncate_lower() {
+    let index = fetch_string_index();
+    let timestamp = fetch_timestamp();
+    let mut f = Formatter::new();
+
+    winfo!(
+        f,
+        "bitfields {0:9..14}",
+        0b0000_0000_0000_1111_0110_0011_1101_0010u32
+    );
+    assert_eq!(
+        f.bytes(),
+        &[
+            index, // bitfields {0:9..14}",
+            timestamp,
+            0b0110_0011, // the first octet should have been truncated away
+        ]
+    );
+}
+
+#[test]
+fn bitfields_assert_range_exclusive() {
+    let index = fetch_string_index();
+    let timestamp = fetch_timestamp();
+    let mut f = Formatter::new();
+
+    winfo!(f, "bitfields {0:6..8}", 0b1010_0101u8,);
+    assert_eq!(
+        f.bytes(),
+        &[
+            index, // "bitfields {0:6..8}"
+            timestamp,
+            0b1010_0101
         ]
     );
 }


### PR DESCRIPTION
resolves https://github.com/knurling-rs/defmt/issues/101 without the middle bytes compression part.

imo the code is pretty wonky in parts, so I'd be grateful for any feedback on how to make it more idiomatic (I've marked some of the weird parts with `TODO`). The bitfield deduplication in `prepare_params()` has been the biggest fight and I'm not really happy with the tangled index/tracking vars I ended up with.