### PR TITLE
Support referring to `Self` in bitflags constants

### DIFF
--- a/firmware/qemu/src/bin/bitflags.out
+++ b/firmware/qemu/src/bin/bitflags.out
@@ -1,11 +1,11 @@
 INFO Flags::empty(): FLAG_0
 INFO Flags::empty(): FLAG_0 (fmt::Debug)
-INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7
-INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7 (fmt::Debug)
+INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7 | FLAG_7_COPY
+INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7 | FLAG_7_COPY (fmt::Debug)
 INFO Flags::FLAG_1: FLAG_1
 INFO Flags::FLAG_1: FLAG_1 (fmt::Debug)
-INFO Flags::FLAG_7: FLAG_7
-INFO Flags::FLAG_7: FLAG_7 (fmt::Debug)
+INFO Flags::FLAG_7: FLAG_7 | FLAG_7_COPY
+INFO Flags::FLAG_7: FLAG_7 | FLAG_7_COPY (fmt::Debug)
 INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL
 INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL (fmt::Debug)
 INFO LargeFlags::empty(): (empty)

--- a/firmware/qemu/src/bin/bitflags.release.out
+++ b/firmware/qemu/src/bin/bitflags.release.out
@@ -1,11 +1,11 @@
 INFO Flags::empty(): FLAG_0
 INFO Flags::empty(): FLAG_0 (fmt::Debug)
-INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7
-INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7 (fmt::Debug)
+INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7 | FLAG_7_COPY
+INFO Flags::all(): FLAG_1 | FLAG_2 | FLAG_7 | FLAG_7_COPY (fmt::Debug)
 INFO Flags::FLAG_1: FLAG_1
 INFO Flags::FLAG_1: FLAG_1 (fmt::Debug)
-INFO Flags::FLAG_7: FLAG_7
-INFO Flags::FLAG_7: FLAG_7 (fmt::Debug)
+INFO Flags::FLAG_7: FLAG_7 | FLAG_7_COPY
+INFO Flags::FLAG_7: FLAG_7 | FLAG_7_COPY (fmt::Debug)
 INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL
 INFO LargeFlags::ALL: MSB | ALL | NON_LITERAL (fmt::Debug)
 INFO LargeFlags::empty(): (empty)

--- a/firmware/qemu/src/bin/bitflags.rs
+++ b/firmware/qemu/src/bin/bitflags.rs
@@ -15,6 +15,8 @@ bitflags! {
         const FLAG_2 = 0b10;
         const FLAG_7 = 1 << 7;
 
+        const FLAG_7_COPY = Self::FLAG_7.bits;
+
         #[cfg(never)]
         const CFGD_OUT = 1;
     }

--- a/macros/src/items/bitflags.rs
+++ b/macros/src/items/bitflags.rs
@@ -64,9 +64,9 @@ fn codegen_flag_statics(input: &Input) -> Vec<TokenStream2> {
         .enumerate()
         .map(|(i, flag)| {
             let cfg_attrs = flag.cfg_attrs();
-            let var_name = &flag.ident();
-            let value = &flag.value();
-            let repr_ty = &input.ty();
+            let var_name = flag.ident();
+            let struct_name = input.ident();
+            let repr_ty = input.ty();
 
             let sym_name = construct::mangled_symbol_name(
                 "bitflags_value",
@@ -83,7 +83,7 @@ fn codegen_flag_statics(input: &Input) -> Vec<TokenStream2> {
                     // causes a value such as `1 << 127` to be evaluated as an `i32`, which
                     // overflows. So we instead coerce (but don't cast) it to the bitflags' raw
                     // type, and then cast that to u128.
-                    let coerced_value: #repr_ty = #value;
+                    let coerced_value: #repr_ty = #struct_name::#var_name.bits;
                     coerced_value as u128
                 };
             }

--- a/macros/src/items/bitflags/input.rs
+++ b/macros/src/items/bitflags/input.rs
@@ -78,10 +78,6 @@ impl Flag {
     pub(super) fn ident(&self) -> &Ident {
         &self.ident
     }
-
-    pub(super) fn value(&self) -> &Expr {
-        &self.value
-    }
 }
 
 fn extract_cfgs(attrs: &[Attribute]) -> Vec<Attribute> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,17 +320,13 @@ pub use defmt_macros::timestamp;
 ///
 /// # Limitations
 ///
-/// To integrate with defmt, this macro imposes a few minor limitations on the input that do not
-/// apply when using the `bitflags` crate directly:
-///
-/// - The macro only supports Rust's built-in unsigned types. Custom types are not supported.
-///
-/// - When defining bitflags constants, you cannot refer to the `Self` type. Instead, spell out the
-///   name of the bitflags struct.
+/// This macro only supports bitflags structs represented as one of Rust's built-in unsigned integer
+/// types (`u8`, `u16`, `u32`, `u64`, or `u128`). Custom types are not supported. This restriction
+/// is necessary to support defmt's efficient encoding.
 ///
 /// # Examples
 ///
-/// The example from the bitflags crate works with a minor modification:
+/// The example from the bitflags crate works as-is:
 ///
 /// ```
 /// defmt::bitflags! {
@@ -338,8 +334,7 @@ pub use defmt_macros::timestamp;
 ///         const A = 0b00000001;
 ///         const B = 0b00000010;
 ///         const C = 0b00000100;
-///         // Uses `Flags` instead of `Self`
-///         const ABC = Flags::A.bits | Flags::B.bits | Flags::C.bits;
+///         const ABC = Self::A.bits | Self::B.bits | Self::C.bits;
 ///     }
 /// }
 ///


### PR DESCRIPTION
The initial bitflags support in https://github.com/knurling-rs/defmt/pull/528 had a restriction where referring to the `Self` type in a `bitflags` constant would result in a compile error.

Turns out that's entirely unnecessary and I wasn't quite awake when I wrote that code. A minor modification of the generated code avoids this somewhat annoying restriction. Instead of copying the expression verbatim, we can just refer to the associated constant created by the `bitflags` crate, and extract the raw bits.