### PR TITLE
Add leading zeros support.

### DIFF
--- a/book/src/hints.md
+++ b/book/src/hints.md
@@ -25,7 +25,15 @@ defmt::info!("{=str}", "hello\tworld");   // -> INFO hello    world
 defmt::info!("{=str:?}", "hello\tworld"); // -> INFO "hello\tworld"
 ```
 
-No further customization like padding, leading zeroes is supported (at the moment).
+Leading zeros are supported, for example
+
+``` rust
+# extern crate defmt;
+defmt::info!("{=u8:03}", 42); // -> INFO 042
+defmt::info!("{=u8:08X}", 42); // -> INFO 0x0000002A
+```
+
+No further customization like padding is supported (at the moment).
 
 The ASCII display hint formats byte slices (and arrays) using Rust's byte string syntax.
 

--- a/decoder/src/frame.rs
+++ b/decoder/src/frame.rs
@@ -137,9 +137,15 @@ fn format_args_real(
         buf: &mut String,
     ) -> Result<(), fmt::Error> {
         match hint {
-            Some(DisplayHint::Binary) => write!(buf, "{:#b}", x)?,
-            Some(DisplayHint::Hexadecimal { uppercase: false }) => write!(buf, "{:#x}", x)?,
-            Some(DisplayHint::Hexadecimal { uppercase: true }) => write!(buf, "{:#X}", x)?,
+            Some(DisplayHint::NoHint { zero_pad }) => write!(buf, "{:#01$}", x, zero_pad)?,
+            Some(DisplayHint::Binary { zero_pad }) => write!(buf, "{:#01$b}", x, zero_pad)?,
+            Some(DisplayHint::Hexadecimal {
+                uppercase,
+                zero_pad,
+            }) => match uppercase {
+                false => write!(buf, "{:#01$x}", x, zero_pad)?,
+                true => write!(buf, "{:#01$X}", x, zero_pad)?,
+            },
             Some(DisplayHint::Microseconds) => {
                 let seconds = x / 1_000_000;
                 let micros = x % 1_000_000;
@@ -156,9 +162,15 @@ fn format_args_real(
         buf: &mut String,
     ) -> Result<(), fmt::Error> {
         match hint {
-            Some(DisplayHint::Binary) => write!(buf, "{:#b}", x)?,
-            Some(DisplayHint::Hexadecimal { uppercase: false }) => write!(buf, "{:#x}", x)?,
-            Some(DisplayHint::Hexadecimal { uppercase: true }) => write!(buf, "{:#X}", x)?,
+            Some(DisplayHint::NoHint { zero_pad }) => write!(buf, "{:#01$}", x, zero_pad)?,
+            Some(DisplayHint::Binary { zero_pad }) => write!(buf, "{:#01$b}", x, zero_pad)?,
+            Some(DisplayHint::Hexadecimal {
+                uppercase,
+                zero_pad,
+            }) => match uppercase {
+                false => write!(buf, "{:#01$x}", x, zero_pad)?,
+                true => write!(buf, "{:#01$X}", x, zero_pad)?,
+            },
             _ => write!(buf, "{}", x)?,
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,9 @@ impl InternalFormatter {
     }
 
     /// Implementation detail
+    ///
     /// # Safety
+    ///
     /// `writer` is `Copy` but the returned type is a singleton. Calling this function should not
     /// break the singleton invariant (one should not create more than one instance of
     /// `InternalFormatter`)


### PR DESCRIPTION
This adds support for things like `info!("{=u16:08X}", 42")`. It is tested in the mdbook.

I could have added precision support as well, but I figure floats aren't so often used on embedded, whereas printing out a `u32` nicely aligned is a common task.