### PR TITLE
Make elf2table::Location public

### DIFF
--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -30,8 +30,10 @@ use std::{
 
 use decoder::{read_leb128, Decoder};
 use defmt_parser::Level;
-use elf2table::{parse_impl, Locations};
+use elf2table::parse_impl;
 use frame::Frame;
+
+pub use elf2table::{Location, Locations};
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum Tag {


### PR DESCRIPTION
`Table::get_locations` returns `Locations` which is not public. The `Location` type seems pretty safe to make public. There should at least be a public opaque type so the result of `get_locations` can be passed between functions.