### PR TITLE
Fix wrong bit count in comment.

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -11,6 +11,6 @@ pub struct Formatter<'a> {
 /// [`intern!`]: macro.intern.html
 #[derive(Clone, Copy)]
 pub struct Str {
-    /// 14-bit address
+    /// 16-bit address
     pub(crate) address: u16,
 }


### PR DESCRIPTION
Previous PRs mean the address can now be the full 16bit, but this comment wasn't updated.