### PR TITLE
`defmt::flush()`

### DIFF
--- a/book/src/global-logger.md
+++ b/book/src/global-logger.md
@@ -21,6 +21,9 @@ unsafe impl defmt::Logger for Logger {
     fn acquire() {
         // ...
     }
+    unsafe fn flush() {
+        // ...
+    }
     unsafe fn release() {
         // ...
     }
@@ -53,6 +56,7 @@ struct Logger;
 unsafe impl defmt::Logger for Logger {
     // ...
     # fn acquire() {}
+    # unsafe fn flush() {}
     # unsafe fn release() {}
     # unsafe fn write(bytes: &[u8]) {}
 }

--- a/firmware/defmt-itm/src/lib.rs
+++ b/firmware/defmt-itm/src/lib.rs
@@ -74,7 +74,7 @@ unsafe impl defmt::Logger for Logger {
 
         // delay "a bit" to drain the queue
         // This is a heuristic and might be too short in reality. Please open an issue if it is!
-        asm::delay(100); // TODO: how long does it take to drain?
+        asm::delay(100);
     }
 
     unsafe fn release() {

--- a/firmware/defmt-itm/src/lib.rs
+++ b/firmware/defmt-itm/src/lib.rs
@@ -16,7 +16,11 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use cortex_m::{interrupt, itm, peripheral::ITM, register};
+use cortex_m::{
+    asm, interrupt, itm,
+    peripheral::{itm::Stim, ITM},
+    register,
+};
 
 #[cfg(armv6m)]
 compile_error!(
@@ -65,7 +69,11 @@ unsafe impl defmt::Logger for Logger {
     }
 
     unsafe fn flush() {
-        todo!()
+        // wait for the queue to be able to accept more data
+        while !stim_0().is_fifo_ready() {}
+
+        // delay "a bit" to drain the queue
+        asm::delay(100); // TODO: how long does it take to drain?
     }
 
     unsafe fn release() {
@@ -88,5 +96,13 @@ unsafe impl defmt::Logger for Logger {
 fn do_write(bytes: &[u8]) {
     // NOTE(unsafe) this function will be invoked *after* `enable` has run so this crate now has
     // ownership over the ITM thus it's OK to instantiate the ITM register block here
-    unsafe { itm::write_all(&mut (*ITM::ptr()).stim[0], bytes) }
+    unsafe { itm::write_all(stim_0(), bytes) }
+}
+
+/// Get access to stimulus port 0
+///
+/// # Safety
+/// Can only be invoked *after* `enable` has run
+unsafe fn stim_0<'a>() -> &'a mut Stim {
+    &mut (*ITM::PTR).stim[0]
 }

--- a/firmware/defmt-itm/src/lib.rs
+++ b/firmware/defmt-itm/src/lib.rs
@@ -73,6 +73,7 @@ unsafe impl defmt::Logger for Logger {
         while !stim_0().is_fifo_ready() {}
 
         // delay "a bit" to drain the queue
+        // This is a heuristic and might be too short in reality. Please open an issue if it is!
         asm::delay(100); // TODO: how long does it take to drain?
     }
 

--- a/firmware/defmt-itm/src/lib.rs
+++ b/firmware/defmt-itm/src/lib.rs
@@ -64,6 +64,10 @@ unsafe impl defmt::Logger for Logger {
         unsafe { ENCODER.start_frame(do_write) }
     }
 
+    unsafe fn flush() {
+        todo!()
+    }
+
     unsafe fn release() {
         // safety: accessing the `static mut` is OK because we have disabled interrupts.
         ENCODER.end_frame(do_write);

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -47,6 +47,10 @@ unsafe impl defmt::Logger for Logger {
         unsafe { ENCODER.start_frame(do_write) }
     }
 
+    unsafe fn flush() {
+        todo!()
+    }
+
     unsafe fn release() {
         // safety: accessing the `static mut` is OK because we have disabled interrupts.
         ENCODER.end_frame(do_write);

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! # Blocking/Non-blocking
 //!
-//! `probe-run` puts RTT into blocking-mode, to avoid loosing data.
+//! `probe-run` puts RTT into blocking-mode, to avoid losing data.
 //!
 //! As an effect this implementation may block forever if `probe-run` disconnects on runtime. This
 //! is because the RTT buffer will fill up and writing will eventually halt the program execution.

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -8,6 +8,15 @@
 //! // src/main.rs or src/bin/my-app.rs
 //! use defmt_rtt as _;
 //! ```
+//!
+//! # Blocking/Non-blocking
+//!
+//! `probe-run` puts RTT into blocking-mode, to avoid loosing data.
+//!
+//! As an effect this implementation may block forever if `probe-run` disconnects on runtime. This
+//! is because the RTT buffer will fill up and writing will eventually halt the program execution.
+//! 
+//! `defmt::flush` would also block forever in that case.
 
 #![no_std]
 

--- a/firmware/defmt-semihosting/src/lib.rs
+++ b/firmware/defmt-semihosting/src/lib.rs
@@ -37,6 +37,10 @@ unsafe impl defmt::Logger for Logger {
         unsafe { ENCODER.start_frame(do_write) }
     }
 
+    unsafe fn flush() {
+        todo!()
+    }
+
     unsafe fn release() {
         // safety: accessing the `static mut` is OK because we have disabled interrupts.
         ENCODER.end_frame(do_write);

--- a/firmware/defmt-semihosting/src/lib.rs
+++ b/firmware/defmt-semihosting/src/lib.rs
@@ -38,7 +38,10 @@ unsafe impl defmt::Logger for Logger {
     }
 
     unsafe fn flush() {
-        todo!()
+        // Do nothing.
+        //
+        // semihosting is fundamentally blocking, and does not have I/O buffers the target can control.
+        // After write returns, the host has the data, so there's nothing left to flush.
     }
 
     unsafe fn release() {

--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -140,4 +140,7 @@
 0.000139 INFO 1
 0.000140 INFO 1
 0.000141 INFO ccbbaadd
-0.000142 INFO QEMU test finished!
+0.000142 INFO log data: 43981
+0.000143 INFO flush! 🚽
+0.000144 INFO log more data! 🎉
+0.000145 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.release.out
+++ b/firmware/qemu/src/bin/log.release.out
@@ -138,4 +138,7 @@
 0.000137 INFO 1
 0.000138 INFO 1
 0.000139 INFO ccbbaadd
-0.000140 INFO QEMU test finished!
+0.000140 INFO log data: 43981
+0.000141 INFO flush! 🚽
+0.000142 INFO log more data! 🎉
+0.000143 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -657,6 +657,12 @@ fn main() -> ! {
     struct NotFormatType;
     defmt::info!("{}", 0xCCBBAADD as *mut NotFormatType);
 
+    // tests for `defmt::flush()`
+    defmt::info!("log data: {}", 0xABCD);
+    defmt::info!("flush! 🚽");
+    defmt::flush();
+    defmt::info!("log more data! 🎉");
+
     defmt::info!("QEMU test finished!");
 
     loop {

--- a/macros/src/attributes/global_logger.rs
+++ b/macros/src/attributes/global_logger.rs
@@ -44,6 +44,11 @@ fn codegen(strukt: &ItemStruct) -> TokenStream {
         }
 
         #[no_mangle]
+        unsafe fn _defmt_flush()  {
+            <#ident as defmt::Logger>::flush()
+        }
+
+        #[no_mangle]
         unsafe fn _defmt_release()  {
             <#ident as defmt::Logger>::release()
         }

--- a/src/export.rs
+++ b/src/export.rs
@@ -48,25 +48,6 @@ pub fn acquire() {
 }
 
 #[cfg(feature = "unstable-test")]
-pub fn flush() {}
-
-#[cfg(not(feature = "unstable-test"))]
-#[inline(never)]
-pub fn flush() {
-    extern "Rust" {
-        fn _defmt_acquire();
-        fn _defmt_flush();
-        fn _defmt_release();
-    }
-    // SAFETY: ...
-    unsafe {
-        _defmt_acquire();
-        _defmt_flush();
-        _defmt_release()
-    }
-}
-
-#[cfg(feature = "unstable-test")]
 pub fn release() {}
 
 #[cfg(not(feature = "unstable-test"))]

--- a/src/export.rs
+++ b/src/export.rs
@@ -48,6 +48,25 @@ pub fn acquire() {
 }
 
 #[cfg(feature = "unstable-test")]
+pub fn flush() {}
+
+#[cfg(not(feature = "unstable-test"))]
+#[inline(never)]
+pub fn flush() {
+    extern "Rust" {
+        fn _defmt_acquire();
+        fn _defmt_flush();
+        fn _defmt_release();
+    }
+    // SAFETY: ...
+    unsafe {
+        _defmt_acquire();
+        _defmt_flush();
+        _defmt_release()
+    }
+}
+
+#[cfg(feature = "unstable-test")]
 pub fn release() {}
 
 #[cfg(not(feature = "unstable-test"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,8 +372,6 @@ fn default_panic() -> ! {
 ///
 /// This calls the method `flush` of the used "global [`Logger`]". The logger is likely provided by
 /// [`defmt-rtt`](https://crates.io/crates/defmt-rtt) or [`defmt-itm`](https://crates.io/crates/defmt-itm).
-#[cfg(not(feature = "unstable-test"))]
-#[inline(never)]
 pub fn flush() {
     extern "Rust" {
         fn _defmt_acquire();
@@ -391,6 +389,3 @@ pub fn flush() {
         _defmt_release()
     }
 }
-
-#[cfg(feature = "unstable-test")]
-pub fn flush() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,10 @@ pub use defmt_macros::write;
 /// # todo!()
 ///         // ...
 ///     }
+///     unsafe fn flush() {
+///         # todo!()
+///         // ...
+///     }
 ///     unsafe fn release() {
 /// # todo!()
 ///         // ...
@@ -351,13 +355,10 @@ pub use defmt_macros::bitflags;
 #[doc(hidden)] // documented as the `Format` trait instead
 pub use defmt_macros::Format;
 
-#[export_name = "__defmt_default_timestamp"]
-fn default_timestamp(_f: Formatter<'_>) {
-    // By default, no timestamp is used.
-}
-
 // There is no default timestamp format. Instead, the decoder looks for a matching ELF symbol. If
 // absent, timestamps are turned off.
+#[export_name = "__defmt_default_timestamp"]
+fn default_timestamp(_f: Formatter<'_>) {}
 
 #[export_name = "__defmt_default_panic"]
 fn default_panic() -> ! {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -96,6 +96,15 @@ pub unsafe trait Logger {
     /// Panics if already acquired in the current execution context. Otherwise it must never fail.
     fn acquire();
 
+    /// Block until host has read all pending data.
+    ///
+    /// The flush operation must not fail. This is a "best effort" operation, I/O errors should be discarded.
+    ///
+    /// # Safety
+    /// Must only be called when the global logger is acquired in the current execution context.
+    /// (i.e. between `acquire()` and `release()`).
+    unsafe fn flush();
+
     /// Releases the global logger in the current execution context.
     ///
     /// This will be called by the defmt logging macros after writing each log frame.
@@ -106,8 +115,9 @@ pub unsafe trait Logger {
 
     /// Writes `bytes` to the destination.
     ///
-    /// This will be called by the defmt logging macros to transmit frame data. The write
-    /// operation must not fail. One log frame may cause multiple `write` calls.
+    /// This will be called by the defmt logging macros to transmit frame data. One log frame may cause multiple `write` calls.
+    ///
+    /// The write operation must not fail. This is a "best effort" operation, I/O errors should be discarded.
     ///
     /// The `bytes` are unencoded log frame data, they MUST be encoded with `Encoder` prior to
     /// sending over the wire.
@@ -117,6 +127,6 @@ pub unsafe trait Logger {
     ///
     /// # Safety
     /// Must only be called when the global logger is acquired in the current execution context.
-    /// (i.e. between acquire() and release())
+    /// (i.e. between `acquire()` and `release()`).
     unsafe fn write(bytes: &[u8]);
 }

--- a/tests/basic_usage.rs
+++ b/tests/basic_usage.rs
@@ -7,6 +7,7 @@ struct Logger;
 
 unsafe impl defmt::Logger for Logger {
     fn acquire() {}
+    unsafe fn flush() {}
     unsafe fn release() {}
     unsafe fn write(_bytes: &[u8]) {}
 }


### PR DESCRIPTION
Fixes #515 

## TODO
- [x] skeleton: add method to trait, TODO-implements in crates and tests
- [x] defmt-rtt
- [x] defmt-semihosting
- [x] defmt-itm
- [x] adapt delays based on docs and testing