### PR TITLE
Don't print leading space when timestamp is absent

### DIFF
--- a/decoder/src/log.rs
+++ b/decoder/src/log.rs
@@ -152,9 +152,14 @@ impl<'a> Printer<'a> {
     pub fn print_colored<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
         writeln!(
             sink,
-            "{timestamp:>0$} {level:5} {args}",
+            "{timestamp:>0$}{spacing}{level:5} {args}",
             self.min_timestamp_width,
             timestamp = self.record.timestamp(),
+            spacing = if self.record.timestamp().is_empty() {
+                ""
+            } else {
+                " "
+            },
             level = self
                 .record
                 .level()


### PR DESCRIPTION
This was causing aesthetically unpleasing output and thus makes defmt completely unusable:

```
 INFO  (11/11) running `ext_roundtrip`...
└─ integration::tests::__defmt_test_entry @ tests/integration.rs:330
 INFO  all tests passed!
└─ integration::tests::__defmt_test_entry @ tests/integration.rs:4
```

Now it should look like

```
INFO  (11/11) running `ext_roundtrip`...
└─ integration::tests::__defmt_test_entry @ tests/integration.rs:330
INFO  all tests passed!
└─ integration::tests::__defmt_test_entry @ tests/integration.rs:4
```

Fixes https://github.com/knurling-rs/probe-run/issues/230