### PR TITLE
Allow printing '@' character.

### DIFF
--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -308,6 +308,9 @@ fn main() -> ! {
 
     defmt::info!("after nested log: {:?}", nested());
 
+    // printing @ is now allowed
+    defmt::info!("I can now print the @ symbol!");
+
     loop {
         debug::exit(debug::EXIT_SUCCESS)
     }

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -310,6 +310,8 @@ fn main() -> ! {
 
     // printing @ is now allowed
     defmt::info!("I can now print the @ symbol!");
+    let interned = defmt::intern!("this is @n interned string");
+    defmt::info!("@nd @lso vi@ interned strings: {:istr}", interned);
 
     loop {
         debug::exit(debug::EXIT_SUCCESS)

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -548,14 +548,6 @@ impl Parse for Log {
 pub fn intern(ts: TokenStream) -> TokenStream {
     let lit = parse_macro_input!(ts as LitStr);
     let ls = lit.value();
-    if ls.contains('@') {
-        return parse::Error::new(
-            ls.span(),
-            "strings that contain the character `@` cannot be interned",
-        )
-        .to_compile_error()
-        .into();
-    }
 
     let sym = mksym(&ls, "str", false);
     quote!({
@@ -569,14 +561,6 @@ pub fn intern(ts: TokenStream) -> TokenStream {
 pub fn internp(ts: TokenStream) -> TokenStream {
     let lit = parse_macro_input!(ts as LitStr);
     let ls = lit.value();
-    if ls.contains('@') {
-        return parse::Error::new(
-            ls.span(),
-            "strings that contain the character `@` cannot be interned",
-        )
-        .to_compile_error()
-        .into();
-    }
 
     let sym = symbol::Symbol::new("prim", &ls).mangle();
     let section = format!(".defmt.prim.{}", sym);

--- a/macros/src/symbol.rs
+++ b/macros/src/symbol.rs
@@ -64,7 +64,7 @@ fn escape(s: &str) -> String {
             '\\' => out.push_str("\\\\"),
             '\"' => out.push_str("\\\""),
             '\n' => out.push_str("\\n"),
-            c if c.is_control() => write!(out, "\\u{:04x}", c as u32).unwrap(),
+            c if c.is_control() || c == '@' => write!(out, "\\u{:04x}", c as u32).unwrap(),
             c => out.push(c),
         }
     }


### PR DESCRIPTION
With the new JSON implementation it's trivial, just escape it. The JSON decoder automatically unescapes it.