### PR TITLE
write! macro: remove runtime check

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1000,7 +1000,6 @@ pub fn write(ts: TokenStream) -> TokenStream {
     let sym = mksym(&ls, "fmt", false);
     quote!(match (#fmt.inner, #(&(#args)),*) {
         (_fmt_, #(#pats),*) => {
-            _fmt_.write_macro_start();
             // HACK conditional should not be here; see FIXME in `format`
             if _fmt_.needs_tag() {
                 _fmt_.istr(&defmt::export::istr(#sym));


### PR DESCRIPTION
when this feature was added, it was possible to call `write!` more than once from a `Format::format`
implementation. that operation corrupted the data stream so a runtime check was added to `write!` to
prevent the data corruption by panicking on a double use of `write!`

PR #305 makes `write!` consume the `Formatter` value so the above issue is now prevented at compile
time. The runtime check is no longer necessary (failure case is unreachable) so we remove it