### PR TITLE
`macros`: match unused vars if logging is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ alloc = []
 unstable-test = ["defmt-macros/unstable-test"]
 
 [dependencies]
+cfg-if = "1.0"
 defmt-macros = { path = "macros", version = "0.2.1" }
 
 [dev-dependencies]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -513,7 +513,7 @@ fn log(level: Level, log: FormatArgs) -> TokenStream2 {
     let sym = mksym(&ls, level.as_str(), true);
     let logging_enabled = cfg_if_logging_enabled(level);
     quote!({
-        cfg_if::cfg_if! {
+        defmt::cfg_if::cfg_if! {
             if #[#logging_enabled] {
                 match (#(&(#args)),*) {
                     (#(#pats),*) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ use crate as defmt;
 use core::fmt::Write as _;
 use core::{fmt, ptr::NonNull};
 
+// re-export in order to call `cfg_if!` in the `defmt-macros`
+pub use cfg_if;
+
 #[doc(hidden)]
 pub mod export;
 mod impls;


### PR DESCRIPTION
Add `cfg_if 1.0` to `defmt`.

Fixes #494