### PR TITLE
Implement Format for char argument

### DIFF
--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -95,4 +95,5 @@
 0.000094 INFO [S { x: -1, y: 2 }, S { x: -1, y: 2 }]
 0.000095 INFO [Some(S { x: -1, y: 2 }), None]
 0.000096 INFO 127.0.0.1:8888
-0.000097 INFO QEMU test finished!
+0.000097 INFO Hello 💜
+0.000098 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -95,5 +95,5 @@
 0.000094 INFO [S { x: -1, y: 2 }, S { x: -1, y: 2 }]
 0.000095 INFO [Some(S { x: -1, y: 2 }), None]
 0.000096 INFO 127.0.0.1:8888
-0.000097 INFO Hello 💜
+0.000097 INFO Hello 💜 & 🍕
 0.000098 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -93,4 +93,5 @@
 0.000092 INFO [S { x: -1, y: 2 }, S { x: -1, y: 2 }]
 0.000093 INFO [Some(S { x: -1, y: 2 }), None]
 0.000094 INFO 127.0.0.1:8888
-0.000095 INFO QEMU test finished!
+0.000095 INFO Hello 💜
+0.000096 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -93,5 +93,5 @@
 0.000092 INFO [S { x: -1, y: 2 }, S { x: -1, y: 2 }]
 0.000093 INFO [Some(S { x: -1, y: 2 }), None]
 0.000094 INFO 127.0.0.1:8888
-0.000095 INFO Hello 💜
+0.000095 INFO Hello 💜 & 🍕
 0.000096 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -482,6 +482,8 @@ fn main() -> ! {
         defmt::info!("{:?}", Display2Format::<consts::U32>(&addr));
     }
 
+    defmt::info!("Hello {:char}", '💜');
+
     defmt::info!("QEMU test finished!");
 
     loop {

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -482,7 +482,7 @@ fn main() -> ! {
         defmt::info!("{:?}", Display2Format::<consts::U32>(&addr));
     }
 
-    defmt::info!("Hello {:char}", '💜');
+    defmt::info!("Hello {:char} & {:?}", '💜', '🍕');
 
     defmt::info!("QEMU test finished!");
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1163,6 +1163,9 @@ impl Codegen {
                 defmt_parser::Type::F32 => {
                     exprs.push(quote!(_fmt_.f32(#arg)));
                 }
+                defmt_parser::Type::Char => {
+                    exprs.push(quote!(_fmt_.u32(&(*#arg as u32))));
+                }
             }
             pats.push(arg);
         }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -69,6 +69,8 @@ pub enum Type {
     U8Slice,
     U8Array(usize), // FIXME: This `usize` is not the target's `usize`; use `u64` instead?
     F32,
+    /// A single Unicode character
+    Char,
 }
 
 fn is_digit(c: Option<char>) -> bool {
@@ -165,6 +167,7 @@ fn parse_param(mut s: &str) -> Result<Param, Cow<'static, str>> {
         "[u8]" => Type::U8Slice,
         "?" => Type::Format,
         "[?]" => Type::FormatSlice,
+        "char" => Type::Char,
         _ if s.starts_with(U8_ARRAY_START) => {
             s = &s[U8_ARRAY_START.len()..];
             let len = parse_array(s)?;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -138,6 +138,16 @@ impl Format for Str {
     }
 }
 
+impl Format for char {
+    fn format(&self, fmt: &mut Formatter) {
+        if fmt.needs_tag() {
+            let t = internp!("{:char}");
+            fmt.u8(&t);
+        }
+        fmt.u32(&(*self as u32));
+    }
+}
+
 impl<T> Format for [T]
 where
     T: Format,

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -684,6 +684,17 @@ fn format_primitives() {
             0xFF,
         ],
     );
+
+    check_format_implementation(
+        &'a',
+        &[
+            inc(index, 16), // "{:char}"
+            0x61,
+            0x00,
+            0x00,
+            0x00,
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support to format a single `char`.

It implements Format for the `char` argument.

```rust
defmt::info!("x = {:char}", 'y');
```

For now it is implemented by encoding / decoding the `char` as a `u32`, the first mentioned option in the related issue #186.