### PR TITLE
Replace Write trait with a `write` fn in Logger.

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -77,13 +77,18 @@ pub fn global_logger(args: TokenStream, input: TokenStream) -> TokenStream {
         #vis struct #ident;
 
         #[no_mangle]
-        unsafe fn _defmt_acquire() -> Option<defmt::InternalFormatter> {
-            <#ident as defmt::Logger>::acquire().map(|nn| defmt::InternalFormatter::from_raw(nn))
+        unsafe fn _defmt_acquire() -> bool {
+            <#ident as defmt::Logger>::acquire()
         }
 
         #[no_mangle]
-        unsafe fn _defmt_release(f: defmt::InternalFormatter)  {
-            <#ident as defmt::Logger>::release(f.into_raw())
+        unsafe fn _defmt_release()  {
+            <#ident as defmt::Logger>::release()
+        }
+
+        #[no_mangle]
+        unsafe fn _defmt_write(bytes: &[u8])  {
+            <#ident as defmt::Logger>::write(bytes)
         }
     )
     .into()
@@ -512,11 +517,12 @@ fn log(level: Level, log: FormatArgs) -> TokenStream2 {
         if #logging_enabled {
             match (#(&(#args)),*) {
                 (#(#pats),*) => {
-                    if let Some(mut _fmt_) = defmt::export::acquire() {
+                    if defmt::export::acquire() {
+                        let mut _fmt_ = defmt::InternalFormatter::new();
                         _fmt_.header(&defmt::export::istr(#sym));
                         #(#exprs;)*
                         _fmt_.finalize();
-                        defmt::export::release(_fmt_)
+                        defmt::export::release()
                     }
                 }
             }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,4 +1,4 @@
-use crate::{InternalFormatter, Str};
+use crate::Str;
 
 #[cfg(feature = "unstable-test")]
 thread_local! {
@@ -23,29 +23,38 @@ pub fn fetch_add_string_index() -> usize {
 }
 
 #[cfg(feature = "unstable-test")]
-pub fn acquire() -> Option<InternalFormatter> {
-    None
+pub fn acquire() -> bool {
+    false
 }
 
 #[cfg(not(feature = "unstable-test"))]
 #[inline(never)]
-pub fn acquire() -> Option<InternalFormatter> {
+pub fn acquire() -> bool {
     extern "Rust" {
-        fn _defmt_acquire() -> Option<InternalFormatter>;
+        fn _defmt_acquire() -> bool;
     }
     unsafe { _defmt_acquire() }
 }
 
 #[cfg(feature = "unstable-test")]
-pub fn release(_: InternalFormatter) {}
+pub fn release() {}
 
 #[cfg(not(feature = "unstable-test"))]
 #[inline(never)]
-pub fn release(fmt: InternalFormatter) {
+pub fn release() {
     extern "Rust" {
-        fn _defmt_release(fmt: InternalFormatter);
+        fn _defmt_release();
     }
-    unsafe { _defmt_release(fmt) }
+    unsafe { _defmt_release() }
+}
+
+#[cfg(not(feature = "unstable-test"))]
+#[inline(never)]
+pub fn write(bytes: &[u8]) {
+    extern "Rust" {
+        fn _defmt_write(bytes: &[u8]);
+    }
+    unsafe { _defmt_write(bytes) }
 }
 
 /// For testing purposes

--- a/tests/basic_usage.rs
+++ b/tests/basic_usage.rs
@@ -6,10 +6,11 @@ fn main() {
 struct Logger;
 
 unsafe impl defmt::Logger for Logger {
-    fn acquire() -> Option<core::ptr::NonNull<dyn defmt::Write>> {
-        None
+    fn acquire() -> bool {
+        false
     }
-    unsafe fn release(_writer: core::ptr::NonNull<dyn defmt::Write>) {}
+    unsafe fn release() {}
+    unsafe fn write(_bytes: &[u8]) {}
 }
 
 defmt::timestamp!("{=u32}", 0);


### PR DESCRIPTION
The "remove dyn Write" part of of #257 contained breaking changes, so it's extracted here as a separate PR. See that PR for details.