### PR TITLE
Derive and Decoder fixes around bools

### DIFF
--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -87,3 +87,5 @@
 0.000086 INFO [(u32,u32);4]: [(1, 2), (3, 4), (5, 6), (7, 8)]
 0.000087 INFO 1-variant enum: A { fld: 123 }
 0.000088 INFO wrapped: A(A { fld: 200 })
+0.000089 INFO (A(true), B(true)), (A(false), B(true)), (A(true), B(false))
+0.000090 INFO true, [1, 2]: DhcpReprMin { broadcast: true, a: [1, 2] }

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -85,3 +85,5 @@
 0.000084 INFO [(u32,u32);4]: [(1, 2), (3, 4), (5, 6), (7, 8)]
 0.000085 INFO 1-variant enum: A { fld: 123 }
 0.000086 INFO wrapped: A(A { fld: 200 })
+0.000087 INFO (A(true), B(true)), (A(false), B(true)), (A(true), B(false))
+0.000088 INFO true, [1, 2]: DhcpReprMin { broadcast: true, a: [1, 2] }

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -386,6 +386,40 @@ fn main() -> ! {
         defmt::info!("wrapped: {:?}", Wrap::A(Single::A { fld: 200 }));
     }
 
+    {
+        // check that bools are compressed per *log frame*, not per `Format` impl
+
+        #[derive(Format)]
+        struct A(bool);
+
+        #[derive(Format)]
+        struct B(bool);
+
+        defmt::info!(
+            "{:?}, {:?}, {:?}",
+            (A(true), B(true)),
+            (A(false), B(true)),
+            (A(true), B(false))
+        );
+    }
+
+    {
+        // issue #208
+
+        #[derive(Format)]
+        pub struct DhcpReprMin {
+            pub broadcast: bool,
+            pub a: [u8; 2],
+        }
+
+        let dhcp_repr = DhcpReprMin {
+            broadcast: true,
+            a: [1, 2],
+        };
+
+        defmt::info!("true, [1, 2]: {:?}", dhcp_repr);
+    }
+
     loop {
         debug::exit(debug::EXIT_SUCCESS)
     }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -171,7 +171,7 @@ impl Format for bool {
             let t = internp!("{:bool}");
             fmt.u8(&t);
         }
-        fmt.u8(&(*self as u8));
+        fmt.bool(self);
     }
 }
 

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -928,3 +928,30 @@ fn format_bools() {
         ],
     );
 }
+
+#[test]
+fn issue_208() {
+    #[derive(Format)]
+    struct DhcpReprMin {
+        pub broadcast: bool,
+        pub a: [u8; 2],
+    }
+
+    let dhcp_repr = DhcpReprMin {
+        broadcast: true,
+        a: [10, 10],
+    };
+
+    let index = fetch_string_index();
+    check_format_implementation(
+        &dhcp_repr,
+        &[
+            index,         // "DhcpReprMin {{ broadcast: {:bool}, a: {:?} }}"
+            inc(index, 1), // "{:[?;2]}"
+            inc(index, 2), // "{:u8}"
+            10,            // a[0]
+            10,            // a[1]
+            1,             // compressed bools
+        ],
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/knurling-rs/defmt/issues/208

This makes our bool compression scheme match the documentation in the book – previously we've flushed the compression after every `Format` impl, which wastes bandwidth.