### PR TITLE
firmware/qemu: bump linked-list-allocator dep

### DIFF
--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
 cortex-m-semihosting = "0.3.7"
 alloc-cortex-m = { version = "0.4.1", optional = true }
-linked_list_allocator = { version = "0.8.11", optional = true }
+linked_list_allocator = { version = "0.9.0", optional = true }
 
 [features]
 defmt-default = [] # log at INFO, or TRACE, level and up


### PR DESCRIPTION
0.8.x no longer compiles with a recent nightly compiler

fixes #467 