### PR TITLE
Update printers.md

### DIFF
--- a/book/src/printers.md
+++ b/book/src/printers.md
@@ -3,8 +3,10 @@
 *Printers* are *host* programs that receive log data, format it and display it.
 The following printers are currently available:
 
+- [`probe-run`], parses data sent over RTT (ARM Cortex-M only). NOTE: if you are using the git version of defmt, make sure you also install the tool from git (not crates.io).
+- [`defmt-print`], a generic command-line tool that decodes defmt data passed into its standard input.
 - [`qemu-run`], parses data sent by QEMU over semihosting (ARM Cortex-M only). NOTE: used for internal testing; won't be published to crates.io
-- [`probe-run`], parses data sent over RTT (ARM Cortex-M only). NOTE: make sure you install the tool from git (not crates.io) and enable the "defmt" Cargo feature.
 
-[`qemu-run`]: https://github.com/knurling-rs/defmt/tree/main/qemu-run
 [`probe-run`]: https://github.com/knurling-rs/probe-run
+[`defmt-print`]: https://github.com/knurling-rs/defmt/tree/main/print
+[`qemu-run`]: https://github.com/knurling-rs/defmt/tree/main/qemu-run


### PR DESCRIPTION
* Add `defmt-print`
* Reorder them to put the most important implementations up top and qemu-run at the bottom
* Update note, removing mention of the `defmt` feature, which is now unnecessary