### PR TITLE
Refactor rtt [1/2]

### DIFF
--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -22,7 +22,7 @@ impl Channel {
     pub fn write_all(&self, mut bytes: &[u8]) {
         // the host-connection-status is only modified after RAM initialization while the device is
         // halted, so we only need to check it once before the write-loop
-        let write = match host_is_connected(self) {
+        let write = match self.host_is_connected() {
             true => Channel::blocking_write,
             false => Channel::nonblocking_write,
         };
@@ -99,7 +99,7 @@ impl Channel {
 
     pub fn flush(&self) {
         // return early, if host is disconnected
-        if !host_is_connected(self) {
+        if !self.host_is_connected() {
             return;
         }
 
@@ -108,9 +108,9 @@ impl Channel {
         let write = || self.write.load(Ordering::Relaxed);
         while read() != write() {}
     }
-}
 
-fn host_is_connected(channel: &Channel) -> bool {
-    // we assume that a host is connected if we are in blocking-mode. this is what probe-run does.
-    channel.flags.load(Ordering::Relaxed) & MODE_MASK == MODE_BLOCK_IF_FULL
+    fn host_is_connected(&self) -> bool {
+        // we assume that a host is connected if we are in blocking-mode. this is what probe-run does.
+        self.flags.load(Ordering::Relaxed) & MODE_MASK == MODE_BLOCK_IF_FULL
+    }
 }

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -1,0 +1,116 @@
+use core::{
+    ptr,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use crate::{MODE_BLOCK_IF_FULL, MODE_MASK, SIZE};
+
+#[repr(C)]
+pub(crate) struct Channel {
+    pub name: *const u8,
+    pub buffer: *mut u8,
+    pub size: usize,
+    pub write: AtomicUsize,
+    pub read: AtomicUsize,
+    /// Channel properties.
+    ///
+    /// Currently, only the lowest 2 bits are used to set the channel mode (see constants below).
+    pub flags: AtomicUsize,
+}
+
+impl Channel {
+    pub fn write_all(&self, mut bytes: &[u8]) {
+        // the host-connection-status is only modified after RAM initialization while the device is
+        // halted, so we only need to check it once before the write-loop
+        let write = match host_is_connected(self) {
+            true => Channel::blocking_write,
+            false => Channel::nonblocking_write,
+        };
+
+        while !bytes.is_empty() {
+            let consumed = write(self, bytes);
+            if consumed != 0 {
+                bytes = &bytes[consumed..];
+            }
+        }
+    }
+
+    fn blocking_write(&self, bytes: &[u8]) -> usize {
+        if bytes.is_empty() {
+            return 0;
+        }
+
+        let read = self.read.load(Ordering::Relaxed);
+        let write = self.write.load(Ordering::Acquire);
+        let available = if read > write {
+            read - write - 1
+        } else if read == 0 {
+            SIZE - write - 1
+        } else {
+            SIZE - write
+        };
+
+        if available == 0 {
+            return 0;
+        }
+
+        let cursor = write;
+        let len = bytes.len().min(available);
+
+        unsafe {
+            if cursor + len > SIZE {
+                // split memcpy
+                let pivot = SIZE - cursor;
+                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), pivot);
+                ptr::copy_nonoverlapping(bytes.as_ptr().add(pivot), self.buffer, len - pivot);
+            } else {
+                // single memcpy
+                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), len);
+            }
+        }
+        self.write
+            .store(write.wrapping_add(len) % SIZE, Ordering::Release);
+
+        len
+    }
+
+    fn nonblocking_write(&self, bytes: &[u8]) -> usize {
+        let write = self.write.load(Ordering::Acquire);
+        let cursor = write;
+        // NOTE truncate at SIZE to avoid more than one "wrap-around" in a single `write` call
+        let len = bytes.len().min(SIZE);
+
+        unsafe {
+            if cursor + len > SIZE {
+                // split memcpy
+                let pivot = SIZE - cursor;
+                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), pivot);
+                ptr::copy_nonoverlapping(bytes.as_ptr().add(pivot), self.buffer, len - pivot);
+            } else {
+                // single memcpy
+                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), len);
+            }
+        }
+        self.write
+            .store(write.wrapping_add(len) % SIZE, Ordering::Release);
+
+        len
+    }
+
+    pub fn flush(&self) {
+        // return early, if host is disconnected
+        if !host_is_connected(self) {
+            return;
+        }
+
+        // busy wait, until the read- catches up with the write-pointer
+        let read = || self.read.load(Ordering::Relaxed);
+        let write = || self.write.load(Ordering::Relaxed);
+        while read() != write() {}
+    }
+}
+
+fn host_is_connected(channel: &Channel) -> bool {
+    // we assume that a host is connected if we are in blocking-mode. this is what probe-run does.
+    channel.flags.load(Ordering::Relaxed) & MODE_MASK == MODE_BLOCK_IF_FULL
+}

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -28,10 +28,6 @@ use cortex_m::{interrupt, register};
 
 use crate::channel::Channel;
 
-// TODO make configurable
-// NOTE use a power of 2 for best performance
-const SIZE: usize = 1024;
-
 #[defmt::global_logger]
 struct Logger;
 
