### PR TITLE
CI: Don't run on .md changes in PRs, except it's the book

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main, staging, trying]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    # don't run CI when changing md-files, except they are part of the book
+    paths-ignore:
+      - "*.md"
+      - "!book/src/**"
   schedule:
     # runs 1 min after 2 or 1 AM (summer/winter) berlin time
     - cron: '1 0 * * *'


### PR DESCRIPTION
This should speed up the CI, when we are "only" adapting docs. Tested it on a fork and it seems to work as intended.