### PR TITLE
Replace `µs` hint with `us`

### DIFF
--- a/book/src/design-timestamp.md
+++ b/book/src/design-timestamp.md
@@ -6,4 +6,4 @@ The timestamp format string index is not transmitted over the wire.
 Instead, it is marked with a `defmt_timestamp` tag and the decoder loads it from the ELF file.
 Linker magic is used to make sure that it doesn't get defined twice, and that the symbol doesn't get discarded (which can happen since its address is never used).
 
-The `us` format specifier was introduced to allow replicating the timestamp format of previous defmt  versions, which always used a LEB128-encoded `u64` timestamp and treated it as a number of microseconds.
+The `us` format specifier was introduced to allow replicating the timestamp format of previous defmt versions, which always used a LEB128-encoded `u64` timestamp and treated it as a number of microseconds.

--- a/book/src/design-timestamp.md
+++ b/book/src/design-timestamp.md
@@ -6,4 +6,4 @@ The timestamp format string index is not transmitted over the wire.
 Instead, it is marked with a `defmt_timestamp` tag and the decoder loads it from the ELF file.
 Linker magic is used to make sure that it doesn't get defined twice, and that the symbol doesn't get discarded (which can happen since its address is never used).
 
-The `µs` format specifier was introduced to allow replicating the timestamp format of previous defmt  versions, which always used a LEB128-encoded `u64` timestamp and treated it as a number of microseconds.
+The `us` format specifier was introduced to allow replicating the timestamp format of previous defmt  versions, which always used a LEB128-encoded `u64` timestamp and treated it as a number of microseconds.

--- a/book/src/hints.md
+++ b/book/src/hints.md
@@ -11,7 +11,7 @@ The following display hints are currently supported:
 - `?`, `core::fmt::Debug`-like
 - `b`, binary
 - `a`, ASCII
-- `µs`, microseconds (formats integers as time stamps)
+- `us`, microseconds (formats integers as time stamps)
 
 The first 4 display hints resemble what's supported in `core::fmt`. Examples below:
 

--- a/book/src/timestamps.md
+++ b/book/src/timestamps.md
@@ -23,7 +23,7 @@ defmt::timestamp!("{=usize}", COUNT.fetch_add(1, Ordering::Relaxed));
 A `timestamp` function that uses a device-specific monotonic timer can directly read a MMIO register.
 It's OK if the function returns `0` while the timer is disabled.
 
-The `µs` display hint can be used to format an integer value as a time in microseconds (eg. `1_000_000` may be displayed as `1.000000`).
+The `us` display hint can be used to format an integer value as a time in microseconds (eg. `1_000_000` may be displayed as `1.000000`).
 
 ``` rust
 # extern crate defmt;
@@ -32,7 +32,7 @@ The `µs` display hint can be used to format an integer value as a time in micro
 #     unsafe { &mut X as *mut u32 }
 # }
 // WARNING may overflow and wrap-around in long lived apps
-defmt::timestamp!("{=u32:µs}", {
+defmt::timestamp!("{=u32:us}", {
     // NOTE(interrupt-safe) single instruction volatile read operation
     unsafe { monotonic_timer_counter_register().read_volatile() }
 });

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -295,7 +295,7 @@ mod tests {
             entries,
             timestamp: Some(TableEntry::new_without_symbol(
                 Tag::Timestamp,
-                "{=u8:µs}".to_owned(),
+                "{=u8:us}".to_owned(),
             )),
         };
 
@@ -531,7 +531,7 @@ mod tests {
             entries,
             timestamp: Some(TableEntry::new_without_symbol(
                 Tag::Timestamp,
-                "{=u8:µs}".to_owned(),
+                "{=u8:us}".to_owned(),
             )),
         };
 
@@ -837,7 +837,7 @@ mod tests {
             entries,
             timestamp: Some(TableEntry::new_without_symbol(
                 Tag::Timestamp,
-                "{=u8:µs}".to_owned(),
+                "{=u8:us}".to_owned(),
             )),
         };
 

--- a/firmware/qemu/src/bin/alloc.rs
+++ b/firmware/qemu/src/bin/alloc.rs
@@ -64,7 +64,7 @@ fn nested() -> NestedStruct {
 
 // monotonic counter
 static COUNT: AtomicU32 = AtomicU32::new(0);
-defmt::timestamp!("{=u32:µs}", COUNT.fetch_add(1, Ordering::Relaxed));
+defmt::timestamp!("{=u32:us}", COUNT.fetch_add(1, Ordering::Relaxed));
 
 mod if_alloc {
     use alloc_cortex_m::CortexMHeap;

--- a/firmware/qemu/src/bin/hints.rs
+++ b/firmware/qemu/src/bin/hints.rs
@@ -126,7 +126,7 @@ fn main() -> ! {
 }
 
 static COUNT: AtomicU32 = AtomicU32::new(0);
-defmt::timestamp!("{=u32:µs}", COUNT.fetch_add(1, Ordering::Relaxed));
+defmt::timestamp!("{=u32:us}", COUNT.fetch_add(1, Ordering::Relaxed));
 
 // like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
 #[cfg(target_os = "none")]

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -665,7 +665,7 @@ impl Format for True {
 }
 
 static COUNT: AtomicU32 = AtomicU32::new(0);
-defmt::timestamp!("{=u32:µs}", COUNT.fetch_add(1, Ordering::Relaxed));
+defmt::timestamp!("{=u32:us}", COUNT.fetch_add(1, Ordering::Relaxed));
 
 // like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
 #[cfg(target_os = "none")]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -48,7 +48,7 @@ pub enum DisplayHint {
     Ascii,
     /// `:?`
     Debug,
-    /// `:µs`, formats integers as timestamps in microseconds
+    /// `:us`, formats integers as timestamps in microseconds
     Microseconds,
     /// Display hints currently not supported / understood
     Unknown(String),
@@ -75,7 +75,7 @@ fn parse_display_hint(mut s: &str) -> Option<DisplayHint> {
 
     Some(match s {
         "" => DisplayHint::NoHint { zero_pad },
-        "µs" => DisplayHint::Microseconds,
+        "us" => DisplayHint::Microseconds,
         "a" => DisplayHint::Ascii,
         "b" => DisplayHint::Binary {
             alternate,
@@ -124,7 +124,7 @@ pub enum Fragment<'f> {
 ///
 /// format_spec := [ zero_pad ] type
 /// zero_pad := '0' integer
-/// type := 'a' | 'b' | 'o' | 'x' | 'X' | '?' | 'µs'
+/// type := 'a' | 'b' | 'o' | 'x' | 'X' | '?' | 'us'
 /// ```
 #[derive(Debug, PartialEq)]
 struct Param {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ pub use defmt_macros::global_logger;
 /// # use core::sync::atomic::{AtomicU32, Ordering};
 ///
 /// static COUNT: AtomicU32 = AtomicU32::new(0);
-/// defmt::timestamp!("{=u32:µs}", COUNT.fetch_add(1, Ordering::Relaxed));
+/// defmt::timestamp!("{=u32:us}", COUNT.fetch_add(1, Ordering::Relaxed));
 /// ```
 pub use defmt_macros::timestamp;
 


### PR DESCRIPTION
Fixes https://github.com/knurling-rs/defmt/issues/434 via search-and-replace