### PR TITLE
Remove outdated doc "you may only call write! once"

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -42,8 +42,6 @@ use crate::{export, Formatter, Str};
 ///     }
 /// }
 /// ```
-///
-/// Note that [`write!`] can only be called once, as it consumes the [`Formatter`].
 pub trait Format {
     /// Writes the defmt representation of `self` to `fmt`.
     fn format(&self, fmt: Formatter);


### PR DESCRIPTION
SInce #508 it is possible to call it multiple times, and the result is concatenated as you'd expect.

The rest of the comment is still relevant.

Fixes #583