### PR TITLE
Make order of bitflags values deterministic

### DIFF
--- a/decoder/src/frame.rs
+++ b/decoder/src/frame.rs
@@ -226,8 +226,6 @@ impl<'t> Frame<'t> {
                 };
                 match self.table.bitflags.get(&key) {
                     Some(flags) => {
-                        // FIXME flag print order does not match definition order
-                        // (does some part of the toolchain alphabetically sort them?)
                         let set_flags = flags
                             .iter()
                             .filter(|(_, value)| {

--- a/firmware/qemu/src/bin/bitflags.out
+++ b/firmware/qemu/src/bin/bitflags.out
@@ -6,7 +6,7 @@ INFO Flags::FLAG_1: FLAG_1
 INFO Flags::FLAG_1: FLAG_1 (fmt::Debug)
 INFO Flags::FLAG_7: FLAG_7
 INFO Flags::FLAG_7: FLAG_7 (fmt::Debug)
-INFO LargeFlags::ALL: ALL | MSB | NON_LITERAL
+INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL
 INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL (fmt::Debug)
 INFO LargeFlags::empty(): (empty)
 INFO LargeFlags::empty(): (empty) (fmt::Debug)

--- a/firmware/qemu/src/bin/bitflags.release.out
+++ b/firmware/qemu/src/bin/bitflags.release.out
@@ -6,7 +6,7 @@ INFO Flags::FLAG_1: FLAG_1
 INFO Flags::FLAG_1: FLAG_1 (fmt::Debug)
 INFO Flags::FLAG_7: FLAG_7
 INFO Flags::FLAG_7: FLAG_7 (fmt::Debug)
-INFO LargeFlags::ALL: ALL | MSB | NON_LITERAL
+INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL
 INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL (fmt::Debug)
 INFO LargeFlags::empty(): (empty)
 INFO LargeFlags::empty(): (empty) (fmt::Debug)

--- a/macros/src/items/bitflags.rs
+++ b/macros/src/items/bitflags.rs
@@ -61,7 +61,8 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
 fn codegen_flag_statics(input: &Input) -> Vec<TokenStream2> {
     input
         .flags()
-        .map(|flag| {
+        .enumerate()
+        .map(|(i, flag)| {
             let cfg_attrs = flag.cfg_attrs();
             let var_name = &flag.ident();
             let value = &flag.value();
@@ -69,7 +70,7 @@ fn codegen_flag_statics(input: &Input) -> Vec<TokenStream2> {
 
             let sym_name = construct::mangled_symbol_name(
                 "bitflags_value",
-                &format!("{}::{}", input.ident(), flag.ident()),
+                &format!("{}::{}::{}", input.ident(), i, flag.ident()),
             );
 
             quote! {


### PR DESCRIPTION
Fixes https://github.com/knurling-rs/defmt/issues/563

Since each bitflags value is stored in its own symbol, their order in the final executable is up to rustc/LLVM, or even the linker. This causes unreliable output that depends on toolchain details.

This PR fixes that by storing an index in the symbol for bitflags values, which indicates their order in the source code. The decoder sorts by this index to put the values back in definition order. We now exactly match the output of the `bitflags` crate.