### PR TITLE
make crates.io version not depend on the `git` tool

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,18 +8,22 @@ fn main() -> Result<(), Box<dyn Error>> {
     let hash = Command::new("git")
         .args(&["rev-parse", "HEAD"])
         .output()
-        .map(|output| {
+        .ok()
+        .and_then(|output| {
             if output.status.success() {
                 String::from_utf8(output.stdout).ok()
             } else {
-                assert!(!Path::new(".git").exists(), "you need to install the `git` command line tool to use the git version of `defmt`");
-
                 None
             }
         });
-    let version = if let Ok(Some(hash)) = hash {
+    let version = if let Some(hash) = hash {
         hash
     } else {
+        assert!(
+            !Path::new(".git").exists(),
+            "you need to install the `git` command line tool to use the git version of `defmt`"
+        );
+
         // no git info -> assume crates.io
         let semver = Version::parse(&std::env::var("CARGO_PKG_VERSION")?)?;
         if semver.major == 0 {

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,24 @@
 use semver::Version;
-use std::{env, error::Error, fs, path::PathBuf, process::Command};
+use std::{env, error::Error, fs, path::Path, path::PathBuf, process::Command};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var("OUT_DIR")?);
     let mut linker_script = fs::read_to_string("defmt.x.in")?;
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output()?;
-    let version = if output.status.success() {
-        String::from_utf8(output.stdout).unwrap()
+    let hash = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .map(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                assert!(!Path::new(".git").exists(), "you need to install the `git` command line tool to use the git version of `defmt`");
+
+                None
+            }
+        });
+    let version = if let Ok(Some(hash)) = hash {
+        hash
     } else {
         // no git info -> assume crates.io
         let semver = Version::parse(&std::env::var("CARGO_PKG_VERSION")?)?;

--- a/decoder/build.rs
+++ b/decoder/build.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             if output.status.success() {
                 String::from_utf8(output.stdout).ok()
             } else {
-                assert!(!Path::new(".git").exists(), "you need to install the `git` command line tool to use the git version of `defmt`");
+                assert!(!Path::new(".git").exists(), "you need to install the `git` command line tool to install the git version of `probe-run`");
 
                 None
             }

--- a/decoder/build.rs
+++ b/decoder/build.rs
@@ -9,7 +9,6 @@ use std::{
 use semver::Version;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    panic!("{:?}", env::current_dir());
     let out = &PathBuf::from(env::var("OUT_DIR")?);
     let hash = Command::new("git")
         .args(&["rev-parse", "HEAD"])

--- a/decoder/build.rs
+++ b/decoder/build.rs
@@ -13,18 +13,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     let hash = Command::new("git")
         .args(&["rev-parse", "HEAD"])
         .output()
-        .map(|output| {
+        .ok()
+        .and_then(|output| {
             if output.status.success() {
                 String::from_utf8(output.stdout).ok()
             } else {
-                assert!(!Path::new(".git").exists(), "you need to install the `git` command line tool to install the git version of `probe-run`");
-
                 None
             }
         });
-    let version = if let Ok(Some(hash)) = hash {
+    let version = if let Some(hash) = hash {
         hash
     } else {
+        assert!(!Path::new(".git").exists(), "you need to install the `git` command line tool to install the git version of `probe-run`");
+
         // no git info -> assume crates.io
         let semver = Version::parse(&std::env::var("CARGO_PKG_VERSION")?)?;
         if semver.major == 0 {


### PR DESCRIPTION
also error if git version is used but `git` is not installed
prompt the user to install `git` in that case

fixes #256

---

we need `git` when the git version is used because we use the commit hash to check if probe-run is compatible with the firmware-side defmt
instead of panicking when git is not installed we could:
- depend on the libgit2 crate and use that to retrieve the commit hash (from what I remember libgit2 is as, or more, annoying to install as git on Windows (not WSL))
- implement `git rev-parse HEAD` using just the std library. It seems reading the `.git/HEAD` file and then reading the file specified there (e.g. `.git/refs/heads/main`, which contains the full hash) should do the trick but it does feel a bit brittle