### PR TITLE
Refactor rtt [3/2]

### DIFF
--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -5,12 +5,16 @@ use core::{
 
 use crate::{MODE_BLOCK_IF_FULL, MODE_MASK, SIZE};
 
+/// RTT Up channel
 #[repr(C)]
 pub(crate) struct Channel {
     pub name: *const u8,
+    /// Pointer to the RTT buffer.
     pub buffer: *mut u8,
     pub size: usize,
+    /// Written by the target.
     pub write: AtomicUsize,
+    /// Written by the host.
     pub read: AtomicUsize,
     /// Channel properties.
     ///

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -27,8 +27,8 @@ impl Channel {
         // the host-connection-status is only modified after RAM initialization while the device is
         // halted, so we only need to check it once before the write-loop
         let write = match self.host_is_connected() {
-            true => Channel::blocking_write,
-            false => Channel::nonblocking_write,
+            true => Self::blocking_write,
+            false => Self::nonblocking_write,
         };
 
         while !bytes.is_empty() {


### PR DESCRIPTION
This PR mainly factors out the common part of `fn blocking_write` and `fn nonblocking_write` into one common method.