### PR TITLE
Satisfy clippy

### DIFF
--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -1269,17 +1269,17 @@ mod tests {
                     timestamp_args: vec![],
                     format: FMT,
                     args: vec![
-                        Arg::Uxx(42),                       // u8
-                        Arg::Uxx(u16::max_value().into()),  // u16
-                        Arg::Uxx(0x10000),                  // u24
-                        Arg::Uxx(u32::max_value().into()),  // u32
-                        Arg::Uxx(u64::max_value().into()),  // u64
-                        Arg::Uxx(u128::max_value().into()), // u128
-                        Arg::Ixx(-1),                       // i8
-                        Arg::Ixx(-1),                       // i16
-                        Arg::Ixx(-1),                       // i32
-                        Arg::Ixx(-1),                       // i64
-                        Arg::Ixx(-1),                       // i128
+                        Arg::Uxx(42),                      // u8
+                        Arg::Uxx(u16::max_value().into()), // u16
+                        Arg::Uxx(0x10000),                 // u24
+                        Arg::Uxx(u32::max_value().into()), // u32
+                        Arg::Uxx(u64::max_value().into()), // u64
+                        Arg::Uxx(u128::max_value()),       // u128
+                        Arg::Ixx(-1),                      // i8
+                        Arg::Ixx(-1),                      // i16
+                        Arg::Ixx(-1),                      // i32
+                        Arg::Ixx(-1),                      // i64
+                        Arg::Ixx(-1),                      // i128
                     ],
                 },
                 bytes.len(),

--- a/elf2table/src/lib.rs
+++ b/elf2table/src/lib.rs
@@ -208,17 +208,14 @@ pub fn get_locations(elf: &[u8], table: &Table) -> Result<Locations, anyhow::Err
                 let mut attrs = entry.attrs();
 
                 while let Some(attr) = attrs.next()? {
-                    match attr.name() {
-                        gimli::constants::DW_AT_name => {
-                            if let gimli::AttributeValue::DebugStrRef(off) = attr.value() {
-                                let s = dwarf.string(off)?;
-                                for _ in (depth as usize)..segments.len() + 1 {
-                                    segments.pop();
-                                }
-                                segments.push(core::str::from_utf8(&s)?.to_string());
+                    if attr.name() == gimli::constants::DW_AT_name {
+                        if let gimli::AttributeValue::DebugStrRef(off) = attr.value() {
+                            let s = dwarf.string(off)?;
+                            for _ in (depth as usize)..segments.len() + 1 {
+                                segments.pop();
                             }
+                            segments.push(core::str::from_utf8(&s)?.to_string());
                         }
-                        _ => {}
                     }
                 }
             } else if entry.tag() == gimli::constants::DW_TAG_variable {

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -111,7 +111,7 @@ impl Log for Logger {
             format!("{}.{:06}", seconds, micros)
         } else {
             // Mark host logs.
-            format!("(HOST)")
+            "(HOST)".to_string()
         };
 
         self.timing_align

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -87,8 +87,7 @@ fn main() -> anyhow::Result<()> {
                 Err(defmt_decoder::DecodeError::UnexpectedEof) => break,
                 Err(defmt_decoder::DecodeError::Malformed) => {
                     log::error!("failed to decode defmt data: {:x?}", frames);
-                    #[allow(clippy::try_err)]
-                    Err(defmt_decoder::DecodeError::Malformed)?
+                    return Err(defmt_decoder::DecodeError::Malformed.into());
                 }
             }
         }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -78,12 +78,7 @@ fn main() -> anyhow::Result<()> {
                     }
 
                     // Forward the defmt frame to our logger.
-                    defmt_logger::log_defmt(
-                        &frame,
-                        file.as_deref(),
-                        line,
-                        mod_path.as_ref().map(|s| &**s),
-                    );
+                    defmt_logger::log_defmt(&frame, file.as_deref(), line, mod_path.as_deref());
 
                     let num_frames = frames.len();
                     frames.rotate_left(consumed);
@@ -92,6 +87,7 @@ fn main() -> anyhow::Result<()> {
                 Err(defmt_decoder::DecodeError::UnexpectedEof) => break,
                 Err(defmt_decoder::DecodeError::Malformed) => {
                     log::error!("failed to decode defmt data: {:x?}", frames);
+                    #[allow(clippy::try_err)]
                     Err(defmt_decoder::DecodeError::Malformed)?
                 }
             }


### PR DESCRIPTION
Fix multiple clippy warnings:
* useless conversion to the same type: `u128`
* useless use of `format!`
* called `.as_ref().map(|s| &**s)` on an Option value. This can be done more directly by calling `mod_path.as_deref()` instead
* you seem to be trying to use match for destructuring a single pattern. Consider using `if let`

Surpress:
* returning an `Err(_)` with the `?` operator