### PR TITLE
fix compilation to ARMv6-M with +alloc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       run: |
         for target in $NO_STD_CHECK_TARGETS; do
           cargo check --target $target
+          cargo check --target $target --features alloc
         done
     - name: Build panic-probe with different features
       working-directory: firmware/panic-probe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.3] - 2020-11-30
+
+### Fixed
+
+- fixed cross compilation to ARMv6-M when the "alloc" feature is enabled
+
 ## [v0.1.2] - 2020-11-26
 
 ### Added
@@ -57,6 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.1.2...main
-[v0.1.1]: https://github.com/knurling-rs/defmt/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.1.3...main
+[v0.1.3]: https://github.com/knurling-rs/defmt/compare/defmt-v0.1.2...defmt-v0.1.3
 [v0.1.2]: https://github.com/knurling-rs/defmt/compare/v0.1.1...defmt-v0.1.2
+[v0.1.1]: https://github.com/knurling-rs/defmt/compare/v0.1.0...v0.1.1

--- a/build.rs
+++ b/build.rs
@@ -37,5 +37,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     linker_script = linker_script.replace("$DEFMT_VERSION", version.trim());
     fs::write(out.join("defmt.x"), linker_script)?;
     println!("cargo:rustc-link-search={}", out.display());
+    let target = env::var("TARGET")?;
+    if target == "thumbv6m-none-eabi" {
+        println!("cargo:rustc-cfg=thumbv6m");
+    }
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -38,8 +38,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     fs::write(out.join("defmt.x"), linker_script)?;
     println!("cargo:rustc-link-search={}", out.display());
     let target = env::var("TARGET")?;
-    if target == "thumbv6m-none-eabi" {
-        println!("cargo:rustc-cfg=thumbv6m");
+
+    // `"atomic-cas": false` in `--print target-spec-json`
+    // last updated: rust 1.48.0
+    match &target[..] {
+        "avr-gnu-base"
+        | "msp430-none-elf"
+        | "riscv32i-unknown-none-elf"
+        | "riscv32imc-unknown-none-elf"
+        | "thumbv4t-none-eabi"
+        | "thumbv6m-none-eabi" => {
+            println!("cargo:rustc-cfg=no_cas");
+        }
+        _ => {}
     }
     Ok(())
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -375,7 +375,7 @@ mod if_alloc {
         }
     }
 
-    #[cfg(not(thumbv6m))]
+    #[cfg(not(no_cas))]
     impl<T> Format for alloc::sync::Arc<T>
     where
         T: ?Sized + Format,

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -375,6 +375,7 @@ mod if_alloc {
         }
     }
 
+    #[cfg(not(thumbv6m))]
     impl<T> Format for alloc::sync::Arc<T>
     where
         T: ?Sized + Format,


### PR DESCRIPTION
fixes #285 

explanation: there's no `Arc` type in the `alloc` crate (or the standard library) when you compile for ARMv6-M because the type uses CAS operations (compare_and_swap) in its implementation and that API is not available on ARMv6-M. this PR fixes the issue by omitting the `impl Format for Arc` when the target is ARMv6-M

actually there are more "no CAS" targets than ARMv6-M so this PR does the same for all those (that we know of as of rust 1.48)