### PR TITLE
Update CI test job on OSX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       # (see https://github.com/rust-embedded/cortex-m-rt/issues/74), so we cannot use
       # `cargo test --workspace` and have to build the test suites individually instead
       if: matrix.os == 'macOS-latest'
-      run: cargo test -p defmt -p defmt-decoder -p defmt-parser -p defmt-macros
+      run: cargo test -p defmt -p defmt-decoder -p defmt-parser -p defmt-macros --all-features
 
   no-std:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the CI test task to run all tests on OSX.

Previously the test task did not run the tests of the `defmt-decoder` crate due to the missing feature `unstable`. In order to run these tests as well the `cargo test` command now includes the `--all-features` option to enable all features. For the decoder this enables the `unstable` feature and therefore runs all of its tests.