### PR TITLE
Don't call `finalize` in `write!`

### DIFF
--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -111,4 +111,5 @@
 0.000110 INFO b"Hi"
 0.000111 INFO [45054, 49406]
 0.000112 INFO [Data { name: b"Hi", value: true }]
-0.000113 INFO QEMU test finished!
+0.000113 INFO true true
+0.000114 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -109,4 +109,5 @@
 0.000108 INFO b"Hi"
 0.000109 INFO [45054, 49406]
 0.000110 INFO [Data { name: b"Hi", value: true }]
-0.000111 INFO QEMU test finished!
+0.000111 INFO true true
+0.000112 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -589,6 +589,9 @@ fn main() -> ! {
         defmt::info!("{=[?]:a}", *data);
     }
 
+    // #341 - should output `true true`
+    defmt::info!("{} {=bool}", True, true);
+
     defmt::info!("QEMU test finished!");
 
     loop {
@@ -607,6 +610,14 @@ fn nested() -> NestedStruct {
     NestedStruct {
         a: 0xAA,
         b: 0x12345678,
+    }
+}
+
+struct True;
+
+impl Format for True {
+    fn format(&self, fmt: Formatter<'_>) {
+        defmt::write!(fmt, "{=bool}", true);
     }
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1017,7 +1017,6 @@ pub fn write(ts: TokenStream) -> TokenStream {
                     _fmt_.istr(&defmt::export::istr(#sym));
                 }
                 #(#exprs;)*
-                _fmt_.finalize();
             }
         }
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,8 @@ impl InternalFormatter {
 
     /// Only for testing
     #[cfg(feature = "unstable-test")]
-    pub fn bytes(&self) -> &[u8] {
+    pub fn bytes(&mut self) -> &[u8] {
+        self.finalize();
         &self.bytes
     }
 


### PR DESCRIPTION
`finalize` flushes accumulated `bool`s to the output stream. This should only happen once at the very end of a log frame, never within.

Fixes https://github.com/knurling-rs/defmt/issues/341