### PR TITLE
Fix dead intra-doc-link in parser

### DIFF
--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,7 +1,9 @@
-//! Parsing library for [`defmt`](https://github.com/knurling-rs/defmt) format strings.
+//! Parsing library for [`defmt`] format strings.
 //!
 //! This is an implementation detail of [`defmt`] and not meant to be consumed by other tools at the
 //! moment so all the API is unstable.
+//!
+//! [`defmt`]: https://github.com/knurling-rs/defmt
 
 #![cfg(feature = "unstable")]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
This was giving a rustdoc warning