### PR TITLE
CI: add backwards compatibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,8 @@ jobs:
     - name: Build and Run QEMU tests
       working-directory: firmware/qemu
       run: ./test.sh
+    - name: Backward compatibility check against decoder v0.1.0
+      working-directory: firmware/qemu
+      run: |
+        cargo install --debug --git https://github.com/knurling-rs/defmt --branch do-not-delete-v0.1.0-with-no-version-check
+        CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER=qemu-run ./test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,5 +125,5 @@ jobs:
     - name: Backward compatibility check against decoder v0.1.0
       working-directory: firmware/qemu
       run: |
-        cargo install --debug --git https://github.com/knurling-rs/defmt --branch do-not-delete-v0.1.0-with-no-version-check qemu-run
+        cargo install --debug --git https://github.com/knurling-rs/defmt --tag v0.1.0-without-version-check qemu-run
         CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER=qemu-run ./test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,5 +125,5 @@ jobs:
     - name: Backward compatibility check against decoder v0.1.0
       working-directory: firmware/qemu
       run: |
-        cargo install --debug --git https://github.com/knurling-rs/defmt --branch do-not-delete-v0.1.0-with-no-version-check
+        cargo install --debug --git https://github.com/knurling-rs/defmt --branch do-not-delete-v0.1.0-with-no-version-check qemu-run
         CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER=qemu-run ./test.sh

--- a/firmware/qemu/test.sh
+++ b/firmware/qemu/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit
+set -o pipefail
 
 function test() {
     local bin=$1


### PR DESCRIPTION
the check runs the snapshot tests against decoder v0.1.0
the tests must produce the same output even if they are decoder using the oldest v0.1.x decoder
closes #275 