### PR TITLE
Use primitive formatting for primitive references

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -422,6 +422,7 @@ fn as_native_type(ty: &Type) -> Option<String> {
             }
             None => None,
         },
+        Type::Reference(tref) => as_native_type(&*tref.elem),
         _ => None,
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -447,11 +447,7 @@ fn log(level: Level, log: FormatArgs) -> TokenStream2 {
     let ls = log.litstr.value();
     let fragments = match defmt_parser::parse(&ls) {
         Ok(args) => args,
-        Err(e) => {
-            return parse::Error::new(log.litstr.span(), e)
-                .to_compile_error()
-                .into()
-        }
+        Err(e) => return parse::Error::new(log.litstr.span(), e).to_compile_error(),
     };
 
     let args = log
@@ -461,7 +457,7 @@ fn log(level: Level, log: FormatArgs) -> TokenStream2 {
 
     let (pats, exprs) = match Codegen::new(&fragments, args.len(), log.litstr.span()) {
         Ok(cg) => (cg.pats, cg.exprs),
-        Err(e) => return e.to_compile_error().into(),
+        Err(e) => return e.to_compile_error(),
     };
 
     let sym = mksym(&ls, level.as_str(), true);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -29,10 +29,7 @@ pub fn global_logger(args: TokenStream, input: TokenStream) -> TokenStream {
     }
     let s = parse_macro_input!(input as ItemStruct);
     let ident = &s.ident;
-    let is_unit = match s.fields {
-        Fields::Unit => true,
-        _ => false,
-    };
+    let is_unit = matches!(s.fields, Fields::Unit);
     if !s.generics.params.is_empty() || s.generics.where_clause.is_some() || !is_unit {
         return parse::Error::new(
             ident.span(),

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -457,7 +457,7 @@ fn log(level: Level, log: FormatArgs) -> TokenStream2 {
     let args = log
         .rest
         .map(|(_, exprs)| exprs.into_iter().collect())
-        .unwrap_or(vec![]);
+        .unwrap_or_else(Vec::new);
 
     let (pats, exprs) = match Codegen::new(&fragments, args.len(), log.litstr.span()) {
         Ok(cg) => (cg.pats, cg.exprs),

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -325,33 +325,30 @@ pub fn parse<'f>(format_string: &'f str) -> Result<Vec<Fragment<'f>>, Cow<'stati
     // Check for argument type conflicts.
     let mut args = Vec::new();
     for frag in &fragments {
-        match frag {
-            Fragment::Parameter(Parameter { index, ty }) => {
-                if args.len() <= *index {
-                    args.resize(*index + 1, None);
-                }
+        if let Fragment::Parameter(Parameter { index, ty }) = frag {
+            if args.len() <= *index {
+                args.resize(*index + 1, None);
+            }
 
-                match &mut args[*index] {
-                    none @ None => {
-                        *none = Some(ty.clone());
-                    }
-                    Some(other_ty) => {
-                        // FIXME: Bitfield range shouldn't be part of the type.
-                        match (&*other_ty, ty) {
-                            (Type::BitField(_), Type::BitField(_)) => {}
-                            (a, b) if a != b => {
-                                return Err(format!(
-                                    "conflicting types for argument {}: used as {:?} and {:?}",
-                                    index, other_ty, ty
-                                )
-                                .into());
-                            }
-                            _ => {}
+            match &mut args[*index] {
+                none @ None => {
+                    *none = Some(ty.clone());
+                }
+                Some(other_ty) => {
+                    // FIXME: Bitfield range shouldn't be part of the type.
+                    match (&*other_ty, ty) {
+                        (Type::BitField(_), Type::BitField(_)) => {}
+                        (a, b) if a != b => {
+                            return Err(format!(
+                                "conflicting types for argument {}: used as {:?} and {:?}",
+                                index, other_ty, ty
+                            )
+                            .into());
                         }
+                        _ => {}
                     }
                 }
             }
-            _ => {}
         }
     }
 

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -884,10 +884,8 @@ fn derive_with_bounds() {
     check_format_implementation(
         &S2 { a: &1, b: &2 },
         &[
-            index,         // "S2 { a: {:?}, b: {:?} }}"
-            inc(index, 1), // "{:u8}"
+            index,         // "S2 { a: {:u8}, b: {:u8} }}"
             1,
-            inc(index, 2), // "{:u8}"
             2,
         ],
     );


### PR DESCRIPTION
Closes #163

A single recursive call in `as_native_type` is sufficient
to unpack the type from the reference.
Formatting functions (`fmt.i32()` etc.) are already taking
a reference, so this does not need to be changed.

Tests are adjusted, so that they pass.
This introduced change is not explicitly tested though.

```rust
#[derive(Format)]
struct S2<'a> {
    x: &'a i32,
    y: &'a u8,
}
```

now expands into

```rust
fn format(&self, f: &mut defmt::Formatter) {
    if f.needs_tag() {
        f.istr (&defmt::export::istr({ 
            #[link_section = ".defmt.{\"package\":\"use-test\",\"tag\":\"defmt_fmt\",\"data\":\"S2 {{ x: {:i32}, y: {:u8} }}\",\"disambiguator\":\"10404396863279507298\"}"]
            #[export_name = "{\"package\":\"use-test\",\"tag\":\"defmt_fmt\",\"data\":\"S2 {{ x: {:i32}, y: {:u8} }}\",\"disambiguator\":\"10404396863279507298\"}"]
            static S: u8 = 0; 
            &S as * const u8 as usize 
        })) ;
    }
    match self {
        Self { x, y } => {
            f.i32(x);
            f.u8(y);
        }
    }
}
```