### PR TITLE
Make defmt-logger more configurable, remove probe-run strings

### DIFF
--- a/decoder/src/logger/mod.rs
+++ b/decoder/src/logger/mod.rs
@@ -273,7 +273,8 @@ fn color_diff(text: String) -> String {
 /// printed.
 ///
 /// If `always_include_location` is `true`, a second line containing location information will be
-/// printed for *all* records, not just for defmt frames.
+/// printed for *all* records, not just for defmt frames (defmt frames always get location info
+/// included if it is available, regardless of this setting).
 pub fn init_logger(
     always_include_location: bool,
     should_log: impl Fn(&log::Metadata) -> bool + Sync + Send + 'static,

--- a/decoder/src/logger/mod.rs
+++ b/decoder/src/logger/mod.rs
@@ -1,7 +1,7 @@
-//! This crate provides interoperability utilities between [`defmt`] and the [`log`] crate.
+//! This module provides interoperability utilities between [`defmt`] and the [`log`] crate.
 //!
-//! If you are implementing a custom defmt decoding tool, this crate can make it easier to integrate
-//! it with logs produced with the [`log`] crate.
+//! If you are implementing a custom defmt decoding tool, this module can make it easier to
+//! integrate it with logs produced with the [`log`] crate.
 //!
 //! [`log`]: https://crates.io/crates/log
 //! [`defmt`]: https://crates.io/crates/defmt

--- a/decoder/src/logger/mod.rs
+++ b/decoder/src/logger/mod.rs
@@ -127,10 +127,11 @@ pub struct Printer<'a> {
 }
 
 impl<'a> Printer<'a> {
-    /// Whether to include location info (file, line) in the output.
+    /// Configure whether to include location info (file, line) in the output.
     ///
     /// If `true`, an additional line will be included in the output that contains file and line
-    /// information of the logging statement. By default, this is `false`.
+    /// information of the logging statement.
+    /// By default, this is `false`.
     pub fn include_location(&mut self, include_location: bool) -> &mut Self {
         self.include_location = include_location;
         self

--- a/decoder/src/logger/mod.rs
+++ b/decoder/src/logger/mod.rs
@@ -110,7 +110,7 @@ impl<'a> DefmtRecord<'a> {
     }
 
     /// Returns a builder that can format this record for displaying it to the user.
-    pub fn print(&'a self) -> Printer<'a> {
+    pub fn printer(&'a self) -> Printer<'a> {
         Printer {
             record: self,
             include_location: false,
@@ -298,7 +298,7 @@ impl Log for Logger {
                 let min_timestamp_width = self.timing_align.load(Ordering::Relaxed);
 
                 defmt
-                    .print()
+                    .printer()
                     .include_location(true) // always include location for defmt output
                     .min_timestamp_width(min_timestamp_width)
                     .print_colored(&mut sink)

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -32,7 +32,10 @@ fn main() -> anyhow::Result<()> {
     }
 
     let verbose = false;
-    defmt_decoder::logger::init(verbose);
+    defmt_decoder::logger::init_logger(verbose, |metadata| {
+        // We display *all* defmt frames, but nothing else.
+        defmt_decoder::logger::is_defmt_frame(metadata)
+    });
 
     let bytes = fs::read(&opts.elf.unwrap())?;
 


### PR DESCRIPTION
This refactors `defmt-logger` so that it does not make decisions about what data to include. It adds more API surface that can be used to write custom loggers, and removes any assumptions about being used by `probe-run` from the existing logger.

Closes https://github.com/knurling-rs/defmt/issues/356