### PR TITLE
Add impl for alloc::Layout

### DIFF
--- a/src/impls/core_/alloc_.rs
+++ b/src/impls/core_/alloc_.rs
@@ -1,0 +1,14 @@
+use core::alloc;
+
+use super::*;
+
+impl Format for alloc::Layout {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(
+            fmt,
+            "Layout {{ size: {}, align: {} }}",
+            self.size(),
+            self.align()
+        );
+    }
+}

--- a/src/impls/core_/mod.rs
+++ b/src/impls/core_/mod.rs
@@ -5,6 +5,7 @@
 //! We generally keep the type parameter trait bounds in case it becomes possible to use this
 //! later, without making a backwards-incompatible change.
 
+mod alloc_;
 mod array;
 mod num;
 mod ops;


### PR DESCRIPTION
This is useful for displaying the layout argument in the `alloc_error_handler`, e.g.

```rs
#[alloc_error_handler]
fn oom(layout: Layout) -> ! {
    defmt::error!("OOM {}", layout):

    loop {
        cortex_m::asm::bkpt();
    }
}
```