### PR TITLE
Encoding docs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,15 @@ alloc = []
 # will pick a default one. The current default is `encoding-rzcobs`. The default may change 
 # in minor releases, changing it is not considered a breaking change since all encodings
 # are guaranteed to be supported by the corresponding `defmt-decoder` version.
+
+# Raw encoding: All log frames are concatenated and sent over the wire with no framing or compression.
+# This is the fastest CPU-wise, but may end up being slower if the limiting factor is wire speed.
 encoding-raw = []
+
+# rzCOBS encoding: Performs framing on the log frames using reverse-COBS, additionally applying a
+# light compression for data known to contain many zero bytes, like defmt streams.
+# The framing allows the decoder to recover from missing or corrupted data, and start decoding
+# in the middle of a stream, for example when attaching to an already-running device.
 encoding-rzcobs = []
 
 # WARNING: for internal use only, not covered by semver guarantees

--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -38,7 +38,8 @@ pub fn parse_impl(elf: &[u8], check_version: bool) -> Result<Option<Table>, anyh
         }
     };
 
-    // No need to remove quotes for `_defmt_encoding_`, since it's
+    // No need to remove quotes for `_defmt_encoding_`, since it's defined in Rust code
+    // using `#[export_name = "_defmt_encoding_ = x"]`, never in linker scripts.
     let try_get_encoding = |name: &str| {
         name.strip_prefix("_defmt_encoding_ = ")
             .map(ToString::to_string)

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -7,30 +7,79 @@ mod inner;
 
 // This wrapper struct is to avoid copypasting the public docs in all the impls.
 
-/// TODO
+/// Encode raw defmt frames for sending over the wire.
+///
+/// defmt emits "log frames", which are sequences of bytes. The raw log frame data
+/// is then *encoded* prior to sending over the wire.
+///
+/// `Encoder` will encode the frames according to the currently selected
+/// `encoding-*` Cargo feature. See `Cargo.toml` for the supported encodings
+/// and their tradeoffs.
+///
+/// Encodings may perform two functions:
+///
+/// - Framing: Adds extra data to allow the encoder to know when each frame starts
+/// and ends in the stream. Unframed log frames already contain enough information for
+/// the decoder to know when they end, so framing is optional. However, without framing
+/// the decoder must receive all bytes intact or it may "lose sync". With framing, it can
+/// recover from missing/corrupted data, and can start decoding from the "middle" of an
+/// already-running stream.
+/// - Compression: The frame data has rather low entropy (for example, it contains many
+/// zero bytes due to encoding all integers in fixed with, and will likely contain many
+/// repetitions). Compression can decrease the on-the-wire required bandwidth.
+///
+/// defmt provides the `Encoder` separately instead of feeding already-encoded bytes
+/// to the `Logger` because `Logger` implementations may decide to allow
+/// concurrent logging from multiple "contexts" such as threads or interrupt
+/// priority levels. In this case, the Logger implementation needs to create one
+/// Encoder for each such context.
 pub struct Encoder {
     inner: inner::Encoder,
 }
 
 impl Encoder {
-    /// TODO
+    /// Create a new `Encoder`.
     pub const fn new() -> Self {
         Self {
             inner: inner::Encoder::new(),
         }
     }
 
-    /// TODO
+    /// Start encoding a log frame.
+    ///
+    /// `Logger` impls will typically call this from `acquire()`.
+    ///
+    /// You may only call `start_frame` when no frame is currently being encoded.
+    /// Failure to do so may result in corrupted data on the wire.
+    ///
+    /// The `write` closure will be called with the encoded data that must
+    /// be sent on the wire. It may be called zero, one, or multiple times.
     pub fn start_frame(&mut self, write: impl FnMut(&[u8])) {
         self.inner.start_frame(write)
     }
 
-    /// TODO
+    /// Finish encoding a log frame.
+    ///
+    /// `Logger` impls will typically call this from `release()`.
+    ///
+    /// You may only call `end_frame` when a frame is currently being encoded.
+    /// Failure to do so may result in corrupted data on the wire.
+    ///
+    /// The `write` closure will be called with the encoded data that must
+    /// be sent on the wire. It may be called zero, one, or multiple times.
     pub fn end_frame(&mut self, write: impl FnMut(&[u8])) {
         self.inner.end_frame(write)
     }
 
-    /// TODO
+    /// Write part of data for a log frame.
+    ///
+    /// `Logger` impls will typically call this from `write()`.
+    ///
+    /// You may only call `write` when a frame is currently being encoded.
+    /// Failure to do so may result in corrupted data on the wire.
+    ///
+    /// The `write` closure will be called with the encoded data that must
+    /// be sent on the wire. It may be called zero, one, or multiple times.
     pub fn write(&mut self, data: &[u8], write: impl FnMut(&[u8])) {
         self.inner.write(data, write)
     }


### PR DESCRIPTION
- Document `Encoder`.
- Document in `Logger` that implementations MUST pass all the data through `Encoder`.
- Add user-facing docs on the available encoding features in `Cargo.toml` (you may want to copy/move those to the book?)
- Minor fixes.

Fixes #567