### PR TITLE
Handle crates.io versions in decoder build script

### DIFF
--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -12,6 +12,9 @@ colored = "2.0.0"
 leb128 = "0.2.4"
 ryu = "1"
 
+[build-dependencies]
+semver = "0.11.0"
+
 [features]
 # WARNING: API and wire format subject to change.
 unstable = []

--- a/decoder/build.rs
+++ b/decoder/build.rs
@@ -1,9 +1,24 @@
 use std::{env, error::Error, fs, path::PathBuf, process::Command};
 
+use semver::Version;
+
 fn main() -> Result<(), Box<dyn Error>> {
     let out = &PathBuf::from(env::var("OUT_DIR")?);
     let output = Command::new("git").args(&["rev-parse", "HEAD"]).output()?;
-    let commit = String::from_utf8(output.stdout).unwrap();
+    let version = if output.status.success() {
+        String::from_utf8(output.stdout).unwrap()
+    } else {
+        // no git info -> assume crates.io
+        let semver = Version::parse(&std::env::var("CARGO_PKG_VERSION")?)?;
+        if semver.major == 0 {
+            // minor is breaking when major = 0
+            format!("{}.{}", semver.major, semver.minor)
+        } else {
+            // ignore minor, patch, pre and build
+            semver.major.to_string()
+        }
+    };
+
     fs::write(
         out.join("version.rs"),
         format!(
@@ -11,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 /// Supported `defmt` wire format
 const DEFMT_VERSION: &str = "{}";
 "#,
-            commit.trim(),
+            version.trim(),
         ),
     )?;
     Ok(())


### PR DESCRIPTION
Looks like this was missed when the defmt build script was changed