### PR TITLE
Remove unused cortex-m-rt in panic-probe

### DIFF
--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.2.0"
 
 [dependencies]
 cortex-m = "0.7.2"
-cortex-m-rt = "0.7.0"
 defmt = { version = "0.2.0", path = "../..", optional = true }
 rtt-target = { version = "0.3.1", optional = true }
 


### PR DESCRIPTION
It's nice to not depend on a particular cortex-m-rt version, it'll help the 0.6 -> 0.7 breaking transition.

This shouldn't be a breaking change. Could we get a release of this as 0.2.1 to help with the transition? Thank you!