### PR TITLE
`CI`: Temporarily drop backward-compatibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
       - name: Run QEMU snapshot tests
         run: cargo xtask test-snapshot
-      - name: install decoder v0.2.0
-        run: cargo install --debug --path qemu-run
-      - name: Backward compatibility check against decoder v0.2.0
-        env:
-          CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: qemu-run
-          QEMU_RUN_IGNORE_VERSION: 1
-        run: cargo xtask test-snapshot
 
   # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   # bors.tech integration


### PR DESCRIPTION
Temporarily drop backward-compatibility check (they aren't currently fulfilling their job anyways).

They will get added back in a different form. See #506. 