### PR TITLE
Fix defmt docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,6 @@ opt-level = 0
 overflow-checks = false
 
 [package.metadata.docs.rs]
-features = ["unstable"]
+all-features = true
 rustdoc-args = [ "--cfg docsrs" ]
+targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabihf"]


### PR DESCRIPTION
It doesn't have an unstable feature. Also, build it for relevant targets instead of tier 1 host targets.