@@ -97,6 +93,10 @@ const MODE_MASK: usize = 0b11;
 const MODE_BLOCK_IF_FULL: usize = 2;
 /// Don't block if the RTT buffer is full. Truncate data to output as much as fits.
 const MODE_NON_BLOCKING_TRIM: usize = 1;
+
+// TODO make configurable
+// NOTE use a power of 2 for best performance
+const SIZE: usize = 1024;
 
 // make sure we only get shared references to the header/channel (avoid UB)
 /// # Safety

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -35,6 +35,7 @@ const SIZE: usize = 1024;
 #[defmt::global_logger]
 struct Logger;
 
+/// Global logger lock.
 static TAKEN: AtomicBool = AtomicBool::new(false);
 static INTERRUPTS_ACTIVE: AtomicBool = AtomicBool::new(false);
 static mut ENCODER: defmt::Encoder = defmt::Encoder::new();

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -20,12 +20,13 @@
 
 #![no_std]
 
-use core::{
-    ptr,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-};
+mod channel;
+
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use cortex_m::{interrupt, register};
+
+use crate::channel::Channel;
 
 // TODO make configurable
 // NOTE use a power of 2 for best performance
@@ -90,116 +91,11 @@ struct Header {
     up_channel: Channel,
 }
 
-#[repr(C)]
-struct Channel {
-    name: *const u8,
-    buffer: *mut u8,
-    size: usize,
-    write: AtomicUsize,
-    read: AtomicUsize,
-    /// Channel properties.
-    ///
-    /// Currently, only the lowest 2 bits are used to set the channel mode (see constants below).
-    flags: AtomicUsize,
-}
-
 const MODE_MASK: usize = 0b11;
 /// Block the application if the RTT buffer is full, wait for the host to read data.
 const MODE_BLOCK_IF_FULL: usize = 2;
 /// Don't block if the RTT buffer is full. Truncate data to output as much as fits.
 const MODE_NON_BLOCKING_TRIM: usize = 1;
-
-impl Channel {
-    fn write_all(&self, mut bytes: &[u8]) {
-        // the host-connection-status is only modified after RAM initialization while the device is
-        // halted, so we only need to check it once before the write-loop
-        let write = match host_is_connected(self) {
-            true => Channel::blocking_write,
-            false => Channel::nonblocking_write,
-        };
-
-        while !bytes.is_empty() {
-            let consumed = write(self, bytes);
-            if consumed != 0 {
-                bytes = &bytes[consumed..];
-            }
-        }
-    }
-
-    fn blocking_write(&self, bytes: &[u8]) -> usize {
-        if bytes.is_empty() {
-            return 0;
-        }
-
-        let read = self.read.load(Ordering::Relaxed);
-        let write = self.write.load(Ordering::Acquire);
-        let available = if read > write {
-            read - write - 1
-        } else if read == 0 {
-            SIZE - write - 1
-        } else {
-            SIZE - write
-        };
-
-        if available == 0 {
-            return 0;
-        }
-
-        let cursor = write;
-        let len = bytes.len().min(available);
-
-        unsafe {
-            if cursor + len > SIZE {
-                // split memcpy
-                let pivot = SIZE - cursor;
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), pivot);
-                ptr::copy_nonoverlapping(bytes.as_ptr().add(pivot), self.buffer, len - pivot);
-            } else {
-                // single memcpy
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), len);
-            }
-        }
-        self.write
-            .store(write.wrapping_add(len) % SIZE, Ordering::Release);
-
-        len
-    }
-
-    fn nonblocking_write(&self, bytes: &[u8]) -> usize {
-        let write = self.write.load(Ordering::Acquire);
-        let cursor = write;
-        // NOTE truncate at SIZE to avoid more than one "wrap-around" in a single `write` call
-        let len = bytes.len().min(SIZE);
-
-        unsafe {
-            if cursor + len > SIZE {
-                // split memcpy
-                let pivot = SIZE - cursor;
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), pivot);
-                ptr::copy_nonoverlapping(bytes.as_ptr().add(pivot), self.buffer, len - pivot);
-            } else {
-                // single memcpy
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), len);
-            }
-        }
-        self.write
-            .store(write.wrapping_add(len) % SIZE, Ordering::Release);
-
-        len
-    }
-
-    fn flush(&self) {
-        // return early, if host is disconnected
-        if !host_is_connected(self) {
-            return;
-        }
-
-        // busy wait, until the read- catches up with the write-pointer
-        let read = || self.read.load(Ordering::Relaxed);
-        let write = || self.write.load(Ordering::Relaxed);
-        while read() != write() {}
-    }
-}
 
 // make sure we only get shared references to the header/channel (avoid UB)
 /// # Safety
@@ -232,9 +128,4 @@ unsafe fn handle() -> &'static Channel {
     static NAME: &[u8] = b"defmt\0";
 
     &_SEGGER_RTT.up_channel
-}
-
-fn host_is_connected(channel: &Channel) -> bool {
-    // we assume that a host is connected if we are in blocking-mode. this is what probe-run does.
-    channel.flags.load(Ordering::Relaxed) & MODE_MASK == MODE_BLOCK_IF_FULL
 }


### PR DESCRIPTION
First half of #573:
*  defmt-rtt: Move struct Channel into own module
* defmt-rtt: Make fn host_is_connected a method of Channel
* defmt-rtt: Move struct Header into own module
* defmt-rtt: Rename fn handle to fn channel + mv to mod channel
