### PR TITLE
Avoid 64-bit arithmetic in LEB encoding

### DIFF
--- a/src/leb.rs
+++ b/src/leb.rs
@@ -92,31 +92,34 @@ mod tests {
         let i = leb64(1 << 7, &mut buf);
         assert_eq!(buf[..i], [0x80, 1]);
         buf.iter_mut().for_each(|b| *b = 0x55);
+    }
 
-        if cfg!(target_pointer_width = "64") {
-            // Test bit patterns that require more than 32-bit `usize`s.
+    /// Smoke test for bit patterns that require 64-bit `usize`s.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn leb_64_bit() {
+        let mut buf = [0x55; 10];
 
-            let i = leb64((1 << 32) - 1, &mut buf);
-            assert_eq!(buf[..i], [0xff, 0xff, 0xff, 0xff, 0xf]);
-            buf.iter_mut().for_each(|b| *b = 0x55);
+        let i = leb64((1 << 32) - 1, &mut buf);
+        assert_eq!(buf[..i], [0xff, 0xff, 0xff, 0xff, 0xf]);
+        buf.iter_mut().for_each(|b| *b = 0x55);
 
-            let i = leb64((1 << 35) - 1, &mut buf);
-            assert_eq!(buf[..i], [0xff, 0xff, 0xff, 0xff, 0x7f]);
-            buf.iter_mut().for_each(|b| *b = 0x55);
+        let i = leb64((1 << 35) - 1, &mut buf);
+        assert_eq!(buf[..i], [0xff, 0xff, 0xff, 0xff, 0x7f]);
+        buf.iter_mut().for_each(|b| *b = 0x55);
 
-            let i = leb64(1 << 35, &mut buf);
-            assert_eq!(buf[..i], [0x80, 0x80, 0x80, 0x80, 0x80, 1]);
-            buf.iter_mut().for_each(|b| *b = 0x55);
+        let i = leb64(1 << 35, &mut buf);
+        assert_eq!(buf[..i], [0x80, 0x80, 0x80, 0x80, 0x80, 1]);
+        buf.iter_mut().for_each(|b| *b = 0x55);
 
-            let i = leb64((1 << 42) - 1, &mut buf);
-            assert_eq!(buf[..i], [0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]);
-            buf.iter_mut().for_each(|b| *b = 0x55);
+        let i = leb64((1 << 42) - 1, &mut buf);
+        assert_eq!(buf[..i], [0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]);
+        buf.iter_mut().for_each(|b| *b = 0x55);
 
-            let i = leb64(usize::max_value(), &mut buf);
-            assert_eq!(
-                buf[..i],
-                [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 1]
-            );
-        }
+        let i = leb64(usize::max_value(), &mut buf);
+        assert_eq!(
+            buf[..i],
+            [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 1]
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,9 +417,7 @@ impl InternalFormatter {
 
     /// Implementation detail
     /// leb64-encode `x` and write it to self.bytes
-    pub fn leb64(&mut self, x: u64) {
-        // FIXME: Avoid 64-bit arithmetic on 32-bit systems. This should only be used for
-        // pointer-sized values.
+    pub fn leb64(&mut self, x: usize) {
         let mut buf: [u8; 10] = [0; 10];
         let i = leb::leb64(x, &mut buf);
         self.write(&buf[..i])
@@ -453,12 +451,12 @@ impl InternalFormatter {
     /// Implementation detail
     pub fn isize(&mut self, b: &isize) {
         // Zig-zag encode the signed value.
-        self.leb64(leb::zigzag_encode(*b as i64));
+        self.leb64(leb::zigzag_encode(*b));
     }
 
     /// Implementation detail
     pub fn fmt_slice(&mut self, values: &[impl Format]) {
-        self.leb64(values.len() as u64);
+        self.leb64(values.len());
         let mut is_first = true;
         for value in values {
             let omit_tag = !is_first;
@@ -505,7 +503,7 @@ impl InternalFormatter {
 
     /// Implementation detail
     pub fn usize(&mut self, b: &usize) {
-        self.leb64(*b as u64);
+        self.leb64(*b);
     }
 
     /// Implementation detail
@@ -514,12 +512,12 @@ impl InternalFormatter {
     }
 
     pub fn str(&mut self, s: &str) {
-        self.leb64(s.len() as u64);
+        self.leb64(s.len());
         self.write(s.as_bytes());
     }
 
     pub fn slice(&mut self, s: &[u8]) {
-        self.leb64(s.len() as u64);
+        self.leb64(s.len());
         self.write(s);
     }
 


### PR DESCRIPTION
Fixes https://github.com/knurling-rs/defmt/issues/75

This uses `usize` instead of `u64` in `leb64`, which is now possible since timestamps aren't hard-coded to LEB64-encoded-`u64` anymore.

Before:

```
   text	   data	    bss	    dec	    hex	filename
  32084	      0	      8	  32092	   7d5c	../../target/thumbv7m-none-eabi/release/log
```

After:
```
   text	   data	    bss	    dec	    hex	filename
  31876	      0	      8	  31884	   7c8c	../../target/thumbv7m-none-eabi/release/log
```

So, ~200 bytes of code saved.