### PR TITLE
CI: fix nightly build

### DIFF
--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -14,6 +14,7 @@ cortex-m = "0.6.0"
 cortex-m-rt = "0.6.10"
 cortex-m-semihosting = "0.3.3"
 alloc-cortex-m = { version = "0.4.0", optional = true }
+linked_list_allocator = { version = "0.8.7", optional = true }
 
 [features]
 defmt-default = [] # log at INFO, or TRACE, level and up
@@ -23,7 +24,7 @@ defmt-info = []    # log at INFO level and up
 defmt-warn = []    # log at WARN level and up
 defmt-error = []   # log at ERROR level
 default = ["defmt-default"]
-alloc = ["defmt/alloc", "alloc-cortex-m"]
+alloc = ["defmt/alloc", "alloc-cortex-m", "linked_list_allocator/const_mut_refs"]
 
 [[bin]]
 name = "assert"


### PR DESCRIPTION
`linked_list_allocator` (LLA) added a default (opt-out) Cargo feature, "const_mut_refs", in 0.8.7. This feature controls whether `Heap::new` is a const function or not.
`alloc-cortex-m` uses `linked_list_allocator` with `default-features = no`
as a result `alloc-cortex-m` doesn't compile on nightly after 0.8.7 was released

to work around the issue we manually enable the LLA's "const_mut_refs"