### PR TITLE
`defmt_decoder`: Extend doc-comments and make `Frame` public

### DIFF
--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -178,6 +178,7 @@ panic-probe = {{ git = \"https://github.com/knurling-rs/defmt\", features = [\"p
     Ok(())
 }
 
+/// Location of a defmt log statement in the elf-file
 #[derive(Clone)]
 pub struct Location {
     pub file: PathBuf,
@@ -191,6 +192,7 @@ impl fmt::Debug for Location {
     }
 }
 
+/// Mapping of memory address to [`Location`]
 pub type Locations = BTreeMap<u64, Location>;
 
 pub fn get_locations(elf: &[u8], table: &Table) -> Result<Locations, anyhow::Error> {

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -31,10 +31,11 @@ use std::{
 use decoder::{read_leb128, Decoder};
 use defmt_parser::Level;
 use elf2table::parse_impl;
-use frame::Frame;
 
 pub use elf2table::{Location, Locations};
+pub use frame::Frame;
 
+/// Specifies the origin of a format string
 #[derive(PartialEq, Eq, Debug)]
 pub enum Tag {
     /// Defmt-controlled format string for primitive types.
@@ -68,6 +69,7 @@ impl Tag {
     }
 }
 
+/// Entry in [`Table`] combining a format string with it's raw symbol
 #[derive(Debug)]
 pub struct TableEntry {
     string: StringEntry,
@@ -88,6 +90,7 @@ impl TableEntry {
     }
 }
 
+/// A format string and it's [`Tag`]
 #[derive(Debug)]
 pub struct StringEntry {
     tag: Tag,


### PR DESCRIPTION
Fixes #430