### PR TITLE
make defmt attributes forward input attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ unstable-test = ["defmt-macros/unstable-test"]
 defmt-macros = { path = "macros", version = "0.1.1" }
 heapless = "0.5.6"
 
+[dev-dependencies]
+trybuild = "1.0.37"
+
 [workspace]
 members = [
   ".",

--- a/book/src/panic.md
+++ b/book/src/panic.md
@@ -38,3 +38,7 @@ fn defmt_panic() -> ! {
 If you are using the `panic-probe` crate then you should "abort" (call `cortex_m::asm::udf`) from `#[defmt::panic_handler]` to match its behavior.
 
 NOTE: even if you don't run into the "double panic message printed" issue you may still want to use `#[defmt::panic_handler]` because this way `defmt::panic` and `defmt::assert` will *not* go through the `core::panic` machinery and that *may* reduce code size (we recommend you measure the effect of the change).
+
+## Inter-operation with built-in attributes
+
+The `#[panic_handler]` attribute cannot be used together with the `export_name` or `no_mangle` attributes

--- a/book/src/timestamp.md
+++ b/book/src/timestamp.md
@@ -96,3 +96,7 @@ count: u64 <- (high1 << 32) | low
 ```
 
 The loop should be kept as tight as possible and the read operations must be single-instruction operations.
+
+## Inter-operation with built-in attributes
+
+The `#[timestamp]` attribute cannot be used together with the `export_name` or `no_mangle` attributes

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -18,19 +18,20 @@ use syn::{
 };
 
 fn reject_attributes(
-    which_attr: &str,
-    attrs: &[Attribute],
-    block_list: &[&str],
+    // appears in the error message
+    attr_name: &str,
+    attrs_to_check: &[Attribute],
+    reject_list: &[&str],
 ) -> parse::Result<()> {
-    for attr in attrs {
+    for attr in attrs_to_check {
         if let Some(ident) = attr.path.get_ident() {
             let ident = ident.to_string();
-            if block_list.contains(&&*ident) {
+            if reject_list.contains(&&*ident) {
                 return Err(parse::Error::new(
                     attr.span(),
                     format!(
                         "`#[{}]` attribute cannot be used together with `#[{}]`",
-                        which_attr, ident
+                        attr_name, ident
                     ),
                 ));
             }
@@ -121,7 +122,7 @@ pub fn panic_handler(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let attrs = &f.attrs;
-    if let Err(e) = reject_attributes("panic_handler", attrs, &["export_name"]) {
+    if let Err(e) = reject_attributes("panic_handler", attrs, &["export_name", "no_mangle"]) {
         return e.to_compile_error().into();
     }
     let block = &f.block;
@@ -172,7 +173,7 @@ pub fn timestamp(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let attrs = &f.attrs;
-    if let Err(e) = reject_attributes("timestamp", attrs, &["export_name"]) {
+    if let Err(e) = reject_attributes("timestamp", attrs, &["export_name", "no_mangle"]) {
         return e.to_compile_error().into();
     }
     let block = &f.block;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -17,8 +17,10 @@ use syn::{
     WhereClause, WherePredicate,
 };
 
-fn reject_attributes(
-    // appears in the error message
+/// Checks if any attribute in `attrs_to_check` is in `reject_list` and returns a compiler error if there's a match
+///
+/// The compiler error will indicate that the attribute conflicts with `attr_name`
+fn check_attribute_conflicts(
     attr_name: &str,
     attrs_to_check: &[Attribute],
     reject_list: &[&str],
@@ -122,7 +124,8 @@ pub fn panic_handler(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let attrs = &f.attrs;
-    if let Err(e) = reject_attributes("panic_handler", attrs, &["export_name", "no_mangle"]) {
+    if let Err(e) = check_attribute_conflicts("panic_handler", attrs, &["export_name", "no_mangle"])
+    {
         return e.to_compile_error().into();
     }
     let block = &f.block;
@@ -173,7 +176,7 @@ pub fn timestamp(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let attrs = &f.attrs;
-    if let Err(e) = reject_attributes("timestamp", attrs, &["export_name", "no_mangle"]) {
+    if let Err(e) = check_attribute_conflicts("timestamp", attrs, &["export_name", "no_mangle"]) {
         return e.to_compile_error().into();
     }
     let block = &f.block;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -42,8 +42,10 @@ pub fn global_logger(args: TokenStream, input: TokenStream) -> TokenStream {
         .into();
     }
 
+    let attrs = &s.attrs;
     let vis = &s.vis;
     quote!(
+        #(#attrs)*
         #vis struct #ident;
 
         #[no_mangle]
@@ -95,8 +97,10 @@ pub fn panic_handler(args: TokenStream, input: TokenStream) -> TokenStream {
             .into();
     }
 
+    let attrs = &f.attrs;
     let block = &f.block;
     quote!(
+        #(#attrs)*
         #[export_name = "_defmt_panic"]
         fn #ident() -> ! {
             #block
@@ -141,9 +145,11 @@ pub fn timestamp(args: TokenStream, input: TokenStream) -> TokenStream {
             .into();
     }
 
+    let attrs = &f.attrs;
     let block = &f.block;
     quote!(
         #[export_name = "_defmt_timestamp"]
+        #(#attrs)*
         fn #ident() -> u64 {
             #block
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,10 @@ pub use defmt_macros::unwrap;
 /// this macro. See [the manual] for details.
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/panic.html
+///
+/// # Inter-operation with built-in attributes
+///
+/// This attribute cannot be used together with the `export_name` or `no_mangle` attributes
 pub use defmt_macros::panic_handler;
 
 /// Creates an interned string ([`Str`]) from a string literal.
@@ -260,6 +264,10 @@ pub use defmt_macros::global_logger;
 ///     0
 /// }
 /// ```
+///
+/// # Inter-operation with built-in attributes
+///
+/// This attribute cannot be used together with the `export_name` or `no_mangle` attributes
 pub use defmt_macros::timestamp;
 
 #[doc(hidden)] // documented as the `Format` trait instead

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/tests/ui/panic-handler-export-name.rs
+++ b/tests/ui/panic-handler-export-name.rs
@@ -1,0 +1,8 @@
+#![no_main]
+#![no_std]
+
+#[defmt::panic_handler]
+#[export_name = "hello"]
+fn foo() -> ! {
+    loop {}
+}

--- a/tests/ui/panic-handler-export-name.stderr
+++ b/tests/ui/panic-handler-export-name.stderr
@@ -1,0 +1,5 @@
+error: `#[panic_handler]` attribute cannot be used together with `#[export_name]`
+ --> $DIR/panic-handler-export-name.rs:5:1
+  |
+5 | #[export_name = "hello"]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/panic-handler-no-mangle.rs
+++ b/tests/ui/panic-handler-no-mangle.rs
@@ -1,0 +1,8 @@
+#![no_main]
+#![no_std]
+
+#[defmt::panic_handler]
+#[no_mangle]
+fn panic() -> ! {
+    loop {}
+}

--- a/tests/ui/panic-handler-no-mangle.stderr
+++ b/tests/ui/panic-handler-no-mangle.stderr
@@ -1,0 +1,5 @@
+error: `#[panic_handler]` attribute cannot be used together with `#[no_mangle]`
+ --> $DIR/panic-handler-no-mangle.rs:5:1
+  |
+5 | #[no_mangle]
+  | ^^^^^^^^^^^^

--- a/tests/ui/timestamp-export-name.rs
+++ b/tests/ui/timestamp-export-name.rs
@@ -1,0 +1,8 @@
+#![no_main]
+#![no_std]
+
+#[defmt::timestamp]
+#[export_name = "hello"]
+fn foo() -> u64 {
+    0
+}

--- a/tests/ui/timestamp-export-name.stderr
+++ b/tests/ui/timestamp-export-name.stderr
@@ -1,0 +1,5 @@
+error: `#[timestamp]` attribute cannot be used together with `#[export_name]`
+ --> $DIR/timestamp-export-name.rs:5:1
+  |
+5 | #[export_name = "hello"]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/timestamp-no-mangle.rs
+++ b/tests/ui/timestamp-no-mangle.rs
@@ -1,0 +1,8 @@
+#![no_main]
+#![no_std]
+
+#[defmt::timestamp]
+#[no_mangle]
+fn foo() -> u64 {
+    0
+}

--- a/tests/ui/timestamp-no-mangle.stderr
+++ b/tests/ui/timestamp-no-mangle.stderr
@@ -1,0 +1,5 @@
+error: `#[timestamp]` attribute cannot be used together with `#[no_mangle]`
+ --> $DIR/timestamp-no-mangle.rs:5:1
+  |
+5 | #[no_mangle]
+  | ^^^^^^^^^^^^


### PR DESCRIPTION
work towards fixing #252 

- [x] reject {panic_handler,timestamp} + ( `#[export_name]` OR `#[no_mangle]`)

(I was expecting `#[timestamp] #[inline(always)] fn foo() -> u64 { 0 }` to fail at link time but it works ... perhaps export_name undoes inlining?)

