### PR TITLE
Update dependencies

### DIFF
--- a/firmware/defmt-itm/Cargo.toml
+++ b/firmware/defmt-itm/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.2.0"
 
 [dependencies]
-cortex-m = "0.6.4"
+cortex-m = "0.7.2"
 defmt = { version = "0.2.0", path = "../.." }

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.2.0"
 
 [dependencies]
-cortex-m = "0.6.3"
+cortex-m = "0.7.2"
 defmt = { path = "../..", version = "0.2.0" }

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -8,5 +8,5 @@ version = "0.1.0"
 
 [dependencies]
 defmt = { path = "../.." }
-cortex-m = "0.6.3"
-cortex-m-semihosting = "0.3.5"
+cortex-m = "0.7.2"
+cortex-m-semihosting = "0.3.7"

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.2.1"
 
 [dependencies]
-cortex-m = "0.6.3"
+cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
 defmt = { version = "0.2.0", path = "../.." }
 defmt-test-macros = { version = "=0.2.0", path = "macros" }

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.2.0"
 
 [dependencies]
-cortex-m = "0.6.3"
-cortex-m-rt = "0.6.12"
+cortex-m = "0.7.2"
+cortex-m-rt = "0.6.13"
 defmt = { version = "0.2.0", path = "../..", optional = true }
-rtt-target = { version = "0.2.2", optional = true }
+rtt-target = { version = "0.3.0", optional = true }
 
 
 [features]

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -10,11 +10,11 @@ version = "0.1.0"
 defmt = { path = "../.." }
 defmt-semihosting = { path = "../defmt-semihosting" }
 defmt-test = { path = "../defmt-test" }
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.10"
-cortex-m-semihosting = "0.3.3"
-alloc-cortex-m = { version = "0.4.0", optional = true }
-linked_list_allocator = { version = "0.8.7", optional = true }
+cortex-m = "0.7.2"
+cortex-m-rt = "0.6.13"
+cortex-m-semihosting = "0.3.7"
+alloc-cortex-m = { version = "0.4.1", optional = true }
+linked_list_allocator = { version = "0.8.11", optional = true }
 
 [features]
 defmt-default = [] # log at INFO, or TRACE, level and up


### PR DESCRIPTION
More specifically update cortex-m from `0.6.x` to `0.7.x` to reduce
the dependency tree a little, see https://github.com/rust-embedded/cortex-m/pull/190

Another interesting update is rtt-target (`0.2.x` -> `0.3.x`)

I've lazily used `cargo upgrade` to update the dependencies, which 
means patch release versions are also changed. I can revert these lines, if not desired :) 