### PR TITLE
GHA: remove ci-failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,16 +141,3 @@ jobs:
     steps:
       - name: CI succeeded
         run: exit 0
-
-  ci-failure:
-    name: ci
-    if: ${{ !success() }}
-    needs:
-      - test
-      - no-std
-      - mdbook
-      - qemu
-    runs-on: ubuntu-20.04
-    steps:
-      - name: CI failed
-        run: exit 1


### PR DESCRIPTION
bors' semantics have changed: skipped checks are now considered failures
the result is that when all build jobs pass the ci-failure reports a "ci" check as skipped
(expected behavior) but that is now considered a failure by bors

removing the ci-failure conditional should fix the issue
if any build job fails then ci-success will report "ci" as skipped, which bors will consider as a
failure