### PR TITLE
348 format for duration

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1032,7 +1032,7 @@ pub fn write(ts: TokenStream) -> TokenStream {
     let fmt = &write.fmt;
     let sym = mksym(&ls, "write", false);
     quote!({
-        let fmt: ::defmt::Formatter<'_> = #fmt;
+        let fmt: defmt::Formatter<'_> = #fmt;
         match (fmt.inner, #(&(#args)),*) {
             (_fmt_, #(#pats),*) => {
                 // HACK conditional should not be here; see FIXME in `format`

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "unstable-test")]
 use crate as defmt;
 use defmt_macros::internp;
 
@@ -456,5 +455,16 @@ impl Format for core::convert::Infallible {
     fn format(&self, _: Formatter) {
         // type cannot be instantiated so nothing to do here
         match *self {}
+    }
+}
+
+impl Format for core::time::Duration {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(
+            fmt,
+            "Duration {{ secs: {=u64}, nanos: {=u32} }}",
+            self.as_secs(),
+            self.subsec_nanos(),
+        )
     }
 }


### PR DESCRIPTION
This implements the `trait defmt::Format for core::time::Duration` and also adapts `defmt_macros::write!` to achieve this.

Fixes #348 