### PR TITLE
`impl<T> Format for {*const, *mut} T where T: Format + ?Sized`

### DIFF
--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -113,4 +113,6 @@
 0.000112 INFO [45054, 49406]
 0.000113 INFO [Data { name: b"Hi", value: true }]
 0.000114 INFO true true
-0.000115 INFO QEMU test finished!
+0.000115 INFO 0xaabbccdd
+0.000116 INFO 0xddccbbaa
+0.000117 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -111,4 +111,6 @@
 0.000110 INFO [45054, 49406]
 0.000111 INFO [Data { name: b"Hi", value: true }]
 0.000112 INFO true true
-0.000113 INFO QEMU test finished!
+0.000113 INFO 0xaabbccdd
+0.000114 INFO 0xddccbbaa
+0.000115 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -597,6 +597,10 @@ fn main() -> ! {
     // #341 - should output `true true`
     defmt::info!("{} {=bool}", True, true);
 
+    // raw pointer
+    defmt::info!("{:?}", 0xAABBCCDD as *const u8);
+    defmt::info!("{:?}", 0xDDCCBBAA as *mut u8);
+
     defmt::info!("QEMU test finished!");
 
     loop {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,7 +1,6 @@
-use crate as defmt;
 use defmt_macros::internp;
 
-use crate::{Format, Formatter, Str};
+use crate::{self as defmt, Format, Formatter, Str};
 
 impl Format for i8 {
     fn format(&self, fmt: Formatter) {
@@ -466,5 +465,26 @@ impl Format for core::time::Duration {
             self.as_secs(),
             self.subsec_nanos(),
         )
+    }
+}
+
+// Format raw pointer as hexadecimal
+//
+// First cast raw pointer to thin pointer, then to usize and finally format as hexadecimal.
+impl<T> Format for *const T
+where
+    T: Format + ?Sized,
+{
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "{:x}", *self as *const () as usize);
+    }
+}
+
+impl<T> Format for *mut T
+where
+    T: Format + ?Sized,
+{
+    fn format(&self, fmt: Formatter) {
+        Format::format(&(*self as *const T), fmt)
     }
 }


### PR DESCRIPTION
* This behaves like `std::fmt::Debug` by printing the address as hexadecimal.
* The `*self as *const () as usize` is also used at [rust/library/core/src/fmt/mod.rs#L2130](https://github.com/rust-lang/rust/blob/master/library/core/src/fmt/mod.rs#L2130).
* The `as *const ()`, seems to be required cause else `rustc` complains with "casting `*const T` as `usize` is invalid, cast through a thin pointer first".

Fixes #442