### PR TITLE
Revert "snapshot-tests: Temporarily pass --gc-sections to linker"

### DIFF
--- a/firmware/qemu/.cargo/config.toml
+++ b/firmware/qemu/.cargo/config.toml
@@ -10,7 +10,6 @@ rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker
   "-C", "link-arg=-Tlink.x",
   "-C", "link-arg=-Tdefmt.x",
-  "-C", "link-arg=--gc-sections",
 
   # CI cannot set this, so we do it here
   "-Dwarnings",


### PR DESCRIPTION
This reverts commit e6d96ed69997c706e8e7d28c8c670744e6d783d4, reversing changes made to 4b907f572b27050198dbcf7ed98ac60555010788.

Fixes #483 