### PR TITLE
remove profile overrides

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,23 +37,8 @@ lto = "fat"
 opt-level = 3
 overflow-checks = false
 
-# faster builds from scratch
-[profile.dev.build-override]
-codegen-units = 8
-debug = false
-debug-assertions = false
-opt-level = 0
-overflow-checks = false
-
 [build-dependencies]
 semver = "0.11.0"
-
-[profile.release.build-override]
-codegen-units = 8
-debug = false
-debug-assertions = false
-opt-level = 0
-overflow-checks = false
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
these settings are now the default as of Cargo 1.47
this is the same as knurling-rs/app-template#25