### PR TITLE
add defmt::panic!

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Filtering](./filtering.md)
   - [#[timestamp]](./timestamp.md)
   - [#[global_logger]](./global-logger.md)
+  - [panic! and assert!](./panic.md)
   - [Printers](./printers.md)
   - [Migrating from git defmt to stable defmt](./migration.md)
 - [Design & impl details](./design.md)

--- a/book/src/panic.md
+++ b/book/src/panic.md
@@ -1,0 +1,38 @@
+# `panic!` and `assert!`
+
+The `defmt` crate provides its own version of `panic!`-like and `assert!`-like macros.
+The `defmt` version of these macros will log the panic message using `defmt` and then call `core::panic!` (by default).
+Because the panic message is formatted using `defmt!` the format string must use the same syntax as the logging macros (e.g. `info!`).
+
+## `#[defmt::panic_handler]`
+
+Because `defmt::panic!` invokes `core::panic!` this can result in the panic message being printed twice if your `#[core::panic_handler]` also prints the panic message.
+This is the case if you use [`panic-probe`] with the `print-defmt` feature enabled but not an issue if you are using the [`panic-abort`] crate, for example.
+
+[`panic-probe`]: https://crates.io/crates/panic-probe
+[`panic-abort`]: https://crates.io/crates/panic-abort
+
+To avoid this issue you can use the `#[defmt::panic_handler]` to *override* the panicking behavior of `defmt::panic`-like and `defmt::assert`-like macros.
+This attribute must be placed on a function with signature `fn() -> !`.
+In this function you'll want to replicate the panicking behavior of `#[core::panic_handler]` but leave out the part that prints the panic message.
+For example:
+
+<!-- NOTE(ignore) we can't compile this test because the `panic_handler` defined here collides with the one in `std` -->
+
+``` rust, ignore
+#[panic_handler] // built-in ("core") attribute
+fn core_panic(info: &core::panic::PanicInfo) -> ! {
+    print(info); // e.g. using RTT
+    reset()
+}
+
+#[defmt::panic_handler] // defmt's attribute
+fn defmt_panic() -> ! {
+    // leave out the printing part here
+    reset()
+}
+```
+
+If you are using the `panic-probe` crate then you should "abort" (call `cortex_m::asm::udf`) from `#[defmt::panic_handler]` to match its behavior.
+
+NOTE: even if you don't run into the "double panic message printed" issue you may still want to use `#[defmt::panic_handler]` because this way `defmt::panic` and `defmt::assert` will *not* go through the `core::panic` machinery and that *may* reduce code size (we recommend you measure the effect of the change).

--- a/book/src/panic.md
+++ b/book/src/panic.md
@@ -14,7 +14,7 @@ This is the case if you use [`panic-probe`] with the `print-defmt` feature enabl
 
 To avoid this issue you can use the `#[defmt::panic_handler]` to *override* the panicking behavior of `defmt::panic`-like and `defmt::assert`-like macros.
 This attribute must be placed on a function with signature `fn() -> !`.
-In this function you'll want to replicate the panicking behavior of `#[core::panic_handler]` but leave out the part that prints the panic message.
+In this function you'll want to replicate the panicking behavior of the Rust `#[panic_handler]` but leave out the part that prints the panic message.
 For example:
 
 <!-- NOTE(ignore) we can't compile this test because the `panic_handler` defined here collides with the one in `std` -->

--- a/defmt.x.in
+++ b/defmt.x.in
@@ -3,6 +3,7 @@ EXTERN(_defmt_acquire);
 EXTERN(_defmt_release);
 EXTERN(__defmt_default_timestamp);
 PROVIDE(_defmt_timestamp = __defmt_default_timestamp);
+PROVIDE(_defmt_panic = __defmt_default_panic);
 
 SECTIONS
 {

--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -75,7 +75,8 @@ pub fn parse(elf: &[u8]) -> Result<Option<Table>, anyhow::Error> {
         }
     };
 
-    defmt_decoder::check_version(version).map_err(anyhow::Error::msg)?;
+    // TODO(japaric) REMOVE!
+    // defmt_decoder::check_version(version).map_err(anyhow::Error::msg)?;
 
     // second pass to demangle symbols
     let mut map = BTreeMap::new();

--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -75,8 +75,7 @@ pub fn parse(elf: &[u8]) -> Result<Option<Table>, anyhow::Error> {
         }
     };
 
-    // TODO(japaric) REMOVE!
-    // defmt_decoder::check_version(version).map_err(anyhow::Error::msg)?;
+    defmt_decoder::check_version(version).map_err(anyhow::Error::msg)?;
 
     // second pass to demangle symbols
     let mut map = BTreeMap::new();

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -25,6 +25,22 @@ default = ["defmt-default"]
 alloc = ["defmt/alloc", "alloc-cortex-m"]
 
 [[bin]]
+name = "assert"
+test = false
+
+[[bin]]
+name = "assert-eq"
+test = false
+
+[[bin]]
+name = "assert-ne"
+test = false
+
+[[bin]]
+name = "panic"
+test = false
+
+[[bin]]
 name = "log"
 test = false
 

--- a/firmware/qemu/src/bin/assert-eq.out
+++ b/firmware/qemu/src/bin/assert-eq.out
@@ -1,0 +1,3 @@
+0.000000 ERROR panicked at 'assertion failed: `(left == right)`: dev'
+ left: `41`
+right: `43`

--- a/firmware/qemu/src/bin/assert-eq.release.out
+++ b/firmware/qemu/src/bin/assert-eq.release.out
@@ -1,0 +1,3 @@
+0.000000 ERROR panicked at 'assertion failed: `(left == right)`: release'
+ left: `41`
+right: `43`

--- a/firmware/qemu/src/bin/assert-eq.rs
+++ b/firmware/qemu/src/bin/assert-eq.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 
 use defmt_semihosting as _; // global logger
 
@@ -19,6 +18,6 @@ fn main() -> ! {
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {
-        debug::exit(debug::EXIT_SUCCESS)
+        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/assert-eq.rs
+++ b/firmware/qemu/src/bin/assert-eq.rs
@@ -17,7 +17,9 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
+    use cortex_m_semihosting::debug;
+
     loop {
-        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
+        debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/assert-eq.rs
+++ b/firmware/qemu/src/bin/assert-eq.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::debug;
+
+use defmt_semihosting as _; // global logger
+
+#[entry]
+fn main() -> ! {
+    let x = 42;
+    defmt::debug_assert_eq!(x - 1, x + 1, "dev");
+    defmt::assert_eq!(x - 1, x + 1, "release");
+    defmt::unreachable!();
+}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}

--- a/firmware/qemu/src/bin/assert-ne.out
+++ b/firmware/qemu/src/bin/assert-ne.out
@@ -1,3 +1,2 @@
 0.000000 ERROR panicked at 'assertion failed: `(left != right)`: dev'
- left: `42`
-right: `42`
+left/right: `42`

--- a/firmware/qemu/src/bin/assert-ne.out
+++ b/firmware/qemu/src/bin/assert-ne.out
@@ -1,0 +1,3 @@
+0.000000 ERROR panicked at 'assertion failed: `(left != right)`: dev'
+ left: `42`
+right: `42`

--- a/firmware/qemu/src/bin/assert-ne.release.out
+++ b/firmware/qemu/src/bin/assert-ne.release.out
@@ -1,3 +1,2 @@
 0.000000 ERROR panicked at 'assertion failed: `(left != right)`: release'
- left: `42`
-right: `42`
+left/right: `42`

--- a/firmware/qemu/src/bin/assert-ne.release.out
+++ b/firmware/qemu/src/bin/assert-ne.release.out
@@ -1,0 +1,3 @@
+0.000000 ERROR panicked at 'assertion failed: `(left != right)`: release'
+ left: `42`
+right: `42`

--- a/firmware/qemu/src/bin/assert-ne.rs
+++ b/firmware/qemu/src/bin/assert-ne.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 
 use defmt_semihosting as _; // global logger
 
@@ -19,6 +18,6 @@ fn main() -> ! {
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {
-        debug::exit(debug::EXIT_SUCCESS)
+        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/assert-ne.rs
+++ b/firmware/qemu/src/bin/assert-ne.rs
@@ -17,7 +17,9 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
+    use cortex_m_semihosting::debug;
+
     loop {
-        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
+        debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/assert-ne.rs
+++ b/firmware/qemu/src/bin/assert-ne.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::debug;
+
+use defmt_semihosting as _; // global logger
+
+#[entry]
+fn main() -> ! {
+    let x = 42;
+    defmt::debug_assert_ne!(x, x, "dev");
+    defmt::assert_ne!(x, x, "release");
+    defmt::unreachable!();
+}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}

--- a/firmware/qemu/src/bin/assert.out
+++ b/firmware/qemu/src/bin/assert.out
@@ -1,0 +1,1 @@
+0.000000 ERROR panicked at 'assertion failed: dev'

--- a/firmware/qemu/src/bin/assert.release.out
+++ b/firmware/qemu/src/bin/assert.release.out
@@ -1,0 +1,1 @@
+0.000000 ERROR panicked at 'assertion failed: release'

--- a/firmware/qemu/src/bin/assert.rs
+++ b/firmware/qemu/src/bin/assert.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 
 use defmt_semihosting as _; // global logger
 
@@ -20,6 +19,6 @@ fn main() -> ! {
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {
-        debug::exit(debug::EXIT_SUCCESS)
+        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/assert.rs
+++ b/firmware/qemu/src/bin/assert.rs
@@ -18,7 +18,9 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
+    use cortex_m_semihosting::debug;
+
     loop {
-        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
+        debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/assert.rs
+++ b/firmware/qemu/src/bin/assert.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::debug;
+
+use defmt_semihosting as _; // global logger
+
+#[entry]
+fn main() -> ! {
+    let dev = false;
+    let release = false;
+    defmt::debug_assert!(dev);
+    defmt::assert!(release);
+    defmt::unreachable!();
+}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}

--- a/firmware/qemu/src/bin/panic.out
+++ b/firmware/qemu/src/bin/panic.out
@@ -1,0 +1,1 @@
+0.000000 ERROR panicked at 'The answer is 42'

--- a/firmware/qemu/src/bin/panic.release.out
+++ b/firmware/qemu/src/bin/panic.release.out
@@ -1,0 +1,1 @@
+0.000000 ERROR panicked at 'The answer is 42'

--- a/firmware/qemu/src/bin/panic.rs
+++ b/firmware/qemu/src/bin/panic.rs
@@ -14,7 +14,9 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
+    use cortex_m_semihosting::debug;
+
     loop {
-        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
+        debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/panic.rs
+++ b/firmware/qemu/src/bin/panic.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 
 use defmt_semihosting as _; // global logger
 
@@ -16,6 +15,6 @@ fn main() -> ! {
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {
-        debug::exit(debug::EXIT_SUCCESS)
+        cortex_m_semihosting::debug::exit(debug::EXIT_SUCCESS)
     }
 }

--- a/firmware/qemu/src/bin/panic.rs
+++ b/firmware/qemu/src/bin/panic.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::debug;
+
+use defmt_semihosting as _; // global logger
+
+#[entry]
+fn main() -> ! {
+    defmt::panic!("The answer is {:?}", 42);
+}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}

--- a/firmware/qemu/test.sh
+++ b/firmware/qemu/test.sh
@@ -5,12 +5,14 @@ set -o errexit
 function test() {
     local bin=$1
     local features=${2-,}
-    
+
     cargo rb "$bin" --features "$features" | tee "src/bin/$bin.out.new" | diff "src/bin/$bin.out" -
     cargo rrb "$bin" --features "$features" | tee "src/bin/$bin.release.out.new" | diff "src/bin/$bin.release.out" -
 }
 
 test "log"
+test "panic"
+test "assert"
 if rustc -V | grep nightly; then
     test "alloc" "alloc"
 fi

--- a/firmware/qemu/test.sh
+++ b/firmware/qemu/test.sh
@@ -13,6 +13,8 @@ function test() {
 test "log"
 test "panic"
 test "assert"
+test "assert-eq"
+test "assert-ne"
 if rustc -V | grep nightly; then
     test "alloc" "alloc"
 fi

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -679,7 +679,7 @@ fn assert_binop(ts: TokenStream, binop: BinOp) -> TokenStream {
         FormatArgs {
             litstr: LitStr::new(
                 &format!(
-                    "panicked at 'assertion failed: `(left {} right)`'{}
+                    "panicked at 'assertion failed: `(left {} right)`{}'
  left: `{{:?}}`
 right: `{{:?}}`",
                     binop, extra_string

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -580,13 +580,22 @@ pub fn assert_(ts: TokenStream) -> TokenStream {
 
     let condition = assert.condition;
     let log_stmt = if let Some(args) = assert.args {
-        log(Level::Error, args)
+        log(
+            Level::Error,
+            FormatArgs {
+                litstr: LitStr::new(
+                    &format!("panicked at '{}'", args.litstr.value()),
+                    Span2::call_site(),
+                ),
+                rest: args.rest,
+            },
+        )
     } else {
         log(
             Level::Error,
             FormatArgs {
                 litstr: LitStr::new(
-                    &format!("assertion failed: {}", quote!(#condition)),
+                    &format!("panicked at 'assertion failed: {}'", quote!(#condition)),
                     Span2::call_site(),
                 ),
                 rest: None,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -710,6 +710,37 @@ right: `{{:?}}`",
     .into()
 }
 
+// NOTE these `debug_*` macros can be written using `macro_rules!` (that'd be simpler) but that
+// results in an incorrect source code location being reported: the location of the `macro_rules!`
+// statement is reported. Using a proc-macro results in the call site being reported, which is what
+// we want
+#[proc_macro]
+pub fn debug_assert_(ts: TokenStream) -> TokenStream {
+    let assert = TokenStream2::from(assert_(ts));
+    quote!(if cfg!(debug_assertions) {
+        #assert
+    })
+    .into()
+}
+
+#[proc_macro]
+pub fn debug_assert_eq_(ts: TokenStream) -> TokenStream {
+    let assert = TokenStream2::from(assert_eq_(ts));
+    quote!(if cfg!(debug_assertions) {
+        #assert
+    })
+    .into()
+}
+
+#[proc_macro]
+pub fn debug_assert_ne_(ts: TokenStream) -> TokenStream {
+    let assert = TokenStream2::from(assert_ne_(ts));
+    quote!(if cfg!(debug_assertions) {
+        #assert
+    })
+    .into()
+}
+
 // TODO share more code with `log`
 #[proc_macro]
 pub fn winfo(ts: TokenStream) -> TokenStream {

--- a/src/export.rs
+++ b/src/export.rs
@@ -146,3 +146,10 @@ mod sealed {
 pub fn truncate<T>(x: impl sealed::Truncate<T>) -> T {
     x.truncate()
 }
+
+pub fn panic() -> ! {
+    extern "Rust" {
+        fn _defmt_panic() -> !;
+    }
+    unsafe { _defmt_panic() }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -52,12 +52,12 @@ pub fn release(fmt: Formatter) {
     unsafe { _defmt_release(fmt) }
 }
 
+/// For testing purposes
 #[cfg(target_arch = "x86_64")]
 pub fn timestamp() -> u64 {
     (T.with(|i| i.fetch_add(1, core::sync::atomic::Ordering::Relaxed)) & 0x7f) as u64
 }
 
-/// For testing purposes
 #[cfg(not(target_arch = "x86_64"))]
 pub fn timestamp() -> u64 {
     extern "Rust" {
@@ -147,6 +147,13 @@ pub fn truncate<T>(x: impl sealed::Truncate<T>) -> T {
     x.truncate()
 }
 
+/// For testing purposes
+#[cfg(target_arch = "x86_64")]
+pub fn panic() -> ! {
+    panic!()
+}
+
+#[cfg(not(target_arch = "x86_64"))]
 pub fn panic() -> ! {
     extern "Rust" {
         fn _defmt_panic() -> !;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ mod leb;
 #[cfg(test)]
 mod tests;
 
+pub use defmt_macros::assert_ as assert;
+
 pub use defmt_macros::unreachable_ as unreachable;
 
 pub use defmt_macros::todo_ as todo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-use core::mem::MaybeUninit;
-use core::ptr::NonNull;
+use core::{mem::MaybeUninit, ptr::NonNull};
 
 #[doc(hidden)]
 pub mod export;
@@ -25,6 +24,10 @@ mod impls;
 mod leb;
 #[cfg(test)]
 mod tests;
+
+pub use defmt_macros::panic_ as panic;
+
+pub use defmt_macros::panic_handler;
 
 /// Creates an interned string ([`Str`]) from a string literal.
 ///
@@ -460,4 +463,9 @@ pub trait Format {
 #[export_name = "__defmt_default_timestamp"]
 fn default_timestamp() -> u64 {
     0
+}
+
+#[export_name = "__defmt_default_panic"]
+fn default_panic() -> ! {
+    core::panic!()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod tests;
 
 pub use defmt_macros::assert_ as assert;
 pub use defmt_macros::assert_eq_ as assert_eq;
+pub use defmt_macros::assert_ne_ as assert_ne;
 
 pub use defmt_macros::unreachable_ as unreachable;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ mod leb;
 #[cfg(test)]
 mod tests;
 
+pub use defmt_macros::unreachable_ as unreachable;
+
 pub use defmt_macros::todo_ as todo;
 pub use defmt_macros::todo_ as unimplemented;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,21 +25,103 @@ mod leb;
 #[cfg(test)]
 mod tests;
 
+/// Just like the [`core::assert!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::assert!`]: https://doc.rust-lang.org/core/macro.assert.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::assert_ as assert;
+
+/// Just like the [`core::assert_eq!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::assert_eq!`]: https://doc.rust-lang.org/core/macro.assert_eq.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::assert_eq_ as assert_eq;
+
+/// Just like the [`core::assert_ne!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::assert_ne!`]: https://doc.rust-lang.org/core/macro.assert_ne.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::assert_ne_ as assert_ne;
 
+/// Just like the [`core::debug_assert!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::debug_assert!`]: https://doc.rust-lang.org/core/macro.debug_assert.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::debug_assert_ as debug_assert;
+
+/// Just like the [`core::debug_assert_eq!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::debug_assert_eq!`]: https://doc.rust-lang.org/core/macro.debug_assert_eq.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::debug_assert_eq_ as debug_assert_eq;
+
+/// Just like the [`core::debug_assert_ne!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::debug_assert_ne!`]: https://doc.rust-lang.org/core/macro.debug_assert_ne.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::debug_assert_ne_ as debug_assert_ne;
 
+/// Just like the [`core::unreachable!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::unreachable!`]: https://doc.rust-lang.org/core/macro.unreachable.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::unreachable_ as unreachable;
 
+/// Just like the [`core::todo!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::todo!`]: https://doc.rust-lang.org/core/macro.todo.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::todo_ as todo;
+
+/// Just like the [`core::unimplemented!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::unimplemented!`]: https://doc.rust-lang.org/core/macro.unimplemented.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::todo_ as unimplemented;
 
+/// Just like the [`core::panic!`] macro but `defmt` is used to log the panic message
+///
+/// [`core::panic!`]: https://doc.rust-lang.org/core/macro.panic.html
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::panic_ as panic;
 
+/// Overrides the panicking behavior of `defmt::panic!`
+///
+/// By default, `defmt::panic!` calls `core::panic!` after logging the panic message using `defmt`.
+/// This can result in the panic message being printed twice in some cases. To avoid that issue use
+/// this macro. See [the manual] for details.
+///
+/// [the manual]: https://defmt.ferrous-systems.com/panic.html
 pub use defmt_macros::panic_handler;
 
 /// Creates an interned string ([`Str`]) from a string literal.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,10 @@ pub use defmt_macros::assert_ as assert;
 pub use defmt_macros::assert_eq_ as assert_eq;
 pub use defmt_macros::assert_ne_ as assert_ne;
 
+pub use defmt_macros::debug_assert_ as debug_assert;
+pub use defmt_macros::debug_assert_eq_ as debug_assert_eq;
+pub use defmt_macros::debug_assert_ne_ as debug_assert_ne;
+
 pub use defmt_macros::unreachable_ as unreachable;
 
 pub use defmt_macros::todo_ as todo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ mod leb;
 #[cfg(test)]
 mod tests;
 
+pub use defmt_macros::todo_ as todo;
+pub use defmt_macros::todo_ as unimplemented;
+
 pub use defmt_macros::panic_ as panic;
 
 pub use defmt_macros::panic_handler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,12 +216,6 @@ impl Formatter {
     }
 
     /// Implementation detail
-    #[cfg(target_arch = "x86_64")]
-    pub unsafe fn from_raw(_: NonNull<dyn Write>) -> Self {
-        unreachable!()
-    }
-
-    /// Implementation detail
     #[cfg(not(target_arch = "x86_64"))]
     pub unsafe fn from_raw(writer: NonNull<dyn Write>) -> Self {
         Self {
@@ -230,12 +224,6 @@ impl Formatter {
             bools_left: MAX_NUM_BOOL_FLAGS,
             omit_tag: false,
         }
-    }
-
-    /// Implementation detail
-    #[cfg(target_arch = "x86_64")]
-    pub unsafe fn into_raw(self) -> NonNull<dyn Write> {
-        unreachable!()
     }
 
     /// Implementation detail
@@ -423,6 +411,29 @@ impl Formatter {
         self.u8(&flags);
         self.bools_left = MAX_NUM_BOOL_FLAGS;
         self.bool_flags = 0;
+    }
+}
+
+// these need to be in a separate module or `unreachable!` will end up calling `defmt::panic` and
+// this will not compile
+// (using `core::unreachable!` instead of `unreachable!` doesn't help)
+#[cfg(target_arch = "x86_64")]
+mod x86_64 {
+    use core::ptr::NonNull;
+
+    use super::Write;
+
+    #[doc(hidden)]
+    impl super::Formatter {
+        /// Implementation detail
+        pub unsafe fn from_raw(_: NonNull<dyn Write>) -> Self {
+            unreachable!()
+        }
+
+        /// Implementation detail
+        pub unsafe fn into_raw(self) -> NonNull<dyn Write> {
+            unreachable!()
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod leb;
 mod tests;
 
 pub use defmt_macros::assert_ as assert;
+pub use defmt_macros::assert_eq_ as assert_eq;
 
 pub use defmt_macros::unreachable_ as unreachable;
 


### PR DESCRIPTION
closes #136
this implements `defmt::panic!` which calls `defmt::error!` and then "panics"

by default, `defmt::panic!` will "panic" by calling `core::panic!`. This preserves the panicking *behavior* (e.g. abort on panic, reset on panic, etc.) but can result in the panic message being printed *twice* -- this is the case if you use `panic_probe` (+print-defmt)

to prevent printing the panic message *twice*, the panicking *behavior* of `defmt::panic` can be overridden using the `#[defmt::panic_handler]` attribute, which works about the same as `#[core::panic_handler]` but expects a `fn() -> !` function (note: no argument)

the idea is that end users will replicate their `#[panic_handler]` panicking *behavior*, and omit the 'print the panic message' part, in the `#[defmt::panic_handler]` function, for example:

``` rust
#[panic_handler]
fn panic(info: &PanicInfo) -> ! {
    print(info); // e.g. using defmt
    reset()
}

#[defmt::panic_handler]
fn defmt_panic() -> ! {
    reset()
}
```

we can do the above for all new users of app-template so they don't run into the 'panic message printed twice':

``` rust
// src/lib.rs
use panic_probe as _; // "print-defmt" is enabled

#[defmt::panic_handler]
fn panic() -> ! {
    cortex_m::asm::udf()
}
```

TODO
- [x] API docs
- [x] book docs
- [x] todo! & unimplemented!
- [x] unreachable!
- [x] assert!
- [x] assert_eq! assert_ne!
- [x] debug_assert, debug_assert_eq, debug_assert_ne
- [x] snapshot tests
- [x] assert_eq! & probe-run integration (colored diff) -> https://github.com/knurling-rs/probe-run/tree/color-diff
- ~~prelude~~ didn't work you can't override core's prelude items using a glob import

FIXME
- [x] probe-run renders `assert_ne` as a color-diff but shouldn't