### PR TITLE
Streaming core::fmt adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ unstable-test = ["defmt-macros/unstable-test"]
 
 [dependencies]
 defmt-macros = { path = "macros", version = "0.1.1" }
-heapless = "0.5.6"
 
 [dev-dependencies]
 rustc_version = "0.3.0"

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -7,7 +7,7 @@ use core::{
 };
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
-use defmt::{consts, Debug2Format, Display2Format, Format, Formatter};
+use defmt::{Debug2Format, Display2Format, Format, Formatter};
 
 use defmt_semihosting as _; // global logger
 
@@ -454,10 +454,10 @@ fn main() -> ! {
         }
 
         let s = S { x: -1, y: 2 };
-        defmt::info!("{=?}", Debug2Format::<consts::U128>(&s));
-        defmt::info!("{=?}", Debug2Format::<consts::U128>(&Some(s)));
-        defmt::info!("{=?}", Debug2Format::<consts::U128>(&[s, s]));
-        defmt::info!("{=?}", Debug2Format::<consts::U128>(&[Some(s), None]));
+        defmt::info!("{}", Debug2Format(&s));
+        defmt::info!("{}", Debug2Format(&Some(s)));
+        defmt::info!("{}", Debug2Format(&[s, s]));
+        defmt::info!("{}", Debug2Format(&[Some(s), None]));
     }
 
     {
@@ -481,7 +481,7 @@ fn main() -> ! {
             port: 8888,
         };
 
-        defmt::info!("{=?}", Display2Format::<consts::U32>(&addr));
+        defmt::info!("{=?}", Display2Format(&addr));
     }
 
     defmt::info!(

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1150,6 +1150,12 @@ impl Codegen {
                 defmt_parser::Type::Usize => {
                     exprs.push(quote!(_fmt_.usize(#arg)));
                 }
+                defmt_parser::Type::Debug => {
+                    exprs.push(quote!(_fmt_.debug(#arg)));
+                }
+                defmt_parser::Type::Display => {
+                    exprs.push(quote!(_fmt_.display(#arg)));
+                }
                 defmt_parser::Type::BitField(_) => {
                     let all_bitfields = parsed_params.iter().filter(|param| param.index == i);
                     let (smallest_bit_index, largest_bit_index) =

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -71,6 +71,8 @@ pub enum Type {
     Format,             // "{=?}" OR "{}"
     FormatSlice,        // "{=[?]}"
     FormatArray(usize), // FIXME: This `usize` is not the target's `usize`; use `u64` instead?
+    Debug,
+    Display,
     I8,
     I16,
     I32,
@@ -217,6 +219,8 @@ fn parse_param(mut input: &str, mode: ParserMode) -> Result<Param, Cow<'static, 
             "bool" => Type::Bool,
             "str" => Type::Str,
             "istr" => Type::IStr,
+            "__internal_Debug" => Type::Debug,
+            "__internal_Display" => Type::Display,
             "[u8]" => Type::U8Slice,
             "?" => Type::Format,
             "[?]" => Type::FormatSlice,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,9 +706,9 @@ fn default_panic() -> ! {
 ///
 /// Note that this always uses `{:?}` to format the contained value, meaning that any provided defmt
 /// display hints will be ignored.
-pub struct Debug2Format<T: fmt::Debug>(pub T);
+pub struct Debug2Format<'a, T: fmt::Debug + ?Sized>(pub &'a T);
 
-impl<T: fmt::Debug> Format for Debug2Format<T> {
+impl<T: fmt::Debug + ?Sized> Format for Debug2Format<'_, T> {
     fn format(&self, fmt: Formatter) {
         if fmt.inner.needs_tag() {
             let t = defmt_macros::internp!("{=__internal_Debug}");
@@ -725,9 +725,9 @@ impl<T: fmt::Debug> Format for Debug2Format<T> {
 ///
 /// Note that this always uses `{}` to format the contained value, meaning that any provided defmt
 /// display hints will be ignored.
-pub struct Display2Format<T: fmt::Display>(pub T);
+pub struct Display2Format<'a, T: fmt::Display + ?Sized>(pub &'a T);
 
-impl<T: fmt::Display> Format for Display2Format<T> {
+impl<T: fmt::Display + ?Sized> Format for Display2Format<'_, T> {
     fn format(&self, fmt: Formatter) {
         if fmt.inner.needs_tag() {
             let t = defmt_macros::internp!("{=__internal_Display}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -703,6 +703,9 @@ fn default_panic() -> ! {
 ///
 /// This adapter disables compression and uses the `core::fmt` code on-device! You should prefer
 /// `defmt::Format` over `Debug` whenever possible.
+///
+/// Note that this always uses `{:?}` to format the contained value, meaning that any provided defmt
+/// display hints will be ignored.
 pub struct Debug2Format<T: fmt::Debug>(pub T);
 
 impl<T: fmt::Debug> Format for Debug2Format<T> {
@@ -719,6 +722,9 @@ impl<T: fmt::Debug> Format for Debug2Format<T> {
 ///
 /// This adapter disables compression and uses the `core::fmt` code on-device! You should prefer
 /// `defmt::Format` over `Display` whenever possible.
+///
+/// Note that this always uses `{}` to format the contained value, meaning that any provided defmt
+/// display hints will be ignored.
 pub struct Display2Format<T: fmt::Display>(pub T);
 
 impl<T: fmt::Display> Format for Display2Format<T> {

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -36,7 +36,10 @@
 //
 // - the mocked index is 7 bits so its LEB128 encoding is the input byte
 
-use defmt::{export::fetch_string_index, write, Format, Formatter, InternalFormatter};
+use defmt::{
+    export::fetch_string_index, write, Debug2Format, Display2Format, Format, Formatter,
+    InternalFormatter,
+};
 
 // Increase the 7-bit mocked interned index
 fn inc(index: u8, n: u8) -> u8 {
@@ -1023,4 +1026,12 @@ fn derive_str() {
             105, // b'i'
         ],
     );
+}
+
+#[test]
+fn core_fmt_adapters() {
+    let index = fetch_string_index();
+    check_format_implementation(&Debug2Format(123u8), &[index, b'1', b'2', b'3', 0xff]);
+    let index = fetch_string_index();
+    check_format_implementation(&Display2Format(123u8), &[index, b'1', b'2', b'3', 0xff]);
 }

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1031,7 +1031,7 @@ fn derive_str() {
 #[test]
 fn core_fmt_adapters() {
     let index = fetch_string_index();
-    check_format_implementation(&Debug2Format(123u8), &[index, b'1', b'2', b'3', 0xff]);
+    check_format_implementation(&Debug2Format(&123u8), &[index, b'1', b'2', b'3', 0xff]);
     let index = fetch_string_index();
-    check_format_implementation(&Display2Format(123u8), &[index, b'1', b'2', b'3', 0xff]);
+    check_format_implementation(&Display2Format(&123u8), &[index, b'1', b'2', b'3', 0xff]);
 }


### PR DESCRIPTION
This removes heapless, the `consts` reexport, and the need to manually specify buffer sizes for the `X2Format` adapters. Instead of formatting to an on-stack buffer, these adapters now stream the formatted data over the defmt sink and terminate it with a `0xff` byte.

Display hints are, perhaps confusingly, ignored. We could pass them to `core::fmt` if we like, but that's a non-breaking change and can be done later.

No user-facing format type (`{=Debug}`) is provided, since I felt that that may cause confusion between `{}`, `{:?}`, `{=Debug}` and `{=Display}`, which would all mean different things.

Closes https://github.com/knurling-rs/defmt/issues/292