### PR TITLE
Skip empty symbol names while attempting to parse json

### DIFF
--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -61,6 +61,8 @@ pub fn parse(elf: &[u8]) -> Result<Option<Table>, anyhow::Error> {
     // second pass to demangle symbols
     let mut map = BTreeMap::new();
     for (_, entry) in elf.symbols() {
+        // Skipping symbols with empty string names, as they may be added by
+        // `objcopy`, and breaks JSON demangling
         let name = match entry.name() {
             Some(name) if !name.is_empty() => name,
             _ => continue,

--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -62,8 +62,8 @@ pub fn parse(elf: &[u8]) -> Result<Option<Table>, anyhow::Error> {
     let mut map = BTreeMap::new();
     for (_, entry) in elf.symbols() {
         let name = match entry.name() {
-            Some(name) => name,
-            None => continue,
+            Some(name) if !name.is_empty() => name,
+            _ => continue,
         };
 
         if entry.section_index() == Some(defmt_shndx) {


### PR DESCRIPTION
Avoid `Error: EOF while parsing a value at line 1 column 0` if `.defmt` section should contain a symbol with empty name.

This might occur if you run `arm-none-eabi-objcopy ${IN} ${OUT}`, where IN is the output ELF of `cargo build`.