### PR TITLE
[4/n] test: do not depend on custom InternalFormatter

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -2,10 +2,8 @@ use crate::Str;
 
 #[cfg(feature = "unstable-test")]
 thread_local! {
-    static I: core::sync::atomic::AtomicU16 =
-        core::sync::atomic::AtomicU16::new(0);
-    static T: core::sync::atomic::AtomicU16 =
-        core::sync::atomic::AtomicU16::new(0);
+    static I: core::sync::atomic::AtomicU16 = core::sync::atomic::AtomicU16::new(0);
+    static BYTES: core::cell::RefCell<Vec<u8>> = core::cell::RefCell::new(Vec::new());
 }
 
 /// For testing purposes
@@ -18,6 +16,12 @@ pub fn fetch_string_index() -> u16 {
 #[cfg(feature = "unstable-test")]
 pub fn fetch_add_string_index() -> usize {
     (I.with(|i| i.fetch_add(1, core::sync::atomic::Ordering::Relaxed))) as usize
+}
+
+/// Get and clear the logged bytes
+#[cfg(feature = "unstable-test")]
+pub fn fetch_bytes() -> Vec<u8> {
+    BYTES.with(|b| core::mem::replace(&mut *b.borrow_mut(), Vec::new()))
 }
 
 #[cfg(feature = "unstable-test")]
@@ -42,6 +46,11 @@ pub fn release() {
         fn _defmt_release();
     }
     unsafe { _defmt_release() }
+}
+
+#[cfg(feature = "unstable-test")]
+pub fn write(bytes: &[u8]) {
+    BYTES.with(|b| b.borrow_mut().extend(bytes))
 }
 
 #[cfg(not(feature = "unstable-test"))]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -11,8 +11,6 @@ pub struct Formatter<'a> {
 
 #[doc(hidden)]
 pub struct InternalFormatter {
-    #[cfg(feature = "unstable-test")]
-    bytes: Vec<u8>,
     /// Whether to omit the tag of a `Format` value
     ///
     /// * this is disabled while formatting a `{:[?]}` value (second element on-wards)
@@ -22,7 +20,6 @@ pub struct InternalFormatter {
 
 #[doc(hidden)]
 impl InternalFormatter {
-    #[cfg(not(feature = "unstable-test"))]
     pub fn write(&mut self, bytes: &[u8]) {
         export::write(bytes)
     }
@@ -32,7 +29,6 @@ impl InternalFormatter {
     /// # Safety
     ///
     /// Must only be called when the current execution context has acquired the logger with [Logger::acquire]
-    #[cfg(not(feature = "unstable-test"))]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self { omit_tag: false }
@@ -239,25 +235,5 @@ impl fmt::Write for FmtWrite<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.fmt.write(s.as_bytes());
         Ok(())
-    }
-}
-
-#[doc(hidden)]
-#[cfg(feature = "unstable-test")]
-impl super::InternalFormatter {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self {
-            bytes: vec![],
-            omit_tag: false,
-        }
-    }
-
-    pub fn bytes(&mut self) -> &[u8] {
-        &self.bytes
-    }
-
-    pub fn write(&mut self, bytes: &[u8]) {
-        self.bytes.extend_from_slice(bytes)
     }
 }


### PR DESCRIPTION
Part of #492

#508 removes InternalFormatter, so it will no longer be possible to store a `Vec<u8>` there for fake-writing the bytes for testing. This PR replaces that with writing a thread-local `Vec<u8>`.