### PR TITLE
Always respect DisplayHint::Ascii for byte slices

### DIFF
--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -105,4 +105,9 @@
 0.000104 INFO EnumLarge::A269
 0.000105 INFO S { x: "hi" }
 0.000106 INFO bitfields 0x97 0b10000100 12 b"42" b"hello"
-0.000107 INFO QEMU test finished!
+0.000107 INFO b"Hi"
+0.000108 INFO b"Hi"
+0.000109 INFO b"Hi"
+0.000110 INFO [45054, 49406]
+0.000111 INFO [Data { name: b"Hi", value: true }]
+0.000112 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -103,4 +103,9 @@
 0.000102 INFO EnumLarge::A269
 0.000103 INFO S { x: "hi" }
 0.000104 INFO bitfields 0x97 0b10000100 12 b"42" b"hello"
-0.000105 INFO QEMU test finished!
+0.000105 INFO b"Hi"
+0.000106 INFO b"Hi"
+0.000107 INFO b"Hi"
+0.000108 INFO [45054, 49406]
+0.000109 INFO [Data { name: b"Hi", value: true }]
+0.000110 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -548,6 +548,25 @@ fn main() -> ! {
         0x9784_89AE_FF0C_5900_3432_6865_6C6C_6F00u128
     );
 
+    let bytes: &[u8; 2] = b"Hi";
+    let array_u16: &[u16; 2] = &[0xAF_FE, 0xC0_FE];
+
+    defmt::info!("{=[u8]:a}", *bytes);
+    defmt::info!("{=[?]:a}", *bytes);
+    defmt::info!("{:a}", *bytes);
+    defmt::info!("{=[?]:a}", *array_u16);
+
+    {
+        #[derive(Format)]
+        struct Data<'a> {
+            name: &'a [u8],
+            value: bool,
+        }
+
+        let data = &[Data { name: b"Hi", value: true }];
+        defmt::info!("{=[?]:a}", *data);
+    }
+
     defmt::info!("QEMU test finished!");
 
     loop {


### PR DESCRIPTION
This is a naive implementation, which assumes, that the `Uxx` value
is always in `u8` range. It does not consider the given format type `{=$type}`

Also, it assumes that the element args array only contains one element

Fixes #318