### PR TITLE
tweak inline attributes to remove machine code duplication

### DIFF
--- a/macros/src/attributes/global_logger.rs
+++ b/macros/src/attributes/global_logger.rs
@@ -38,21 +38,25 @@ fn codegen(strukt: &ItemStruct) -> TokenStream {
         #(#attrs)*
         #vis struct #ident;
 
+        #[inline(never)]
         #[no_mangle]
         unsafe fn _defmt_acquire()  {
             <#ident as defmt::Logger>::acquire()
         }
 
+        #[inline(never)]
         #[no_mangle]
         unsafe fn _defmt_flush()  {
             <#ident as defmt::Logger>::flush()
         }
 
+        #[inline(never)]
         #[no_mangle]
         unsafe fn _defmt_release()  {
             <#ident as defmt::Logger>::release()
         }
 
+        #[inline(never)]
         #[no_mangle]
         unsafe fn _defmt_write(bytes: &[u8])  {
             <#ident as defmt::Logger>::write(bytes)

--- a/macros/src/attributes/panic_handler.rs
+++ b/macros/src/attributes/panic_handler.rs
@@ -69,6 +69,7 @@ fn codegen(fun: &ItemFn) -> TokenStream {
     quote!(
         #(#attrs)*
         #[export_name = "_defmt_panic"]
+        #[inline(never)]
         fn #ident() -> ! {
             #block
         }

--- a/macros/src/items/timestamp.rs
+++ b/macros/src/items/timestamp.rs
@@ -34,6 +34,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
     quote!(
         const _: () = {
             #[export_name = "_defmt_timestamp"]
+            #[inline(never)]
             fn defmt_timestamp(fmt: ::defmt::Formatter<'_>) {
                 match (#(&(#formatting_exprs)),*) {
                     (#(#patterns),*) => {

--- a/src/export.rs
+++ b/src/export.rs
@@ -39,7 +39,7 @@ pub fn fetch_bytes() -> Vec<u8> {
 pub fn acquire() {}
 
 #[cfg(not(feature = "unstable-test"))]
-#[inline(never)]
+#[inline(always)]
 pub fn acquire() {
     extern "Rust" {
         fn _defmt_acquire();
@@ -51,7 +51,7 @@ pub fn acquire() {
 pub fn release() {}
 
 #[cfg(not(feature = "unstable-test"))]
-#[inline(never)]
+#[inline(always)]
 pub fn release() {
     extern "Rust" {
         fn _defmt_release();
@@ -65,7 +65,7 @@ pub fn write(bytes: &[u8]) {
 }
 
 #[cfg(not(feature = "unstable-test"))]
-#[inline(never)]
+#[inline(always)]
 pub fn write(bytes: &[u8]) {
     extern "Rust" {
         fn _defmt_write(bytes: &[u8]);
@@ -78,6 +78,7 @@ pub fn write(bytes: &[u8]) {
 pub fn timestamp(_fmt: crate::Formatter<'_>) {}
 
 #[cfg(not(feature = "unstable-test"))]
+#[inline(always)]
 pub fn timestamp(fmt: crate::Formatter<'_>) {
     extern "Rust" {
         fn _defmt_timestamp(_: crate::Formatter<'_>);
@@ -257,6 +258,7 @@ pub fn panic() -> ! {
 }
 
 #[cfg(not(feature = "unstable-test"))]
+#[inline(always)]
 pub fn panic() -> ! {
     extern "Rust" {
         fn _defmt_panic() -> !;


### PR DESCRIPTION
fixes #586 and saves 140 bytes of Flash in the example (repro case) given therein