### PR TITLE
throw (cargo) error on version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "defmt"
 version = "0.1.0"
+links = "defmt" # Prevent multiple versions of defmt being linked
 
 [dependencies]
 defmt-macros = { path = "macros" }


### PR DESCRIPTION
resolves #187 , throws

```
error: failed to select a version for `defmt`.
    ... required by package `my-app v0.1.0 (/Users/lottesteenbrink/ferrous/knurling/my-app)`
    ... which is depended on by `testsuite v0.1.0 (/Users/lottesteenbrink/ferrous/knurling/my-app/testsuite)`
versions that meet the requirements `=0.1.0` are: 0.1.0

the package `defmt` links to the native library `defmt`, but it conflicts with a previous package which links to `defmt` as well:
package `defmt v0.24.0 (/Users/lottesteenbrink/ferrous/knurling/defm_versionbreak)`
    ... which is depended on by `testsuite v0.1.0 (/Users/lottesteenbrink/ferrous/knurling/my-app/testsuite)`

failed to select a version for `defmt` which could resolve this conflict
The terminal process "/bin/zsh '-c', 'cargo test --package testsuite --test test'" failed to launch (exit code: 101).
```