### PR TITLE
explicitly place the .defmt section at address 0

### DIFF
--- a/defmt.x.in
+++ b/defmt.x.in
@@ -6,7 +6,8 @@ PROVIDE(_defmt_timestamp = __defmt_default_timestamp);
 
 SECTIONS
 {
-  .defmt (INFO) :
+  /* `0` specifies the start address of this virtual (`(INFO)`) section */
+  .defmt 0 (INFO) :
   {
     /* Format implementations for primitives like u8 */
     *(.defmt.prim.*);


### PR DESCRIPTION
before this PR LLD was placing `.defmt` at address 0 but GNU LD was placing the section at some arbitrary address
with this PR both linkers set the start address of `.defmt` to zero, which is what we want (we rely on the indices / addresses being small, etc.)
with this change linking with GNU LD gives me log messages (before it I was getting nothing from apps linked with GNU LD)