### PR TITLE
Escape braces in assert expressions.

### DIFF
--- a/firmware/qemu/src/bin/assert-eq.rs
+++ b/firmware/qemu/src/bin/assert-eq.rs
@@ -7,6 +7,8 @@ use defmt_semihosting as _; // global logger
 
 #[entry]
 fn main() -> ! {
+    defmt::assert_eq!({1 + 1}, { 2 });
+
     let x = 42;
     defmt::debug_assert_eq!(x - 1, x + 1, "dev");
     defmt::assert_eq!(x - 1, x + 1, "release");

--- a/firmware/qemu/src/bin/assert-ne.rs
+++ b/firmware/qemu/src/bin/assert-ne.rs
@@ -7,6 +7,8 @@ use defmt_semihosting as _; // global logger
 
 #[entry]
 fn main() -> ! {
+    defmt::assert_ne!({1 + 1}, { 3 });
+
     let x = 42;
     defmt::debug_assert_ne!(x, x, "dev");
     defmt::assert_ne!(x, x, "release");

--- a/firmware/qemu/src/bin/assert.rs
+++ b/firmware/qemu/src/bin/assert.rs
@@ -7,6 +7,8 @@ use defmt_semihosting as _; // global logger
 
 #[entry]
 fn main() -> ! {
+    defmt::assert!({1 + 1} == { 2 });
+
     let dev = false;
     let release = false;
     defmt::debug_assert!(dev);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -594,7 +594,7 @@ pub fn assert_(ts: TokenStream) -> TokenStream {
             Level::Error,
             FormatArgs {
                 litstr: LitStr::new(
-                    &format!("panicked at 'assertion failed: {}'", quote!(#condition)),
+                    &format!("panicked at 'assertion failed: {}'", escape_expr(&condition)),
                     Span2::call_site(),
                 ),
                 rest: None,
@@ -750,6 +750,11 @@ pub fn debug_assert_ne_(ts: TokenStream) -> TokenStream {
         #assert
     })
     .into()
+}
+
+fn escape_expr(expr: &Expr) -> String {
+    let q = quote!(#expr);
+    q.to_string().replace("{", "{{").replace("}", "}}")
 }
 
 struct Assert {


### PR DESCRIPTION
Without this, defmt attempts to interpret the braces as format args, resulting in errors like

```rust
    defmt::assert!({1 + 1} == { 2 });
```

```
error: malformed format string (missing `:`)
  --> firmware/qemu/src/bin/assert.rs:10:5
   |
10 |     defmt::assert!({1 + 1} == { 2 });
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

