### PR TITLE
Cleanup defmt tags

### DIFF
--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -31,10 +31,12 @@ include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum Tag {
-    /// A format string for use with `{=?}`. Used for both primitive format strings (which are
-    /// special cased to have lower indices), and user format strings created by
-    /// `#[derive(Format)]`.
-    Fmt,
+    /// Defmt-controlled format string for primitive types.
+    Prim,
+    /// Format string created by `#[derive(Format)]`.
+    Derived,
+    /// A user-defined format string from a `write!` invocation.
+    Write,
     /// An interned string, for use with `{=istr}`.
     Str,
     /// Defines the global timestamp format.
@@ -50,12 +52,12 @@ pub enum Tag {
 impl Tag {
     fn to_level(&self) -> Option<Level> {
         match self {
-            Tag::Fmt | Tag::Str | Tag::Timestamp => None,
             Tag::Trace => Some(Level::Trace),
             Tag::Debug => Some(Level::Debug),
             Tag::Info => Some(Level::Info),
             Tag::Warn => Some(Level::Warn),
             Tag::Error => Some(Level::Error),
+            _ => None,
         }
     }
 }
@@ -1349,7 +1351,7 @@ mod tests {
         );
         entries.insert(
             1,
-            TableEntry::new_without_symbol(Tag::Fmt, "Foo {{ x: {=u8} }}".to_owned()),
+            TableEntry::new_without_symbol(Tag::Derived, "Foo {{ x: {=u8} }}".to_owned()),
         );
 
         let table = Table {
@@ -1391,7 +1393,7 @@ mod tests {
         );
         entries.insert(
             1,
-            TableEntry::new_without_symbol(Tag::Fmt, "Foo {{ x: {=u8} }}".to_owned()),
+            TableEntry::new_without_symbol(Tag::Derived, "Foo {{ x: {=u8} }}".to_owned()),
         );
 
         let table = Table {
@@ -1544,7 +1546,7 @@ mod tests {
         entries.insert(
             1,
             TableEntry::new_without_symbol(
-                Tag::Fmt,
+                Tag::Derived,
                 "Flags {{ a: {=bool}, b: {=bool}, c: {=bool} }}".to_owned(),
             ),
         );
@@ -1826,11 +1828,11 @@ mod tests {
         );
         entries.insert(
             3,
-            TableEntry::new_without_symbol(Tag::Fmt, "None|Some({=?})".to_owned()),
+            TableEntry::new_without_symbol(Tag::Derived, "None|Some({=?})".to_owned()),
         );
         entries.insert(
             2,
-            TableEntry::new_without_symbol(Tag::Fmt, "{=u8}".to_owned()),
+            TableEntry::new_without_symbol(Tag::Derived, "{=u8}".to_owned()),
         );
 
         let table = Table {

--- a/elf2table/src/symbol.rs
+++ b/elf2table/src/symbol.rs
@@ -39,7 +39,9 @@ impl Symbol {
 
     pub fn tag(&self) -> SymbolTag<'_> {
         match &*self.tag {
-            "defmt_prim" | "defmt_fmt" => SymbolTag::Defmt(Tag::Fmt),
+            "defmt_prim" => SymbolTag::Defmt(Tag::Prim),
+            "defmt_derived" => SymbolTag::Defmt(Tag::Derived),
+            "defmt_write" => SymbolTag::Defmt(Tag::Write),
             "defmt_timestamp" => SymbolTag::Defmt(Tag::Timestamp),
             "defmt_str" => SymbolTag::Defmt(Tag::Str),
             "defmt_trace" => SymbolTag::Defmt(Tag::Trace),

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -329,7 +329,7 @@ pub fn format(ts: TokenStream) -> TokenStream {
                     ))
                 }
 
-                let sym = mksym(&fs, "fmt", false);
+                let sym = mksym(&fs, "derived", false);
                 exprs.push(quote!(
                     if f.inner.needs_tag() {
                         f.inner.istr(&defmt::export::istr(#sym));
@@ -346,7 +346,7 @@ pub fn format(ts: TokenStream) -> TokenStream {
             let mut pats = vec![];
             let args = fields(&ds.fields, &mut fs, &mut field_types, &mut pats);
 
-            let sym = mksym(&fs, "fmt", false);
+            let sym = mksym(&fs, "derived", false);
             exprs.push(quote!(
                 if f.inner.needs_tag() {
                     f.inner.istr(&defmt::export::istr(#sym));
@@ -1023,8 +1023,7 @@ pub fn write(ts: TokenStream) -> TokenStream {
     };
 
     let fmt = &write.fmt;
-    // FIXME: Introduce a new `"write"` tag and decode it in a loop (breaking change).
-    let sym = mksym(&ls, "fmt", false);
+    let sym = mksym(&ls, "write", false);
     quote!({
         let fmt: ::defmt::Formatter<'_> = #fmt;
         match (fmt.inner, #(&(#args)),*) {


### PR DESCRIPTION
This adds a `write` tag to identify format strings from user-defined `write!` invocations, and splits up the `fmt` tag into `prim` for primitives, and `derived` for `#[derive(Format)]`-generated strings. This allows tools to distinguish user-controlled format strings from generated ones.