### PR TITLE
impl Format for alloc types (Box & co)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,24 +76,35 @@ jobs:
       run: RUSTFLAGS='--deny warnings' cargo build --verbose --target ${{ env.NO_STD_TARGET }} --bins
 
   qemu:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+        features:
+          - ','  # no features
+          - alloc
+        exclude:
+          - rust: stable
+            features: alloc
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: ${{ matrix.rust }}
         override: true
         target: ${{ env.QEMU_TARGET }}
     - name: Install dependencies
       run: |
         sudo apt-get update && sudo apt-get install qemu
-        rustup +stable target add ${{ env.QEMU_TARGET }}
+        rustup target add ${{ env.QEMU_TARGET }}
     - name: Build QEMU examples
       working-directory: firmware/qemu
-      run: RUSTFLAGS='--deny warnings' cargo build --verbose --target ${{ env.QEMU_TARGET }} --bins
+      run: RUSTFLAGS='--deny warnings' cargo build --verbose --target ${{ env.QEMU_TARGET }} --bins --features ${{ matrix.features }}
     - name: Run QEMU examples
       working-directory: firmware/qemu
       run: |
-        cargo rb log
-        cargo rrb log
+        cargo rb log --features ${{ matrix.features }}
+        cargo rrb log --features ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ name = "defmt"
 version = "0.1.0"
 links = "defmt" # Prevent multiple versions of defmt being linked
 
+[features]
+alloc = []
+
 [dependencies]
 defmt-macros = { path = "macros" }
 defmt-common = { path = "common" }

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -13,6 +13,7 @@ cortex-m = "0.6.0"
 cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
+alloc-cortex-m = { version = "0.4.0", optional = true }
 
 [features]
 defmt-default = [] # log at INFO, or TRACE, level and up
@@ -22,6 +23,7 @@ defmt-info = []    # log at INFO level and up
 defmt-warn = []    # log at WARN level and up
 defmt-error = []   # log at ERROR level
 default = ["defmt-default"]
+alloc = ["defmt/alloc", "alloc-cortex-m"]
 
 [[bin]]
 name = "log"

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![cfg_attr(feature = "alloc", feature(alloc_error_handler))]
 
 use core::sync::atomic::{AtomicU32, Ordering};
 use cortex_m_rt::entry;
@@ -9,8 +10,14 @@ use defmt::Format;
 use defmt_semihosting as _; // global logger
 use panic_halt as _; // panicking behavior
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[entry]
 fn main() -> ! {
+    #[cfg(feature = "alloc")]
+    if_alloc::init();
+
     defmt::info!("Hello!");
     defmt::info!("World!");
     defmt::info!("The answer is {:u8}", 42);
@@ -330,6 +337,26 @@ fn main() -> ! {
     let interned = defmt::intern!("this is @n interned string");
     defmt::info!("@nd @lso vi@ interned strings: {:istr}", interned);
 
+    #[cfg(feature = "alloc")]
+    {
+        use alloc::boxed::Box;
+        use alloc::rc::Rc;
+        use alloc::string::String;
+        use alloc::sync::Arc;
+        use alloc::vec;
+
+        defmt::info!("Box<u32>: {:?}", Box::new(42u32));
+        defmt::info!("Box<Box<u32>>: {:?}", Box::new(Box::new(1337u32)));
+        defmt::info!("Box<NestedStruct>: {:?}", Box::new(nested()));
+        defmt::info!("Rc<u32>: {:?}", Rc::new(42u32));
+        defmt::info!("Arc<u32>: {:?}", Arc::new(42u32));
+        defmt::info!("Vec<u32>: {:?}", vec![1u32, 2, 3, 4]);
+        defmt::info!("Vec<i32>: {:?}", vec![-1i32, 2, 3, 4]);
+        defmt::info!("Vec<Box<i32>>: {:?}", vec![Box::new(-1i32), Box::new(2), Box::new(3), Box::new(4)]);
+        defmt::info!("Box<Vec<i32>>: {:?}", Box::new(vec![-1i32, 2, 3, 4]));
+        defmt::info!("String: {:?}", String::from("Hello! I'm a heap-allocated String"));
+    }
+
     loop {
         debug::exit(debug::EXIT_SUCCESS)
     }
@@ -354,4 +381,25 @@ fn timestamp() -> u64 {
     // monotonic counter
     static COUNT: AtomicU32 = AtomicU32::new(0);
     COUNT.fetch_add(1, Ordering::Relaxed) as u64
+}
+
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use alloc_cortex_m::CortexMHeap;
+    use core::alloc::Layout;
+
+    #[global_allocator]
+    static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
+
+    #[alloc_error_handler]
+    fn oom(_: Layout) -> ! {
+        loop {}
+    }
+
+    pub fn init() {
+        // Initialize the allocator BEFORE you use it
+        let start = cortex_m_rt::heap_start() as usize;
+        let size = 1024; // in bytes
+        unsafe { ALLOCATOR.init(start, size) }
+    }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -262,3 +262,50 @@ where
         }
     }
 }
+
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use crate::{Format, Formatter};
+
+    impl<T> Format for alloc::boxed::Box<T>
+    where
+        T: ?Sized + Format,
+    {
+        fn format(&self, f: &mut Formatter) {
+            self.as_ref().format(f)
+        }
+    }
+
+    impl<T> Format for alloc::rc::Rc<T>
+    where
+        T: ?Sized + Format,
+    {
+        fn format(&self, f: &mut Formatter) {
+            self.as_ref().format(f)
+        }
+    }
+
+    impl<T> Format for alloc::sync::Arc<T>
+    where
+        T: ?Sized + Format,
+    {
+        fn format(&self, f: &mut Formatter) {
+            self.as_ref().format(f)
+        }
+    }
+
+    impl<T> Format for alloc::vec::Vec<T>
+    where
+        T: Format,
+    {
+        fn format(&self, f: &mut Formatter) {
+            self.as_slice().format(f)
+        }
+    }
+
+    impl Format for alloc::string::String {
+        fn format(&self, f: &mut Formatter) {
+            self.as_str().format(f)
+        }
+    }
+}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -272,7 +272,7 @@ mod if_alloc {
         T: ?Sized + Format,
     {
         fn format(&self, f: &mut Formatter) {
-            self.as_ref().format(f)
+            T::format(&*self, f)
         }
     }
 
@@ -281,7 +281,7 @@ mod if_alloc {
         T: ?Sized + Format,
     {
         fn format(&self, f: &mut Formatter) {
-            self.as_ref().format(f)
+            T::format(&*self, f)
         }
     }
 
@@ -290,7 +290,7 @@ mod if_alloc {
         T: ?Sized + Format,
     {
         fn format(&self, f: &mut Formatter) {
-            self.as_ref().format(f)
+            T::format(&*self, f)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
 #![cfg_attr(not(target_arch = "x86_64"), no_std)]
 #![warn(missing_docs)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 


### PR DESCRIPTION
This implements Format for the `alloc` types: Box, Rc, Arc, Vec, String.

The impls are only there if  `alloc` Cargo feature is enabled in order to not pull in `alloc` if the user doesn't want it. I'm not really sure if this is the best way to do it, and maybe this interacts weirdly with the `#![cfg_attr(not(target_arch = "x86_64"), no_std)]` attribute the crate has. Maybe we should change the crate to have `alloc` and `std` features, and do these impls if either is enabled?