### PR TITLE
Update decoder dependencies

### DIFF
--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -24,13 +24,13 @@ log = { version = "0.4.13", features = ["std"] }
 
 # elf2table
 anyhow = "1.0.32"
-gimli = "0.22.0"
+gimli = "0.23.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # elf2table
 [dependencies.object]
-version = "0.21.0"
+version = "0.22.0"
 default-features = false
 features = ["read_core", "elf", "std"]
 


### PR DESCRIPTION
This deduplicates `object` and `gimli`, once probe-run has been
updated after this