### PR TITLE
add defmt-logger and defmt-print

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       # (see https://github.com/rust-embedded/cortex-m-rt/issues/74), so we cannot use
       # `cargo test --workspace` and have to build the test suites individually instead
       if: matrix.os == 'macOS-latest'
-      run: cargo test -p defmt -p defmt-decoder -p defmt-parser -p defmt-macros --all-features
+      run: cargo test -p defmt -p defmt-decoder -p defmt-parser -p defmt-macros -p defmt-logger -p defmt-print --all-features
 
   no-std:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,10 @@ members = [
   ".",
   "decoder",
   "elf2table",
+  "logger",
   "macros",
   "parser",
+  "print",
   "qemu-run",
   "firmware/*",
 ]

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [dependencies]
 ansi_term = "0.12.1"
 colored = "2.0.0"
-defmt-decoder = { path = "../decoder", features = ["unstable"] }
+defmt-decoder = { version = "0.1.4", path = "../decoder", features = ["unstable"] }
 difference = "2.0.0"
 log = { version = "0.4.13", features = ["std"] }
 

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors = ["The Knurling-rs developers"]
+categories = ["embedded"]
+description = "A `log` logger that can format defmt log frames"
+edition = "2018"
+keywords = ["knurling", "logging", "formatting"]
+license = "MIT OR Apache-2.0"
+name = "defmt-logger"
+readme = "README.md"
+repository = "https://github.com/knurling-rs/defmt"
+version = "0.1.0"
+
+[dependencies]
+ansi_term = "0.12.1"
+colored = "2.0.0"
+defmt-decoder = { path = "../decoder", features = ["unstable"] }
+difference = "2.0.0"
+log = { version = "0.4.13", features = ["std"] }
+
+[features]
+unstable = []

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,0 +1,226 @@
+//! A [`log`] logger that supports formatting [`defmt`] frames
+//!
+//! [`log`]: https://crates.io/crates/log
+//! [`defmt`]: https://crates.io/crates/defmt
+
+#![cfg(feature = "unstable")]
+
+use ansi_term::Colour;
+use colored::{Color, Colorize};
+use defmt_decoder::Frame;
+use difference::{Changeset, Difference};
+use log::{Level, Log, Metadata, Record};
+
+use std::{
+    fmt::Write as _,
+    io,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+const DEFMT_TARGET_MARKER: &str = "defmt@";
+
+/// Initializes the `defmt-logger` logger.
+pub fn init(verbose: bool) {
+    log::set_boxed_logger(Box::new(Logger {
+        verbose,
+        timing_align: AtomicUsize::new(8),
+    }))
+    .unwrap();
+    log::set_max_level(log::LevelFilter::Trace);
+}
+
+/// Logs a defmt frame using the `log` facade.
+pub fn log_defmt(
+    frame: &Frame<'_>,
+    file: Option<&str>,
+    line: Option<u32>,
+    module_path: Option<&str>,
+) {
+    let level = match frame.level() {
+        defmt_decoder::Level::Trace => Level::Trace,
+        defmt_decoder::Level::Debug => Level::Debug,
+        defmt_decoder::Level::Info => Level::Info,
+        defmt_decoder::Level::Warn => Level::Warn,
+        defmt_decoder::Level::Error => Level::Error,
+    };
+
+    let target = format!("{}{}", DEFMT_TARGET_MARKER, frame.timestamp());
+    let display = frame.display_message();
+
+    log::logger().log(
+        &Record::builder()
+            .args(format_args!("{}", display))
+            .level(level)
+            .target(&target)
+            .module_path(module_path)
+            .file(file)
+            .line(line)
+            .build(),
+    );
+}
+
+struct Logger {
+    /// Whether to log `debug!` and `trace!`-level host messages.
+    verbose: bool,
+
+    /// Number of characters used by the timestamp. This may increase over time and is used to align
+    /// messages.
+    timing_align: AtomicUsize,
+}
+
+impl Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        if metadata.target().starts_with(DEFMT_TARGET_MARKER) {
+            // defmt is configured at firmware-level, we will print all of it.
+            true
+        } else {
+            // Host logs use `info!` as the default level, but with the `verbose` flag set we log at
+            // `trace!` level instead.
+            if self.verbose {
+                metadata.target().starts_with("probe_run")
+            } else {
+                metadata.target().starts_with("probe_run") && metadata.level() <= Level::Info
+            }
+        }
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let level_color = match record.level() {
+            Level::Error => Color::Red,
+            Level::Warn => Color::Yellow,
+            Level::Info => Color::Green,
+            Level::Debug => Color::BrightWhite,
+            Level::Trace => Color::BrightBlack,
+        };
+
+        let target = record.metadata().target();
+        let is_defmt = target.starts_with(DEFMT_TARGET_MARKER);
+
+        let timestamp = if is_defmt {
+            let timestamp = target[DEFMT_TARGET_MARKER.len()..].parse::<u64>().unwrap();
+            let seconds = timestamp / 1000000;
+            let micros = timestamp % 1000000;
+            format!("{}.{:06}", seconds, micros)
+        } else {
+            // Mark host logs.
+            format!("(HOST)")
+        };
+
+        self.timing_align
+            .fetch_max(timestamp.len(), Ordering::Relaxed);
+
+        let (stdout, stderr, mut stdout_lock, mut stderr_lock);
+        let sink: &mut dyn io::Write = if is_defmt {
+            // defmt goes to stdout, since it's the primary output produced by this tool.
+            stdout = io::stdout();
+            stdout_lock = stdout.lock();
+            &mut stdout_lock
+        } else {
+            // Everything else goes to stderr.
+            stderr = io::stderr();
+            stderr_lock = stderr.lock();
+            &mut stderr_lock
+        };
+
+        writeln!(
+            sink,
+            "{timestamp:>0$} {level:5} {args}",
+            self.timing_align.load(Ordering::Relaxed),
+            timestamp = timestamp,
+            level = record.level().to_string().color(level_color),
+            args = color_diff(record.args().to_string()),
+        )
+        .ok();
+
+        if let Some(file) = record.file() {
+            // NOTE will be `Some` if `file` is `Some`
+            let mod_path = record.module_path().unwrap();
+            // Always include location info for defmt output.
+            if is_defmt || self.verbose {
+                let mut loc = file.to_string();
+                if let Some(line) = record.line() {
+                    loc.push_str(&format!(":{}", line));
+                }
+                writeln!(sink, "{}", format!("└─ {} @ {}", mod_path, loc).dimmed()).ok();
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+// color the output of `defmt::assert_eq`
+// HACK we should not re-parse formatted output but instead directly format into a color diff
+// template; that may require specially tagging log messages that come from `defmt::assert_eq`
+fn color_diff(text: String) -> String {
+    let lines = text.lines().collect::<Vec<_>>();
+    let nlines = lines.len();
+    if nlines > 2 {
+        let left = lines[nlines - 2];
+        let right = lines[nlines - 1];
+
+        const LEFT_START: &str = " left: `";
+        const RIGHT_START: &str = "right: `";
+        const END: &str = "`";
+        if left.starts_with(LEFT_START)
+            && left.ends_with(END)
+            && right.starts_with(RIGHT_START)
+            && right.ends_with(END)
+        {
+            const DARK_RED: Colour = Colour::Fixed(52);
+            const DARK_GREEN: Colour = Colour::Fixed(22);
+
+            // `defmt::assert_eq!` output
+            let left = &left[LEFT_START.len()..left.len() - END.len()];
+            let right = &right[RIGHT_START.len()..right.len() - END.len()];
+
+            let mut buf = lines[..nlines - 2].join("\n").bold().to_string();
+            buf.push('\n');
+
+            let changeset = Changeset::new(left, right, "");
+
+            writeln!(
+                buf,
+                "{} {} / {}",
+                "diff".bold(),
+                "< left".red(),
+                "right >".green()
+            )
+            .ok();
+            write!(buf, "{}", "<".red()).ok();
+            for diff in &changeset.diffs {
+                match diff {
+                    Difference::Same(s) => {
+                        write!(buf, "{}", s.red()).ok();
+                    }
+                    Difference::Add(_) => continue,
+                    Difference::Rem(s) => {
+                        write!(buf, "{}", Colour::Red.on(DARK_RED).bold().paint(s)).ok();
+                    }
+                }
+            }
+            buf.push('\n');
+
+            write!(buf, "{}", ">".green()).ok();
+            for diff in &changeset.diffs {
+                match diff {
+                    Difference::Same(s) => {
+                        write!(buf, "{}", s.green()).ok();
+                    }
+                    Difference::Rem(_) => continue,
+                    Difference::Add(s) => {
+                        write!(buf, "{}", Colour::Green.on(DARK_GREEN).bold().paint(s)).ok();
+                    }
+                }
+            }
+            return buf;
+        }
+    }
+
+    // keep output as it is
+    text.bold().to_string()
+}

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors = ["The Knurling-rs developers"]
+categories = ["embedded"]
+description = "A tool that decodes defmt logs and prints them to the console"
+edition = "2018"
+keywords = ["knurling", "logging", "formatting"]
+license = "MIT OR Apache-2.0"
+name = "defmt-print"
+readme = "README.md"
+repository = "https://github.com/knurling-rs/defmt"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.38"
+defmt-decoder = { path = "../decoder", features = ["unstable"] }
+defmt-elf2table = { path = "../elf2table", features = ["unstable"] }
+defmt-logger = { path = "../logger", features = ["unstable"] }
+log = "0.4.13"
+structopt = "0.3.21"

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -14,8 +14,8 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.38"
-defmt-decoder = { path = "../decoder", features = ["unstable"] }
-defmt-elf2table = { path = "../elf2table", features = ["unstable"] }
-defmt-logger = { path = "../logger", features = ["unstable"] }
+defmt-decoder = { version = "0.1.4", path = "../decoder", features = ["unstable"] }
+defmt-elf2table = { version = "0.1.0", path = "../elf2table", features = ["unstable"] }
+defmt-logger = { version = "0.1.0", path = "../logger", features = ["unstable"] }
 log = "0.4.13"
 structopt = "0.3.21"

--- a/print/README.md
+++ b/print/README.md
@@ -1,0 +1,37 @@
+# `defmt-print`
+
+> A tool to decode and print [`defmt`] data
+
+[`defmt`]: https://crates.io/crates/defmt
+
+There's no stable library API to decode `defmt` log frames but this tool can be used to decode defmt
+data and print it to the console.
+
+## Support
+
+`defmt-print` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com/
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -9,6 +9,7 @@ use structopt::StructOpt;
 
 /// Prints defmt-encoded logs to stdout
 #[derive(StructOpt)]
+#[structopt(name = "defmt-print", version = version())]
 struct Opts {
     #[structopt(short, parse(from_os_str))]
     elf: PathBuf,
@@ -88,4 +89,18 @@ fn main() -> anyhow::Result<()> {
             }
         }
     }
+}
+
+// the string reported by the `--version` flag
+fn version() -> &'static str {
+    // version from Cargo.toml e.g. "0.1.4"
+    let mut output = env!("CARGO_PKG_VERSION").to_string();
+
+    output.push_str("\nsupported defmt version: ");
+    output.push_str(defmt_decoder::DEFMT_VERSION);
+
+    // leak (!) heap memory to create a `&'static str` value. `String` won't work due to how
+    // structopt uses the clap API
+    // (this is only called once so it's not that bad)
+    Box::leak(Box::<str>::from(output))
 }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -1,0 +1,91 @@
