### PR TITLE
use rust-analyzer.linkedProjects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+        "firmware/Cargo.toml",
+    ]
+}


### PR DESCRIPTION
with this VS code configuration RA works transparently across the two Cargo workspaces