### PR TITLE
CI: bump timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - macOS-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The macOS builders can be quite slow, so the 10 minute timeout was
getting hit

bors r+