### PR TITLE
Import panic-probe crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,8 @@ jobs:
     - name: Build panic-probe with different features
       working-directory: firmware/panic-probe
       run: |
-        for target in $NO_STD_CHECK_TARGETS; do
-          cargo check --target $target --features print-defmt
-          cargo check --target $target --features print-rtt
-        done
+        cargo check --target thumbv6m-none-eabi --features print-defmt
+        cargo check --target thumbv6m-none-eabi --features print-rtt
 
   mdbook:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
         for target in $NO_STD_CHECK_TARGETS; do
           cargo check --target $target
         done
+    - name: Build panic-probe with different features
+      working-directory: firmware/panic-probe
+      run: |
+        for target in $NO_STD_CHECK_TARGETS; do
+          cargo check --target $target --features print-defmt
+          cargo check --target $target --features print-rtt
+        done
 
   mdbook:
     strategy:

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+authors = ["The Knurling Authors"]
+categories = ["embedded", "no-std"]
+description = "Panic handler that exits `probe-run` with an error code"
+edition = "2018"
+keywords = ["knurling", "panic-impl", "defmt", "probe-run"]
+license = "MIT OR Apache-2.0"
+name = "panic-probe"
+readme = "README.md"
+repository = "https://github.com/knurling-rs/probe-run"
+version = "0.1.0"
+
+[dependencies]
+cortex-m = "0.6.3"
+cortex-m-rt = "0.6.12"
+
+[dependencies.rtt-target]
+version = "0.2.2"
+optional = true
+
+[dependencies.defmt]
+git = "https://github.com/knurling-rs/defmt.git"
+optional = true
+rev = "3db6b41"
+version = "0.1.0"
+
+[features]
+# Print the panic message using `rtt-target`.
+print-rtt = ["rtt-target"]
+# Print the panic message using `defmt`.
+print-defmt = ["defmt", "defmt-error"]
+
+defmt-error = [] # internal feature, do not use
+
+[package.metadata.docs.rs]
+default-target = "thumbv7m-none-eabi"

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -19,9 +19,8 @@ version = "0.2.2"
 optional = true
 
 [dependencies.defmt]
-git = "https://github.com/knurling-rs/defmt.git"
 optional = true
-rev = "3db6b41"
+path = "../.."
 version = "0.1.0"
 
 [features]

--- a/firmware/panic-probe/README.md
+++ b/firmware/panic-probe/README.md
@@ -1,0 +1,39 @@
+# `panic-probe`
+
+> Panic handler that exits [`probe-run`] with an error code
+
+[`probe-run`]: https://github.com/knurling-rs/probe-run
+
+`panic-probe` can optionally log the panic message using the [`defmt`] logging framework.
+This functionality can be enabled through the `print-defmt` Cargo feature.
+
+[`defmt`]: https://github.com/knurling-rs/defmt
+
+## Support
+
+`panic-probe` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/firmware/panic-probe/build.rs
+++ b/firmware/panic-probe/build.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    if target.starts_with("thumbv6m-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv6m");
+    } else if target.starts_with("thumbv7m-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv7m");
+    } else if target.starts_with("thumbv7em-") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv7m");
+        println!("cargo:rustc-cfg=armv7em"); // (not currently used)
+    } else if target.starts_with("thumbv8m.base") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv8m");
+        println!("cargo:rustc-cfg=armv8m_base");
+    } else if target.starts_with("thumbv8m.main") {
+        println!("cargo:rustc-cfg=cortex_m");
+        println!("cargo:rustc-cfg=armv8m");
+        println!("cargo:rustc-cfg=armv8m_main");
+    }
+}

