### PR TITLE
impl<T> Format for PhantomData<T>

### DIFF
--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -1041,7 +1041,9 @@ fn format_args_real(
                                 let vals = elements
                                     .iter()
                                     .map(|e| match e.args.as_slice() {
-                                        [Arg::Uxx(v)] => u8::try_from(*v).expect("the value must be in u8 range"),
+                                        [Arg::Uxx(v)] => {
+                                            u8::try_from(*v).expect("the value must be in u8 range")
+                                        }
                                         _ => panic!("FormatSlice should only contain one argument"),
                                     })
                                     .collect::<Vec<u8>>();

--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -104,10 +104,11 @@
 0.000103 INFO EnumLarge::A051
 0.000104 INFO EnumLarge::A269
 0.000105 INFO S { x: "hi" }
-0.000106 INFO bitfields 0x97 0b10000100 12 b"42" b"hello"
-0.000107 INFO b"Hi"
+0.000106 INFO S { x: PhantomData, y: 42 }
+0.000107 INFO bitfields 0x97 0b10000100 12 b"42" b"hello"
 0.000108 INFO b"Hi"
 0.000109 INFO b"Hi"
-0.000110 INFO [45054, 49406]
-0.000111 INFO [Data { name: b"Hi", value: true }]
-0.000112 INFO QEMU test finished!
+0.000110 INFO b"Hi"
+0.000111 INFO [45054, 49406]
+0.000112 INFO [Data { name: b"Hi", value: true }]
+0.000113 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -102,10 +102,11 @@
 0.000101 INFO EnumLarge::A051
 0.000102 INFO EnumLarge::A269
 0.000103 INFO S { x: "hi" }
-0.000104 INFO bitfields 0x97 0b10000100 12 b"42" b"hello"
-0.000105 INFO b"Hi"
+0.000104 INFO S { x: PhantomData, y: 42 }
+0.000105 INFO bitfields 0x97 0b10000100 12 b"42" b"hello"
 0.000106 INFO b"Hi"
 0.000107 INFO b"Hi"
-0.000108 INFO [45054, 49406]
-0.000109 INFO [Data { name: b"Hi", value: true }]
-0.000110 INFO QEMU test finished!
+0.000108 INFO b"Hi"
+0.000109 INFO [45054, 49406]
+0.000110 INFO [Data { name: b"Hi", value: true }]
+0.000111 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::{marker::PhantomData, sync::atomic::{AtomicU32, Ordering}};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
 use defmt::{consts, Debug2Format, Display2Format, Format, Formatter};
@@ -536,6 +536,16 @@ fn main() -> ! {
         }
 
         defmt::info!("{:?}", S { x: "hi" });
+    }
+
+    {
+        #[derive(Format)]
+        struct S {
+            x: PhantomData<u8>,
+            y: u8
+        }
+
+        defmt::info!("{:?}", S { x: PhantomData, y: 42 });
     }
 
     defmt::info!(

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -1,7 +1,10 @@
 #![no_std]
 #![no_main]
 
-use core::{marker::PhantomData, sync::atomic::{AtomicU32, Ordering}};
+use core::{
+    marker::PhantomData,
+    sync::atomic::{AtomicU32, Ordering},
+};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
 use defmt::{consts, Debug2Format, Display2Format, Format, Formatter};
@@ -542,10 +545,16 @@ fn main() -> ! {
         #[derive(Format)]
         struct S {
             x: PhantomData<u8>,
-            y: u8
+            y: u8,
         }
 
-        defmt::info!("{:?}", S { x: PhantomData, y: 42 });
+        defmt::info!(
+            "{:?}",
+            S {
+                x: PhantomData,
+                y: 42
+            }
+        );
     }
 
     defmt::info!(
@@ -573,7 +582,10 @@ fn main() -> ! {
             value: bool,
         }
 
-        let data = &[Data { name: b"Hi", value: true }];
+        let data = &[Data {
+            name: b"Hi",
+            value: true,
+        }];
         defmt::info!("{=[?]:a}", *data);
     }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -346,6 +346,15 @@ impl Format for () {
     }
 }
 
+impl<T> Format for core::marker::PhantomData<T> {
+    fn format(&self, f: Formatter) {
+        if f.inner.needs_tag() {
+            let t = internp!("PhantomData");
+            f.inner.u8(&t);
+        }
+    }
+}
+
 macro_rules! tuple {
     ( $format:expr, ($($name:ident),+) ) => (
         impl<$($name:Format),+> Format for ($($name,)+) where last_type!($($name,)+): ?Sized {


### PR DESCRIPTION
 I needed this to be able to `#[derive(Format)]` on a few structs.