### PR TITLE
Unexport the `write!` macro

### DIFF
--- a/book/src/ser-format.md
+++ b/book/src/ser-format.md
@@ -6,13 +6,17 @@ First let's see how a primitive implements the `Format` trait:
 
 ``` rust
 # extern crate defmt;
-# trait Format { fn format(&self, f: &mut defmt::Formatter); }
+# macro_rules! internp { ($l:literal) => { 0 } }
+# trait Format { fn format(&self, fmt: &mut defmt::Formatter); }
 impl Format for u8 {
-    fn format(&self, f: &mut defmt::Formatter) {
-        defmt::export::write!(f, "{:u8}", self)
+    fn format(&self, fmt: &mut defmt::Formatter) {
+        if fmt.needs_tag() {
+            let t = internp!("{:u8}");
+            fmt.u8(&t);
+        }
+        fmt.u8(self)
         // on the wire: [1, 42]
         //  string index ^  ^^ `self`
-        //  ^ = intern("{:u8}")
     }
 }
 ```

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,7 +1,5 @@
 use crate::{Formatter, Str};
 
-pub use defmt_macros::write;
-
 #[cfg(target_arch = "x86_64")]
 thread_local! {
     static I: core::sync::atomic::AtomicU8 =

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,12 +31,4 @@ fn trailing_comma() {
     defmt::info!("test info {:?}", 0,);
     defmt::warn!("test warn {:?}", 0,);
     defmt::error!("test error {:?}", 0,);
-
-    // Don't run this code, just check that it builds.
-    #[allow(unreachable_code, unused_variables)]
-    if false {
-        let fmt: defmt::Formatter = panic!();
-        defmt::export::write!(fmt, "test write",);
-        defmt::export::write!(fmt, "test write {:?}", 0,);
-    }
 }


### PR DESCRIPTION
It is now completely unused by the derives.

I plan to reintroduce it as public API after the crates.io release, so I left the macro code intact.