### PR TITLE
add Debug2Format adapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ alloc = []
 
 [dependencies]
 defmt-macros = { path = "macros", version = "0.1.0" }
+heapless = "0.5.6"
 
 [workspace]
 members = [

--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -90,4 +90,8 @@
 0.000089 INFO (A(true), B(true)), (A(false), B(true)), (A(true), B(false))
 0.000090 INFO true, [1, 2]: DhcpReprMin { broadcast: true, a: [1, 2] }
 0.000091 INFO nested `Format` impls using `write!`: outer value (inner value (42))
-0.000092 INFO QEMU test finished!
+0.000092 INFO S { x: -1, y: 2 }
+0.000093 INFO Some(S { x: -1, y: 2 })
+0.000094 INFO [S { x: -1, y: 2 }, S { x: -1, y: 2 }]
+0.000095 INFO [Some(S { x: -1, y: 2 }), None]
+0.000096 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -88,4 +88,8 @@
 0.000087 INFO (A(true), B(true)), (A(false), B(true)), (A(true), B(false))
 0.000088 INFO true, [1, 2]: DhcpReprMin { broadcast: true, a: [1, 2] }
 0.000089 INFO nested `Format` impls using `write!`: outer value (inner value (42))
-0.000090 INFO QEMU test finished!
+0.000090 INFO S { x: -1, y: 2 }
+0.000091 INFO Some(S { x: -1, y: 2 })
+0.000092 INFO [S { x: -1, y: 2 }, S { x: -1, y: 2 }]
+0.000093 INFO [Some(S { x: -1, y: 2 }), None]
+0.000094 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -4,7 +4,7 @@
 use core::sync::atomic::{AtomicU32, Ordering};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
-use defmt::{Format, Formatter};
+use defmt::{consts, Debug2Format, Format, Formatter};
 
 use defmt_semihosting as _; // global logger
 
@@ -443,7 +443,23 @@ fn main() -> ! {
         );
     }
 
+    // Debug adapter
+    {
+        #[derive(Clone, Copy, Debug)]
+        struct S {
+            x: i8,
+            y: i16,
+        }
+
+        let s = S { x: -1, y: 2 };
+        defmt::info!("{:?}", Debug2Format::<consts::U128>(&s));
+        defmt::info!("{:?}", Debug2Format::<consts::U128>(&Some(s)));
+        defmt::info!("{:?}", Debug2Format::<consts::U128>(&[s, s]));
+        defmt::info!("{:?}", Debug2Format::<consts::U128>(&[Some(s), None]));
+    }
+
     defmt::info!("QEMU test finished!");
+
     loop {
         debug::exit(debug::EXIT_SUCCESS)
     }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -117,11 +117,15 @@ impl Format for f32 {
 impl Format for str {
     fn format(&self, fmt: &mut Formatter) {
         if fmt.needs_tag() {
-            let t = internp!("{:str}");
+            let t = str_tag();
             fmt.u8(&t);
         }
         fmt.str(self);
     }
+}
+
+pub(crate) fn str_tag() -> u8 {
+    internp!("{:str}")
 }
 
 impl Format for Str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,6 +619,8 @@ fn default_panic() -> ! {
 /// `consts` module. Example:
 ///
 /// ```
+/// use defmt::{consts, Debug2Format};
+///
 /// #[derive(Debug)]
 /// struct S { x: i8, y: i16 }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,6 +662,7 @@ where
 }
 
 /// `Debug2Format` constructor
+#[allow(non_snake_case)]
 pub fn Debug2Format<'a, N>(value: &'a dyn fmt::Debug) -> Debug2Format<'a, N>
 where
     N: ArrayLength<u8>,


### PR DESCRIPTION
this is a temporary solution for #126 
(a better solution is probably something along the lines of https://github.com/knurling-rs/defmt/issues/126#issuecomment-724890594 but that may require changes to the wire format and may *not* make it to the v0.1.x series)
closes #126