### PR TITLE
make version check compatible with crates.io releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ debug-assertions = false
 opt-level = 0
 overflow-checks = false
 
+[build-dependencies]
+semver = "0.11.0"
+
 [profile.release.build-override]
 codegen-units = 8
 debug = false

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use semver::Version;
 use std::{env, error::Error, fs, path::PathBuf, process::Command};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -5,8 +6,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     let out = &PathBuf::from(env::var("OUT_DIR")?);
     let mut linker_script = fs::read_to_string("defmt.x.in")?;
     let output = Command::new("git").args(&["rev-parse", "HEAD"]).output()?;
-    let commit = String::from_utf8(output.stdout).unwrap();
-    linker_script = linker_script.replace("$DEFMT_VERSION", commit.trim());
+    let version = if output.status.success() {
+        String::from_utf8(output.stdout).unwrap()
+    } else {
+        // no git info -> assume crates.io
+        let semver = Version::parse(&std::env::var("CARGO_PKG_VERSION")?)?;
+        if semver.major == 0 {
+            // minor is breaking when major = 0
+            format!("{}.{}", semver.major, semver.minor)
+        } else {
+            // ignore minor, patch, pre and build
+            semver.major.to_string()
+        }
+    };
+    linker_script = linker_script.replace("$DEFMT_VERSION", version.trim());
     fs::write(out.join("defmt.x"), linker_script)?;
     println!("cargo:rustc-link-search={}", out.display());
     Ok(())


### PR DESCRIPTION
tested by `rm -rf .git`-ing a local checkout; got `"_defmt_version_ = 0.1" = 1;` in the `defmt.x` linker script
closes #189