### PR TITLE
`qemu`: Allow dead code

### DIFF
--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -475,6 +475,7 @@ fn main() -> ! {
 
     // Debug adapter
     {
+        #[allow(dead_code)]
         #[derive(Clone, Copy, Debug)]
         struct S {
             x: i8,


### PR DESCRIPTION
The attributes are actually used by the adapter.