--- a/firmware/panic-probe/src/lib.rs
+++ b/firmware/panic-probe/src/lib.rs
@@ -1,0 +1,142 @@
+//! Panic handler for `probe-run`.
+//!
+//! When this panic handler is used, panics will make `probe-run` print a backtrace and exit with a
+//! non-zero status code, indicating failure. This building block can be used to run on-device
+//! tests.
+//!
+//! # Panic Messages
+//!
+//! By default, `panic-probe` *ignores* the panic message. You can enable one of the following
+//! features to print it instead:
+//!
+//! - `print-rtt`: Prints the panic message over plain RTT (via `rtt-target`). RTT must be
+//!   initialized by the app.
+//! - `print-defmt`: Prints the panic message via [defmt]'s transport (note that defmt will not be
+//!   used to efficiently format the message).
+//!
+//! [defmt]: https://github.com/knurling-rs/defmt/
+
+#![no_std]
+#![cfg(target_os = "none")]
+
+#[cfg(not(cortex_m))]
+compile_error!("`panic-probe` only supports Cortex-M targets (thumbvN-none-eabi[hf])");
+
+// Functionality `cfg`d out on platforms with OS/libstd.
+#[cfg(target_os = "none")]
+mod imp {
+    use core::panic::PanicInfo;
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use cortex_m::asm;
+
+    #[cfg(feature = "print-rtt")]
+    use crate::print_rtt::print;
+
+    #[cfg(feature = "print-defmt")]
+    use crate::print_defmt::print;
+
+    #[cfg(not(any(feature = "print-rtt", feature = "print-defmt")))]
+    fn print(_: &core::panic::PanicInfo) {}
+
+    #[panic_handler]
+    fn panic(info: &PanicInfo) -> ! {
+        static PANICKED: AtomicBool = AtomicBool::new(false);
+
+        cortex_m::interrupt::disable();
+
+        // Guard against infinite recursion, just in case.
+        if PANICKED.load(Ordering::Relaxed) {
+            loop {
+                asm::bkpt();
+            }
+        }
+
+        PANICKED.store(true, Ordering::Relaxed);
+
+        print(info);
+
+        // Trigger a `HardFault` via `udf` instruction.
+
+        // If `UsageFault` is enabled, we disable that first, since otherwise `udf` will cause that
+        // exception instead of `HardFault`.
+        #[cfg(not(any(armv6m, armv8m_base)))]
+        {
+            const SHCSR: *mut u32 = 0xE000ED24usize as _;
+            const USGFAULTENA: usize = 18;
+
+            unsafe {
+                let mut shcsr = core::ptr::read_volatile(SHCSR);
+                shcsr &= !(1 << USGFAULTENA);
+                core::ptr::write_volatile(SHCSR, shcsr);
+            }
+        }
+
+        asm::udf();
+    }
+}
+
+#[cfg(feature = "print-rtt")]
+mod print_rtt {
+    use core::panic::PanicInfo;
+    use rtt_target::rprintln;
+
+    pub fn print(info: &PanicInfo) {
+        rprintln!("{}", info);
+    }
+}
+
+#[cfg(feature = "print-defmt")]
+mod print_defmt {
+    use core::{
+        cmp,
+        fmt::{self, Write},
+        mem,
+        panic::PanicInfo,
+        str,
+    };
+
+    const DEFMT_BUF_SIZE: usize = 128;
+    const OVERFLOW_MARK: &str = "…";
+
+    struct Sink<'a> {
+        buf: &'a mut [u8],
+        pos: usize,
+        overflowed: bool,
+    }
+
+    impl<'a> fmt::Write for Sink<'a> {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            if self.overflowed {
+                return Ok(());
+            }
+
+            let buf = mem::replace(&mut self.buf, &mut []);
+            let buf_unused = &mut buf[self.pos..];
+
+            if buf_unused.len() < s.len() {
+                self.overflowed = true;
+            }
+
+            let lim = cmp::min(buf_unused.len(), s.len());
+            buf_unused[..lim].copy_from_slice(&s.as_bytes()[..lim]);
+            self.buf = buf;
+            self.pos += lim;
+            Ok(())
+        }
+    }
+
+    pub fn print(info: &PanicInfo) {
+        let mut buf = [0; DEFMT_BUF_SIZE];
+        let mut sink = Sink {
+            buf: &mut buf,
+            pos: 0,
+            overflowed: false,
+        };
+        write!(sink, "{}", info).ok();
+
+        let msg = str::from_utf8(&sink.buf[..sink.pos]).unwrap_or("<utf-8 error>");
+        let overflow = if sink.overflowed { OVERFLOW_MARK } else { "" };
+        defmt::error!("{:str}{:str}", msg, overflow);
+    }
+}


### PR DESCRIPTION
from the probe-run repo, including its git history
also make it depend on defmt via a path-dependency (instead of a git-dependency)
this makes it easier to use a git version of defmt in e.g. an app-template project