### PR TITLE
panic-probe: use UDF instruction on nested panics

### DIFF
--- a/firmware/panic-probe/src/lib.rs
+++ b/firmware/panic-probe/src/lib.rs
@@ -47,15 +47,11 @@ mod imp {
         cortex_m::interrupt::disable();
 
         // Guard against infinite recursion, just in case.
-        if PANICKED.load(Ordering::Relaxed) {
-            loop {
-                asm::bkpt();
-            }
+        if !PANICKED.load(Ordering::Relaxed) {
+            PANICKED.store(true, Ordering::Relaxed);
+
+            print(info);
         }
-
-        PANICKED.store(true, Ordering::Relaxed);
-
-        print(info);
 
         // Trigger a `HardFault` via `udf` instruction.
 


### PR DESCRIPTION
given this code:

``` rust
use panic_probe as _;

struct S;

impl defmt::Format for S {
    fn format(&self, _: defmt::Formatter) {
        defmt::panic!()
    }
}

#[cortex_m_rt::entry]
fn main() -> ! {
    defmt::panic!("{}", S)
}
```

before this PR:
``` console
$ cargo rb panic
(HOST) INFO  flashing program (6.66 KiB)
(HOST) INFO  success!
────────────────────────────────────────────────────────────────────────────────
────────────────────────────────────────────────────────────────────────────────
(HOST) INFO  device halted without error

$ echo $?
0
```

after this PR:

``` console
(HOST) INFO  flashing program (6.64 KiB)
(HOST) INFO  success!
────────────────────────────────────────────────────────────────────────────────
────────────────────────────────────────────────────────────────────────────────
stack backtrace:
   0: HardFaultTrampoline
      <exception entry>
   1: lib::inline::__udf
        at ./asm/inline.rs:172:5
   2: __udf
        at ./asm/lib.rs:49:17
   3: cortex_m::asm::udf
        at /home/japaric/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.3/src/asm.rs:43:5
   4: rust_begin_unwind
        at /home/japaric/.cargo/git/checkouts/defmt-52fbd7917982cfac/76a0478/firmware/panic-probe/src/lib.rs:72:9
   5: core::panicking::panic_fmt
        at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/panicking.rs:92:14
   6: core::panicking::panic
        at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/panicking.rs:50:5
   7: <defmt_rtt::Logger as defmt::traits::Logger>::acquire
        at /home/japaric/.cargo/git/checkouts/defmt-52fbd7917982cfac/76a0478/firmware/defmt-rtt/src/lib.rs:45:13
(..)
(HOST) ERROR the program panicked

$ echo $?
6
```
