### PR TITLE
#145: Implement display hints to optionally format values as hex

### DIFF
--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -88,6 +88,35 @@ fn info() {
 }
 
 #[test]
+fn info_with_hints() {
+    let index = fetch_string_index();
+    let timestamp = fetch_timestamp();
+    let mut f = Formatter::new();
+
+    winfo!(f, "The answer is {:u8:x}", 42);
+    assert_eq!(
+        f.bytes(),
+        &[
+            index,     // "The answer is {:u8}",
+            timestamp, //
+            42,        // u8 value
+        ]
+    );
+
+    let mut f = Formatter::new();
+    winfo!(f, "The answer is {:?:X}", 42u8);
+    assert_eq!(
+        f.bytes(),
+        &[
+            inc(index, 1),     // "The answer is {:?}"
+            inc(timestamp, 1), //
+            inc(index, 2),     // "{:u8}" / impl Format for u8
+            42,                // u8 value
+        ]
+    );
+}
+
+#[test]
 fn booleans_max_num_bool_flags() {
     let index = fetch_string_index();
     let timestamp = fetch_timestamp();


### PR DESCRIPTION
This PR implements the beginnings of formatting values as hex, as per design in https://github.com/knurling-rs/defmt/issues/145#issuecomment-712235944.

This allows you to do:

```rust
defmt::error!(
    " double-fault at 0x{:u32:X} !",
    fault_addr,
);
```

There's plenty more options to support, but my hope with this PR is to start the conversation on:

1. Where the logic should go and how it should be represented
2. What we should call it (format? display hints?)
3. What we should support (padding? what formats? just integer types or everything?)

To start, this PR just implements the `{<optional-arg-idx>:<type>:<display-hint>}` form, where (currently) the only two display hints are `:x` (lower hex) and `:X` (upper hex).