### PR TITLE
decoder: make DEFMT_VERSION public

### DIFF
--- a/decoder/build.rs
+++ b/decoder/build.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         format!(
             r#"
 /// Supported `defmt` wire format
-const DEFMT_VERSION: &str = "{}";
+pub const DEFMT_VERSION: &str = "{}";
 "#,
             version.trim(),
         ),


### PR DESCRIPTION
so we can print it from `probe-run`