### PR TITLE
`defmt-print`: Recover from decoding-errors

### DIFF
--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -119,7 +119,7 @@ struct BitflagsKey {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-enum Encoding {
+pub enum Encoding {
     Raw,
     Rzcobs,
 }
@@ -252,6 +252,10 @@ impl Table {
             Encoding::Raw => Box::new(stream::Raw::new(self)),
             Encoding::Rzcobs => Box::new(stream::Rzcobs::new(self)),
         }
+    }
+
+    pub fn encoding(&self) -> Encoding {
+        self.encoding
     }
 }
 

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -205,14 +205,15 @@ impl Table {
         elf2table::get_locations(elf, self)
     }
 
-    /// decode the data sent by the device using the previosuly stored metadata
+    /// Decode the data sent by the device using the previously stored metadata.
     ///
-    /// * bytes: contains the data sent by the device that logs.
-    ///          contains the [log string index, timestamp, optional fmt string args]
+    /// * `bytes`
+    ///   * contains the data sent by the device that logs.
+    ///   * contains the [log string index, timestamp, optional fmt string args]
     pub fn decode<'t>(
         &'t self,
         mut bytes: &[u8],
-    ) -> Result<(Frame<'t>, /*consumed: */ usize), DecodeError> {
+    ) -> Result<(Frame<'t>, /* consumed: */ usize), DecodeError> {
         let len = bytes.len();
         let index = bytes.read_u16::<LE>()? as u64;
 

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -138,7 +138,7 @@ impl FromStr for Encoding {
 }
 
 impl Encoding {
-    pub const fn recoverable(&self) -> bool {
+    pub const fn can_recover(&self) -> bool {
         match self {
             Encoding::Raw => false,
             Encoding::Rzcobs => true,

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -119,6 +119,7 @@ struct BitflagsKey {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Encoding {
     Raw,
     Rzcobs,
@@ -132,6 +133,15 @@ impl FromStr for Encoding {
             "raw" => Ok(Encoding::Raw),
             "rzcobs" => Ok(Encoding::Rzcobs),
             _ => anyhow::bail!("Unknown defmt encoding '{}' specified. This is a bug.", s),
+        }
+    }
+}
+
+impl Encoding {
+    pub const fn recoverable(&self) -> bool {
+        match self {
+            Encoding::Raw => false,
+            Encoding::Rzcobs => true,
         }
     }
 }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -65,15 +65,8 @@ fn main() -> anyhow::Result<()> {
         loop {
             match table.decode(&frames) {
                 Ok((frame, consumed)) => {
-                    let (file, line, mod_path) = obtain_location_info(&locs, &frame, &current_dir);
-
-                    // Forward the defmt frame to our logger.
-                    defmt_decoder::log::log_defmt(
-                        &frame,
-                        file.as_deref(),
-                        line,
-                        mod_path.as_deref(),
-                    );
+                    let location_info = obtain_location_info(&locs, &frame, &current_dir);
+                    forward_defmt_frame_to_logger(&frame, location_info);
 
                     let num_frames = frames.len();
                     frames.rotate_left(consumed);
@@ -89,11 +82,13 @@ fn main() -> anyhow::Result<()> {
     }
 }
 
+type LocationInfo = (Option<String>, Option<u32>, Option<String>);
+
 fn obtain_location_info(
     locs: &Option<Locations>,
     frame: &Frame,
     current_dir: &PathBuf,
-) -> (Option<String>, Option<u32>, Option<String>) {
+) -> LocationInfo {
     let (mut file, mut line, mut mod_path) = (None, None, None);
 
     // NOTE(`[]` indexing) all indices in `table` have been verified to exist in the `locs` map
@@ -112,6 +107,11 @@ fn obtain_location_info(
     }
 
     (file, line, mod_path)
+}
+
+fn forward_defmt_frame_to_logger(frame: &Frame, location_info: LocationInfo) {
+    let (file, line, mod_path) = location_info;
+    defmt_decoder::log::log_defmt(&frame, file.as_deref(), line, mod_path.as_deref());
 }
 
 /// Report version from Cargo.toml _(e.g. "0.1.4")_ and supported `defmt`-versions.

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -1,7 +1,7 @@
 use std::{
     env, fs,
     io::{self, Read},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use anyhow::anyhow;
@@ -81,7 +81,12 @@ fn main() -> anyhow::Result<()> {
 
 type LocationInfo = (Option<String>, Option<u32>, Option<String>);
 
-fn location_info(locs: &Option<Locations>, frame: &Frame, current_dir: &PathBuf) -> LocationInfo {
+fn forward_to_logger(frame: &Frame, location_info: LocationInfo) {
+    let (file, line, mod_path) = location_info;
+    defmt_decoder::log::log_defmt(frame, file.as_deref(), line, mod_path.as_deref());
+}
+
+fn location_info(locs: &Option<Locations>, frame: &Frame, current_dir: &Path) -> LocationInfo {
     let (mut file, mut line, mut mod_path) = (None, None, None);
 
     // NOTE(`[]` indexing) all indices in `table` have been verified to exist in the `locs` map
@@ -100,11 +105,6 @@ fn location_info(locs: &Option<Locations>, frame: &Frame, current_dir: &PathBuf)
     }
 
     (file, line, mod_path)
-}
-
-fn forward_to_logger(frame: &Frame, location_info: LocationInfo) {
-    let (file, line, mod_path) = location_info;
-    defmt_decoder::log::log_defmt(&frame, file.as_deref(), line, mod_path.as_deref());
 }
 
 /// Report version from Cargo.toml _(e.g. "0.1.4")_ and supported `defmt`-versions.

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use defmt_decoder::{DecodeError, Encoding, Frame, Locations, Table};
+use defmt_decoder::{DecodeError, Frame, Locations, Table};
 use structopt::StructOpt;
 
 /// Prints defmt-encoded logs to stdout

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
             match stream_decoder.decode() {
                 Ok(frame) => forward_to_logger(&frame, location_info(&locs, &frame, &current_dir)),
                 Err(DecodeError::UnexpectedEof) => break,
-                Err(DecodeError::Malformed) => match table.encoding().recoverable() {
+                Err(DecodeError::Malformed) => match table.encoding().can_recover() {
                     // if recovery is impossible, abort
                     false => return Err(DecodeError::Malformed.into()),
                     // if recovery is possible, skip the current frame and continue with new data


### PR DESCRIPTION
This PR uses the new `StreamDecoder`-API in `defmt-print` and utilizes it to recover from decoding errors.

Fixes #559 