### PR TITLE
Add impl for TryFromIntError

### DIFF
--- a/src/impls/core_/num.rs
+++ b/src/impls/core_/num.rs
@@ -24,3 +24,9 @@ non_zero! {num::NonZeroU32, "{=u32}"}
 non_zero! {num::NonZeroU64, "{=u64}"}
 non_zero! {num::NonZeroU128, "{=u128}"}
 non_zero! {num::NonZeroUsize, "{=usize}"}
+
+impl Format for num::TryFromIntError {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "TryFromIntError(())");
+    }
+}


### PR DESCRIPTION
This implements `defmt::Format` for [`TryFromIntError`](https://doc.rust-lang.org/core/num/struct.TryFromIntError.html) which enables code like this:
```rs
use core::convert::{TryFrom, TryInto};

let foo: u64 = u64::MAX;
let bar: u32 = defmt::unwrap!(foo.try_into());
let eggs: u32 = defmt::unwrap!(u32::try_from(foo));
```

When it fails it looks like this:
```text
ERROR panicked at 'unwrap failed: foo.try_into()'
error: `TryFromIntError(())`
```

Which is similar to what it looks like on `std` targets with `.unwrap()`
```text
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: TryFromIntError(())', src/main.rs:5:35
```
