### PR TITLE
compile-fail test new Formatter move semantics

### DIFF
--- a/tests/ui/fmt-for-loop.rs
+++ b/tests/ui/fmt-for-loop.rs
@@ -1,0 +1,11 @@
+struct S;
+
+impl defmt::Format for S {
+    fn format(&self, f: defmt::Formatter) {
+        for _ in 0..3 {
+            0u8.format(f);
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/fmt-for-loop.stderr
+++ b/tests/ui/fmt-for-loop.stderr
@@ -1,0 +1,8 @@
+error[E0382]: use of moved value: `f`
+ --> $DIR/fmt-for-loop.rs:6:24
+  |
+4 |     fn format(&self, f: defmt::Formatter) {
+  |                      - move occurs because `f` has type `defmt::Formatter<'_>`, which does not implement the `Copy` trait
+5 |         for _ in 0..3 {
+6 |             0u8.format(f);
+  |                        ^ value moved here, in previous iteration of loop

--- a/tests/ui/fmt-twice.rs
+++ b/tests/ui/fmt-twice.rs
@@ -1,0 +1,10 @@
+struct S;
+
+impl defmt::Format for S {
+    fn format(&self, f: defmt::Formatter) {
+        0u8.format(f);
+        0u16.format(f);
+    }
+}
+
+fn main() {}

--- a/tests/ui/fmt-twice.stderr
+++ b/tests/ui/fmt-twice.stderr
@@ -1,0 +1,9 @@
+error[E0382]: use of moved value: `f`
+ --> $DIR/fmt-twice.rs:6:21
+  |
+4 |     fn format(&self, f: defmt::Formatter) {
+  |                      - move occurs because `f` has type `defmt::Formatter<'_>`, which does not implement the `Copy` trait
+5 |         0u8.format(f);
+  |                    - value moved here
+6 |         0u16.format(f);
+  |                     ^ value used here after move

--- a/tests/ui/write-for-loop.rs
+++ b/tests/ui/write-for-loop.rs
@@ -1,0 +1,11 @@
+struct S;
+
+impl defmt::Format for S {
+    fn format(&self, f: defmt::Formatter) {
+        for _ in 0..3 {
+            defmt::write!(f, "hello");
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/write-for-loop.stderr
+++ b/tests/ui/write-for-loop.stderr
@@ -1,0 +1,12 @@
+error[E0382]: use of moved value: `f.inner`
+ --> $DIR/write-for-loop.rs:6:13
+  |
+6 |             defmt::write!(f, "hello");
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ value moved here, in previous iteration of loop
+  |
+  = note: move occurs because `f.inner` has type `&mut InternalFormatter`, which does not implement the `Copy` trait
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider creating a fresh reborrow of `f.inner` here
+  |
+6 |             &mut *defmt::write!(f, "hello");
+  |             ^^^^^^

--- a/tests/ui/write-twice.rs
+++ b/tests/ui/write-twice.rs
@@ -1,0 +1,10 @@
+struct S;
+
+impl defmt::Format for S {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "hello");
+        defmt::write!(f, "world");
+    }
+}
+
+fn main() {}

--- a/tests/ui/write-twice.stderr
+++ b/tests/ui/write-twice.stderr
@@ -1,0 +1,10 @@
+error[E0382]: use of moved value: `f.inner`
+ --> $DIR/write-twice.rs:6:9
+  |
+5 |         defmt::write!(f, "hello");
+  |         -------------------------- value moved here
+6 |         defmt::write!(f, "world");
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ value used here after move
+  |
+  = note: move occurs because `f.inner` has type `&mut InternalFormatter`, which does not implement the `Copy` trait
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
now that the signature of `Format::format` has changed we expect that these uses of the `write!`
macro and `format` method fail so let's test that

the `fmt-*` examples were corrupting the defmt data stream before but now are rejected at compile
time

the error message for the `write!` examples could be better: it should not mention the
`InternalFormatter` type, which is an implementation detail. I'll open an issue about improving the
diagnostics of that macro