+use std::{
+    env, fs,
+    io::{self, Read},
+    path::PathBuf,
+};
+
+use anyhow::anyhow;
+use structopt::StructOpt;
+
+/// Prints defmt-encoded logs to stdout
+#[derive(StructOpt)]
+struct Opts {
+    #[structopt(short, parse(from_os_str))]
+    elf: PathBuf,
+    // may want to add this later
+    // #[structopt(short, long)]
+    // verbose: bool,
+    // TODO add file path argument; always use stdin for now
+}
+
+const READ_BUFFER_SIZE: usize = 1024;
+
+fn main() -> anyhow::Result<()> {
+    let opts: Opts = Opts::from_args();
+    let verbose = false;
+    defmt_logger::init(verbose);
+
+    let bytes = fs::read(&opts.elf)?;
+
+    let table = defmt_elf2table::parse(&bytes)?.ok_or_else(|| anyhow!(".defmt data not found"))?;
+    let locs = defmt_elf2table::get_locations(&bytes, &table)?;
+
+    let locs = if table.indices().all(|idx| locs.contains_key(&(idx as u64))) {
+        Some(locs)
+    } else {
+        log::warn!("(BUG) location info is incomplete; it will be omitted from the output");
+        None
+    };
+
+    let mut buf = [0; READ_BUFFER_SIZE];
+    let mut frames = vec![];
+
+    let current_dir = env::current_dir()?;
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    loop {
+        let n = stdin.read(&mut buf)?;
+
+        frames.extend_from_slice(&buf[..n]);
+
+        loop {
+            match defmt_decoder::decode(&frames, &table) {
+                Ok((frame, consumed)) => {
+                    // NOTE(`[]` indexing) all indices in `table` have already been
+                    // verified to exist in the `locs` map
+                    let loc = locs.as_ref().map(|locs| &locs[&frame.index()]);
+
+                    let (mut file, mut line, mut mod_path) = (None, None, None);
+                    if let Some(loc) = loc {
+                        let relpath = if let Ok(relpath) = loc.file.strip_prefix(&current_dir) {
+                            relpath
+                        } else {
+                            // not relative; use full path
+                            &loc.file
+                        };
+                        file = Some(relpath.display().to_string());
+                        line = Some(loc.line as u32);
+                        mod_path = Some(loc.module.clone());
+                    }
+
+                    // Forward the defmt frame to our logger.
+                    defmt_logger::log_defmt(
+                        &frame,
+                        file.as_deref(),
+                        line,
+                        mod_path.as_ref().map(|s| &**s),
+                    );
+
+                    let num_frames = frames.len();
+                    frames.rotate_left(consumed);
+                    frames.truncate(num_frames - consumed);
+                }
+                Err(defmt_decoder::DecodeError::UnexpectedEof) => break,
+                Err(defmt_decoder::DecodeError::Malformed) => {
+                    log::error!("failed to decode defmt data: {:x?}", frames);
+                    Err(defmt_decoder::DecodeError::Malformed)?
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
defmt-logger is probe-run's code that formats defmt frames into a log::Log-ger sink
defmt-print is a command-line tool that decodes defmt and prints it to the console

TODO
- [ ]  `defmt-print --version` should print supported defmt version

other thoughts: qemu-run should maybe use defmt-logger instead of its own thing?