### PR TITLE
Add impl for TryFromSliceError

### DIFF
--- a/src/impls/core_/array.rs
+++ b/src/impls/core_/array.rs
@@ -1,0 +1,9 @@
+use core::array;
+
+use super::*;
+
+impl Format for array::TryFromSliceError {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "TryFromSliceError(())");
+    }
+}

--- a/src/impls/core_/mod.rs
+++ b/src/impls/core_/mod.rs
@@ -5,6 +5,7 @@
 //! We generally keep the type parameter trait bounds in case it becomes possible to use this
 //! later, without making a backwards-incompatible change.
 
+mod array;
 mod num;
 mod ops;
 mod slice;


### PR DESCRIPTION
This implements `defmt::Format` for [`TryFromSliceError`](https://doc.rust-lang.org/stable/core/array/struct.TryFromSliceError.html) which enables code like this:
```rs
use core::convert::TryInto;

let foo: [u8; 5] = [0, 1, 2, 3, 4];
let bar: u32 = u32::from_be_bytes(defmt::unwrap!(foo[1..2].try_into()));
```

When it fails it looks like this:
```text
ERROR panicked at 'unwrap failed: foo [1 .. 2].try_into()'
error: `TryFromSliceError(())`
```

Which is similar to what it looks like on `std` targets with `.unwrap()`
```text
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: TryFromIntError(())', src/main.rs:5:35
```