### PR TITLE
Unwrap macro

### DIFF
--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -49,6 +49,10 @@ name = "double-write"
 test = false
 
 [[bin]]
+name = "unwrap"
+test = false
+
+[[bin]]
 name = "alloc"
 test = false
 required-features = ["alloc"]

--- a/firmware/qemu/src/bin/assert-eq.rs
+++ b/firmware/qemu/src/bin/assert-eq.rs
@@ -7,6 +7,8 @@ use defmt_semihosting as _; // global logger
 
 #[entry]
 fn main() -> ! {
+    defmt::assert_eq!({1 + 1}, { 2 });
+
     let x = 42;
     defmt::debug_assert_eq!(x - 1, x + 1, "dev");
     defmt::assert_eq!(x - 1, x + 1, "release");

--- a/firmware/qemu/src/bin/assert-ne.rs
+++ b/firmware/qemu/src/bin/assert-ne.rs
@@ -7,6 +7,8 @@ use defmt_semihosting as _; // global logger
 
 #[entry]
 fn main() -> ! {
+    defmt::assert_ne!({1 + 1}, { 3 });
+
     let x = 42;
     defmt::debug_assert_ne!(x, x, "dev");
     defmt::assert_ne!(x, x, "release");

--- a/firmware/qemu/src/bin/assert.rs
+++ b/firmware/qemu/src/bin/assert.rs
@@ -7,6 +7,8 @@ use defmt_semihosting as _; // global logger
 
 #[entry]
 fn main() -> ! {
+    defmt::assert!({1 + 1} == { 2 });
+
     let dev = false;
     let release = false;
     defmt::debug_assert!(dev);

--- a/firmware/qemu/src/bin/unwrap.out
+++ b/firmware/qemu/src/bin/unwrap.out
@@ -1,0 +1,3 @@
+0.000000 INFO The answer is 42
+0.000000 ERROR panicked at 'unwrap failed: x'
+error: `Bar`

--- a/firmware/qemu/src/bin/unwrap.release.out
+++ b/firmware/qemu/src/bin/unwrap.release.out
@@ -1,0 +1,3 @@
+0.000000 INFO The answer is 42
+0.000000 ERROR panicked at 'unwrap failed: x'
+error: `Bar`

--- a/firmware/qemu/src/bin/unwrap.rs
+++ b/firmware/qemu/src/bin/unwrap.rs
@@ -1,0 +1,33 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::debug;
+
+use defmt_semihosting as _; // global logger
+
+#[derive(defmt::Format)]
+enum Error {
+    Bar,
+}
+
+#[entry]
+fn main() -> ! {
+    let x: Result<u32, Error> = Ok(42);
+    defmt::info!("The answer is {:?}", defmt::unwrap!(x));
+    let x: Result<u32, Error> = Err(Error::Bar);
+    defmt::info!("The answer is {:?}", defmt::unwrap!(x));
+
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}

--- a/firmware/qemu/test.sh
+++ b/firmware/qemu/test.sh
@@ -16,6 +16,7 @@ test "assert"
 test "assert-eq"
 test "assert-ne"
 test "double-write"
+test "unwrap"
 if rustc -V | grep nightly; then
     test "alloc" "alloc"
 fi

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -653,20 +653,7 @@ fn assert_binop(ts: TokenStream, binop: BinOp) -> TokenStream {
     };
 
     for val in vals {
-        let mut segments = Punctuated::new();
-        segments.push(PathSegment {
-            ident: Ident2::new(*val, Span2::call_site()),
-            arguments: PathArguments::None,
-        });
-
-        log_args.push(Expr::Path(ExprPath {
-            attrs: vec![],
-            qself: None,
-            path: Path {
-                leading_colon: None,
-                segments,
-            },
-        }));
+        log_args.push(ident_expr(*val));
     }
 
     let log_stmt = match binop {
@@ -750,6 +737,71 @@ pub fn debug_assert_ne_(ts: TokenStream) -> TokenStream {
         #assert
     })
     .into()
+}
+
+#[proc_macro]
+pub fn unwrap(ts: TokenStream) -> TokenStream {
+    let assert = parse_macro_input!(ts as Assert);
+
+    let condition = assert.condition;
+    let log_stmt = if let Some(args) = assert.args {
+        log(
+            Level::Error,
+            FormatArgs {
+                litstr: LitStr::new(
+                    &format!("panicked at '{}'", args.litstr.value()),
+                    Span2::call_site(),
+                ),
+                rest: args.rest,
+            },
+        )
+    } else {
+        let mut log_args = Punctuated::new();
+        log_args.push(ident_expr("_unwrap_err"));
+
+        log(
+            Level::Error,
+            FormatArgs {
+                litstr: LitStr::new(
+                    &format!(
+                        "panicked at 'unwrap failed: {}'
+error: `{{:?}}`",
+                        escape_expr(&condition)
+                    ),
+                    Span2::call_site(),
+                ),
+                rest: Some((syn::token::Comma::default(), log_args)),
+            },
+        )
+    };
+
+    quote!(
+        match defmt::export::into_result(#condition) {
+            ::core::result::Result::Ok(res) => res,
+            ::core::result::Result::Err(_unwrap_err) => {
+                #log_stmt;
+                defmt::export::panic()
+            }
+        }
+    )
+    .into()
+}
+
+fn ident_expr(name: &str) -> Expr {
+    let mut segments = Punctuated::new();
+    segments.push(PathSegment {
+        ident: Ident2::new(name, Span2::call_site()),
+        arguments: PathArguments::None,
+    });
+
+    Expr::Path(ExprPath {
+        attrs: vec![],
+        qself: None,
+        path: Path {
+            leading_colon: None,
+            segments,
+        },
+    })
 }
 
 fn escape_expr(expr: &Expr) -> String {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -594,7 +594,7 @@ pub fn assert_(ts: TokenStream) -> TokenStream {
             Level::Error,
             FormatArgs {
                 litstr: LitStr::new(
-                    &format!("panicked at 'assertion failed: {}'", quote!(#condition)),
+                    &format!("panicked at 'assertion failed: {}'", escape_expr(&condition)),
                     Span2::call_site(),
                 ),
                 rest: None,
@@ -750,6 +750,11 @@ pub fn debug_assert_ne_(ts: TokenStream) -> TokenStream {
         #assert
     })
     .into()
+}
+
+fn escape_expr(expr: &Expr) -> String {
+    let q = quote!(#expr);
+    q.to_string().replace("{", "{{").replace("}", "}}")
 }
 
 struct Assert {

--- a/src/export.rs
+++ b/src/export.rs
@@ -71,6 +71,7 @@ pub fn istr(address: usize) -> Str {
 }
 
 mod sealed {
+    #[allow(unused_imports)]
     use crate as defmt;
     use crate::{Format, Formatter};
     use defmt_macros::internp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,13 @@ pub use defmt_macros::todo_ as unimplemented;
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::panic_ as panic;
 
+/// todo
+///
+/// If used, the format string must follow the defmt syntax (documented in [the manual])
+///
+/// [the manual]: https://defmt.ferrous-systems.com/macros.html
+pub use defmt_macros::unwrap;
+
 /// Overrides the panicking behavior of `defmt::panic!`
 ///
 /// By default, `defmt::panic!` calls `core::panic!` after logging the panic message using `defmt`.


### PR DESCRIPTION
This is a PoC of the `unwrap!` macro discussed in #161, to see how well it works.

Seems to work great, line numbers are printed correctly. The only drawback is the syntax is less nicer than the normal `unwrap()` since it doesn't read left-to-right.

Ignore the `Escape braces in assert expressions.` commit, it's included so the unwrap macro can use the `escape_expr` function.