### PR TITLE
Import defmt-test crate

### DIFF
--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -11,5 +11,5 @@ cortex-m-rt = "0.6.13"
 defmt-test-macros = { path = "macros" }
 
 [dependencies.defmt]
-git = "https://github.com/knurling-rs/defmt"
-branch = "main"
+path = "../.."
+version = "0.1.0"

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["The Knurling-rs developers"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+name = "defmt-test"
+version = "0.1.0"
+
+[dependencies]
+cortex-m = "0.6.3"
+cortex-m-rt = "0.6.13"
+defmt-test-macros = { path = "macros" }
+
+[dependencies.defmt]
+git = "https://github.com/knurling-rs/defmt"
+branch = "main"

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 authors = ["The Knurling-rs developers"]
+categories = ["embedded", "no-std"]
+description = "A test harness for embedded devices"
 edition = "2018"
+keywords = ["knurling", "defmt", "testing"]
 license = "MIT OR Apache-2.0"
 name = "defmt-test"
+readme = "README.md"
+repository = "https://github.com/knurling-rs/defmt"
 version = "0.1.0"
 
 [dependencies]

--- a/firmware/defmt-test/LICENSE-APACHE
+++ b/firmware/defmt-test/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/firmware/defmt-test/LICENSE-MIT
+++ b/firmware/defmt-test/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/firmware/defmt-test/README.md
+++ b/firmware/defmt-test/README.md
@@ -1,0 +1,134 @@
+# `defmt-test`
+
+> a test harness for embedded devices
+
+## Basic usage
+
+0. If you don't have a project setup yet, start from the [`app-template`] 
+
+
+[`app-template`]: https://github.com/knurling-rs/app-template
+
+1. In the **testsuite** crate, add `defmt-test` to the dependencies:
+
+``` toml
+# testsuite/Cargo.toml
+[dependencies.defmt-test]
+git = "https://github.com/knurling-rs/defmt-test"
+branch = "main"
+```
+
+2. Within the `testsuite/tests/test.rs` file, create a `tests` module and mark it with the `#[defmt_test::tests]` attribute. Within that module write `std`-like unit tests: functions marked with the `#[test]` attribute.
+
+``` rust
+// testsuite/tests/test.rs
+
+#[defmt_test::tests]
+mod tests {
+   #[test]
+   fn assert_true() {
+       assert!(true)
+   }
+
+   #[test]
+   fn assert_false() {
+       assert!(false)
+   }
+}
+```
+
+3. Run `cargo test -p testsuite` to run the unit tests
+
+``` console
+$ cargo test -p testsuite
+0.000000 INFO            | running assert_true ..
+0.000001 INFO            | .. assert_true ok
+0.000002 INFO            | running assert_false ..
+0.000003 ERROR           | panicked at 'assertion failed: false', testsuite/tests/test.rs:15:9
+└─ ~/.cargo/git/checkouts/probe-run-31a04fec2ca67672/d81788c/panic-probe/src/lib.rs:139
+stack backtrace:
+   0: 0x000016cc - HardFaultTrampoline
+      <exception entry>
+   1: 0x00000706 - __udf
+   2: 0x00001450 - cortex_m::asm::udf
+   3: 0x0000147a - rust_begin_unwind
+   4: 0x00000878 - core::panicking::panic_fmt
+   5: 0x0000081a - core::panicking::panic
+   6: 0x00000342 - test::tests::assert_false
+   7: 0x0000029a - main
+   8: 0x000000fa - Reset
+```
+
+NOTE unit tests will be executed sequentially
+
+## Adding state
+
+An `#[init]` function can be written within the `#[tests]` module.
+This function will be executed before all unit tests and its return value, the test suite *state*, can be passed to unit tests as an argument.
+
+``` rust
+// state shared across unit tests
+struct MyState {
+    flag: bool,
+}
+
+#[defmt_test::tests]
+mod tests {
+    #[init]
+    fn init() -> super::MyState {
+        // state initial value
+        super::MyState {
+            flag: true,
+        }
+    }
+
+    // this unit test doesn't access the state
+    #[test]
+    fn assert_true() {
+        assert!(true);
+    }
+
+    // but this test does
+    #[test]
+    fn assert_flag(state: &mut super::MyState) {
+        assert!(state.flag)
+    }
+}
+```
+
+``` console
+$ cargo test -p testsuite
+0.000000 INFO            | running assert_true ..
+0.000001 INFO            | .. assert_true ok
+0.000002 INFO            | running assert_flag ..
+0.000003 INFO            | .. assert_flag ok
+```
+
+## Support
+
+`defmt-test` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/firmware/defmt-test/macros/Cargo.toml
+++ b/firmware/defmt-test/macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["The Knurling-rs developers"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+name = "defmt-test-macros"
+version = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.20"
+quote = "1.0.7"
+syn = { version = "1.0.40", features = ["extra-traits", "full"] }

--- a/firmware/defmt-test/macros/Cargo.toml
+++ b/firmware/defmt-test/macros/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 authors = ["The Knurling-rs developers"]
+description = "defmt-test macros"
 edition = "2018"
+keywords = ["knurling", "defmt", "testing"]
 license = "MIT OR Apache-2.0"
 name = "defmt-test-macros"
+readme = "../README.md"
+repository = "https://github.com/knurling-rs/defmt"
 version = "0.1.0"
 
 [lib]

--- a/firmware/defmt-test/macros/src/lib.rs
+++ b/firmware/defmt-test/macros/src/lib.rs
@@ -1,0 +1,276 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote};
+use syn::{parse, spanned::Spanned, Block, FnArg, Ident, Item, ItemMod, Path, ReturnType, Type};
+
+#[proc_macro_attribute]
+pub fn tests(args: TokenStream, input: TokenStream) -> TokenStream {
+    match tests_impl(args, input) {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStream> {
+    if !args.is_empty() {
+        return Err(parse::Error::new(
+            Span::call_site(),
+            "`#[test]` attribute takes no arguments",
+        ));
+    }
+
+    let module: ItemMod = syn::parse(input)?;
+
+    let items = if let Some(content) = module.content {
+        content.1
+    } else {
+        return Err(parse::Error::new(
+            module.span(),
+            "module must be inline (e.g. `mod foo {}`)",
+        ));
+    };
+
+    let mut init = None;
+    let mut tests = vec![];
+    for item in items {
+        let item_span = item.span();
+        match item {
+            Item::Fn(f) => {
+                // TODO span could be better here
+                let attr = if let Some(attr) = f
+                    .attrs
+                    .iter()
+                    .filter_map(|attr| {
+                        if path_is_ident(&attr.path, "init") {
+                            Some(Attr::Init)
+                        } else if path_is_ident(&attr.path, "test") {
+                            Some(Attr::Test)
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+                {
+                    attr
+                } else {
+                    return Err(parse::Error::new(
+                        item_span,
+                        "only attributes `#[test]` and `#[init]` are accepted",
+                    ));
+                };
+
+                match attr {
+                    Attr::Init => {
+                        if init.is_some() {
+                            return Err(parse::Error::new(
+                                f.sig.ident.span(),
+                                "only a single `#[init]` function can be defined",
+                            ));
+                        }
+
+                        if check_fn_sig(&f.sig).is_err() || !f.sig.inputs.is_empty() {
+                            return Err(parse::Error::new(
+                                f.sig.ident.span(),
+                                "`#[init]` function must have signature `fn() [-> Type]` (the return type is optional)",
+                            ));
+                        }
+
+                        let state = match f.sig.output {
+                            ReturnType::Default => None,
+                            ReturnType::Type(.., ty) => Some(ty),
+                        };
+
+                        init = Some(Init {
+                            block: f.block,
+                            ident: f.sig.ident,
+                            state,
+                        });
+                    }
+
+                    Attr::Test => {
+                        if check_fn_sig(&f.sig).is_err()
+                            || f.sig.output != ReturnType::Default
+                            || f.sig.inputs.len() > 1
+                        {
+                            return Err(parse::Error::new(
+                                f.sig.ident.span(),
+                                "`#[test]` function must have signature `fn([&mut Type])` (parameter is optional)",
+                            ));
+                        }
+
+                        let input = if f.sig.inputs.len() == 1 {
+                            let arg = &f.sig.inputs[0];
+
+                            // NOTE we cannot check the argument type matches `init.state` at this
+                            // point
+                            if let Some(ty) = get_mutable_reference_type(arg).cloned() {
+                                Some(Input {
+                                    arg: arg.clone(),
+                                    ty,
+                                })
+                            } else {
+                                // was not `&mut T`
+                                return Err(parse::Error::new(
+                                    arg.span(),
+                                    "parameter must be a mutable reference (`&mut $Type`)",
+                                ));
+                            }
+                        } else {
+                            None
+                        };
+
+                        tests.push(Test {
+                            block: f.block,
+                            ident: f.sig.ident,
+                            input,
+                        })
+                    }
+                }
+            }
+
+            _ => {
+                return Err(parse::Error::new(
+                    item.span(),
+                    "only function items are allowed",
+                ));
+            }
+        }
+    }
+
+    let krate = format_ident!("defmt_test");
+    let ident = module.ident;
+    let mut state_ty = None;
+    let (init_fn, init_expr) = if let Some(init) = init {
+        let init_ident = init.ident;
+        let init_block = init.block;
+        state_ty = init.state;
+
+        (
+            Some(quote!(fn #init_ident() -> #state_ty #init_block)),
+            Some(quote!(#[allow(dead_code)] let mut state = #init_ident();)),
+        )
+    } else {
+        (None, None)
+    };
+
+    let mut unit_test_calls = vec![];
+    for test in &tests {
+        let ident = &test.ident;
+        let span = ident.span();
+        let call = if let Some(input) = test.input.as_ref() {
+            if let Some(state) = &state_ty {
+                if input.ty != **state {
+                    return Err(parse::Error::new(
+                        input.ty.span(),
+                        "this type must match `#[init]`s return type",
+                    ));
+                }
+            } else {
+                return Err(parse::Error::new(
+                    span,
+                    "no state was initialized by `#[init]`; signature must be `fn()`",
+                ));
+            }
+
+            quote!(#ident(&mut state);)
+        } else {
+            quote!(#ident();)
+        };
+        unit_test_calls.push(call);
+    }
+    let unit_test_names = tests.iter().map(|test| &test.ident);
+    let unit_test_inputs = tests
+        .iter()
+        .map(|test| test.input.as_ref().map(|input| &input.arg));
+    let unit_test_blocks = tests.iter().map(|test| &test.block);
+    let unit_test_running = tests
+        .iter()
+        .map(|test| format!("running {} ..", test.ident))
+        .collect::<Vec<_>>();
+    let unit_test_done = tests
+        .iter()
+        .map(|test| format!(".. {} ok", test.ident))
+        .collect::<Vec<_>>();
+    Ok(quote!(mod #ident {
+        // TODO use `cortex-m-rt::entry` here to get the `static mut` transform
+        #[export_name = "main"]
+        unsafe extern "C" fn __defmt_test_entry() -> ! {
+            #init_expr
+            #(
+                defmt::info!(#unit_test_running);
+                #unit_test_calls
+                defmt::info!(#unit_test_done);
+            )*
+
+            #krate::export::exit()
+        }
+
+        #init_fn
+
+        #(
+            fn #unit_test_names(#unit_test_inputs) #unit_test_blocks
+        )*
+    })
+    .into())
+}
+
+#[derive(Clone, Copy)]
+enum Attr {
+    Init,
+    Test,
+}
+
+struct Init {
+    block: Box<Block>,
+    ident: Ident,
+    state: Option<Box<Type>>,
+}
+
+struct Test {
+    block: Box<Block>,
+    ident: Ident,
+    input: Option<Input>,
+}
+
+struct Input {
+    arg: FnArg,
+    ty: Type,
+}
+
+fn path_is_ident(path: &Path, s: &str) -> bool {
+    path.get_ident().map(|ident| ident == s).unwrap_or(false)
+}
+
+// NOTE doesn't check the parameters or the return type
+fn check_fn_sig(sig: &syn::Signature) -> Result<(), ()> {
+    if sig.constness.is_none()
+        && sig.asyncness.is_none()
+        && sig.unsafety.is_none()
+        && sig.abi.is_none()
+        && sig.generics.params.is_empty()
+        && sig.generics.where_clause.is_none()
+        && sig.variadic.is_none()
+    {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+fn get_mutable_reference_type(arg: &syn::FnArg) -> Option<&Type> {
+    if let syn::FnArg::Typed(pat) = arg {
+        if let syn::Type::Reference(refty) = &*pat.ty {
+            if refty.mutability.is_some() {
+                Some(&refty.elem)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/firmware/defmt-test/src/export.rs
+++ b/firmware/defmt-test/src/export.rs
@@ -1,0 +1,8 @@
+use cortex_m_rt as _;
+pub use defmt::info;
+
+pub fn exit() -> ! {
+    loop {
+        cortex_m::asm::bkpt()
+    }
+}

--- a/firmware/defmt-test/src/lib.rs
+++ b/firmware/defmt-test/src/lib.rs
@@ -1,10 +1,10 @@
-//! A test harness for embedded devices
+//! A test harness for embedded devices.
 //!
 //! This crate has a single API: the `#[tests]` macro. This macro is documented in the project
 //! README which can be found at:
 //!
-//! - https://crates.io/crates/defmt (crates.io version)
-//! - https://github.com/knurling-rs/defmt/tree/main/firmware/defmt-test (git version)
+//! - <https://crates.io/crates/defmt-test> (crates.io version)
+//! - <https://github.com/knurling-rs/defmt/tree/main/firmware/defmt-test> (git version)
 
 #![no_std]
 

--- a/firmware/defmt-test/src/lib.rs
+++ b/firmware/defmt-test/src/lib.rs
@@ -1,3 +1,11 @@
+//! A test harness for embedded devices
+//!
+//! This crate has a single API: the `#[tests]` macro. This macro is documented in the project
+//! README which can be found at:
+//!
+//! - https://crates.io/crates/defmt (crates.io version)
+//! - https://github.com/knurling-rs/defmt/tree/main/firmware/defmt-test (git version)
+
 #![no_std]
 
 pub use defmt_test_macros::tests;

--- a/firmware/defmt-test/src/lib.rs
+++ b/firmware/defmt-test/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub use defmt_test_macros::tests;
+
+pub mod export;


### PR DESCRIPTION
from the defmt-test repo, including its git history
also make it depend on defmt via a path-dependency (instead of a git-dependency)
also add missing crate metadata so we can publish this on crates.io
this makes it easier to use a git version of defmt in e.g. an app-template project

Commits before "Merge external defmt-test git history" are existing commits from the defmt-test repo; commits after it are new commits that need reviewing