### PR TITLE
Defmt test macros v0.2.0

### DIFF
--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT OR Apache-2.0"
 name = "defmt-test"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.13"
 defmt = { version = "0.2.0", path = "../.." }
-defmt-test-macros = { version = "=0.1.1", path = "macros" }
+defmt-test-macros = { version = "=0.2.0", path = "macros" }
 
 [features]
 defmt-default = []

--- a/firmware/defmt-test/macros/Cargo.toml
+++ b/firmware/defmt-test/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-test-macros"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.1.1"
+version = "0.2.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Bumps `defmt-test-macros` to `v0.2.0`, make `defmt-test` use this version and bump itself to `v0.2.1`.

Fixes #417 