### PR TITLE
Allow use statements in defmt-test

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -280,7 +280,7 @@ pub fn parse<'f>(format_string: &'f str) -> Result<Vec<Fragment<'f>>, Cow<'stati
         }
 
         // Peek at the next char.
-        if chars.as_str().chars().next() == Some('{') {
+        if chars.as_str().starts_with('{') {
             // Escaped `{{`, also part of a literal fragment.
             chars.next(); // Move after both `{`s.
             continue;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -72,10 +72,7 @@ pub enum Type {
 }
 
 fn is_digit(c: Option<char>) -> bool {
-    match c.unwrap_or('\0') {
-        '0'..='9' => true,
-        _ => false,
-    }
+    matches!(c.unwrap_or('\0'), '0'..='9')
 }
 
 fn parse_range(mut s: &str) -> Option<(Range<u8>, usize /* consumed */)> {


### PR DESCRIPTION
Closes #289 

Thanks to @japaric's [detailed instructions](https://github.com/knurling-rs/defmt/issues/289#issuecomment-735751942) this was straight forward to implement. 

The only thing missing right now, is to update the error message, as "only function items are allowed" is no longer true. 