### PR TITLE
make parser::Level public

### DIFF
--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -19,7 +19,8 @@ use std::{
 use byteorder::{ReadBytesExt, LE};
 use colored::Colorize;
 
-use defmt_parser::{Fragment, Level, Parameter, Type, get_max_bitfield_range};
+pub use defmt_parser::Level;
+use defmt_parser::{Fragment, Parameter, Type, get_max_bitfield_range};
 
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
 


### PR DESCRIPTION
fixes bug introduced by https://github.com/knurling-rs/defmt/pull/191/files :

```
   Compiling probe-run v0.1.3 (/Users/lottesteenbrink/ferrous/knurling/probe-run)
error[E0603]: enum `Level` is private
  --> src/logger.rs:32:24
   |
32 |         defmt_decoder::Level::Trace => Level::Trace,
   |                        ^^^^^ private enum
   |
note: the enum `Level` is defined here
  --> /Users/lottesteenbrink/.cargo/git/checkouts/defmt-7f5b74b4e6ff55d4/1326c20/decoder/src/lib.rs:22:30
   |
22 | use defmt_parser::{Fragment, Level, Parameter, Type, get_max_bitfield_range};
   |
```