### PR TITLE
add dbg! macro

### DIFF
--- a/firmware/qemu/src/bin/dbg.out
+++ b/firmware/qemu/src/bin/dbg.out
@@ -1,3 +1,6 @@
 TRACE x + 1 = 43
 TRACE x - 1 = 41
 INFO the answer is 41
+TRACE x - 2 = 40
+TRACE x + 2 = 44
+TRACE 

--- a/firmware/qemu/src/bin/dbg.out
+++ b/firmware/qemu/src/bin/dbg.out
@@ -4,3 +4,4 @@ INFO the answer is 41
 TRACE x - 2 = 40
 TRACE x + 2 = 44
 TRACE 
+TRACE x = 42

--- a/firmware/qemu/src/bin/dbg.out
+++ b/firmware/qemu/src/bin/dbg.out
@@ -1,0 +1,3 @@
+TRACE x + 1 = 43
+TRACE x - 1 = 41
+INFO the answer is 41

--- a/firmware/qemu/src/bin/dbg.release.out
+++ b/firmware/qemu/src/bin/dbg.release.out
@@ -1,0 +1,1 @@
+INFO the answer is 41

--- a/firmware/qemu/src/bin/dbg.rs
+++ b/firmware/qemu/src/bin/dbg.rs
@@ -16,6 +16,12 @@ fn main() -> ! {
     // dbg! in log statement
     defmt::info!("the answer is {}", dbg!(x - 1));
 
+    // dbg! with multiple arguments
+    let _: (i32, i32) = dbg!(x - 2, x + 2);
+
+    // dbg! with zero arguments
+    let _: () = dbg!();
+
     loop {
         debug::exit(debug::EXIT_SUCCESS)
     }

--- a/firmware/qemu/src/bin/dbg.rs
+++ b/firmware/qemu/src/bin/dbg.rs
@@ -1,0 +1,33 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::debug;
+
+use defmt::dbg;
+use defmt_semihosting as _; // global logger
+
+#[entry]
+fn main() -> ! {
+    // return value
+    let x: i32 = 42;
+    foo(dbg!(x + 1));
+
+    // dbg! in log statement
+    defmt::info!("the answer is {}", dbg!(x - 1));
+
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}
+
+fn foo(_: i32) {}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        debug::exit(debug::EXIT_FAILURE)
+    }
+}

--- a/firmware/qemu/src/bin/dbg.rs
+++ b/firmware/qemu/src/bin/dbg.rs
@@ -22,6 +22,9 @@ fn main() -> ! {
     // dbg! with zero arguments
     let _: () = dbg!();
 
+    // dbg! with trailing comma
+    foo(dbg!(x,));
+
     loop {
         debug::exit(debug::EXIT_SUCCESS)
     }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -529,6 +529,21 @@ fn log(level: Level, log: FormatArgs) -> TokenStream2 {
 }
 
 #[proc_macro]
+pub fn dbg(ts: TokenStream) -> TokenStream {
+    let expr = parse_macro_input!(ts as Expr);
+    let escaped_expr = escape_expr(&expr);
+    let format_string = format!("{} = {{}}", escaped_expr);
+
+    quote!(match #expr {
+        tmp => {
+            defmt::trace!(#format_string, tmp);
+            tmp
+        }
+    })
+    .into()
+}
+
+#[proc_macro]
 pub fn trace(ts: TokenStream) -> TokenStream {
     log_ts(Level::Trace, ts)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,11 @@ pub use defmt_macros::trace;
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::warn;
 
+/// Just like the [`std::dbg!`] macro but `defmt` is used to log the message at TRACE level
+///
+/// [`std::dbg!`]: https://doc.rust-lang.org/std/macro.dbg.html
+pub use defmt_macros::dbg;
+
 /// Writes formatted data to a [`Formatter`].
 ///
 /// [`Formatter`]: struct.Formatter.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ pub use defmt_macros::trace;
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
 pub use defmt_macros::warn;
 
-/// Just like the [`std::dbg!`] macro but `defmt` is used to log the message at TRACE level
+/// Just like the [`std::dbg!`] macro but `defmt` is used to log the message at `TRACE` level.
 ///
 /// [`std::dbg!`]: https://doc.rust-lang.org/std/macro.dbg.html
 pub use defmt_macros::dbg;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -245,6 +245,7 @@ fn test_snapshot() {
         "unwrap",
         "defmt-test",
         "hints",
+        "dbg",
     ];
 
     if rustc_is_nightly() {


### PR DESCRIPTION
behaves like the one in the `std` library but logs the data at TRACE level

closes #394 

TODO:
- [x] support more than one expression