### PR TITLE
`defmt-print`: Log if malformed frame gets skipped

### DIFF
--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -15,6 +15,9 @@ struct Opts {
     #[structopt(short, parse(from_os_str), required_unless_one(&["version"]))]
     elf: Option<PathBuf>,
 
+    #[structopt(long)]
+    show_skipped_frames: bool,
+
     #[structopt(short, long)]
     verbose: bool,
 
@@ -27,6 +30,7 @@ const READ_BUFFER_SIZE: usize = 1024;
 fn main() -> anyhow::Result<()> {
     let Opts {
         elf,
+        show_skipped_frames,
         verbose,
         version,
     } = Opts::from_args();
@@ -74,7 +78,10 @@ fn main() -> anyhow::Result<()> {
                     false => return Err(DecodeError::Malformed.into()),
                     // if recovery is possible, skip the current frame and continue with new data
                     true => {
-                        log::warn!("malformed frame skipped");
+                        if show_skipped_frames || verbose {
+                            println!("(HOST) malformed frame skipped");
+                            println!("└─ {} @ {}:{}", env!("CARGO_PKG_NAME"), file!(), line!());
+                        }
                         continue;
                     }
                 },


### PR DESCRIPTION
Also add `--verbose`-flag to also show non-defmt logs.

Fixes #609

## Example

```
❯ bat defmt-frames | cargo run -- -e hello -v
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `/home/urhengulas/Documents/github.com/knurling-rs/defmt/target/debug/defmt-print -e hello -v`
0 INFO  Lorem Ipsum is simply dummy text
└─ hello::__cortex_m_rt_main @ /home/urhengulas/Documents/github.com/knurling-rs/defmt-app/src/bin/hello.rs:8
1 INFO  of the printing and typesetting 
└─ hello::__cortex_m_rt_main @ /home/urhengulas/Documents/github.com/knurling-rs/defmt-app/src/bin/hello.rs:9
2 INFO  industry. Lorem Ipsum has been the 
└─ hello::__cortex_m_rt_main @ /home/urhengulas/Documents/github.com/knurling-rs/defmt-app/src/bin/hello.rs:10
(HOST) WARN  malformed frame skipped
└─ defmt_print @ print/src/main.rs:79
4 INFO  since the 1500s, when an unknown printer 
└─ hello::__cortex_m_rt_main @ /home/urhengulas/Documents/github.com/knurling-rs/defmt-app/src/bin/hello.rs:12
5 INFO  took a galley of type and scrambled it to 
└─ hello::__cortex_m_rt_main @ /home/urhengulas/Documents/github.com/knurling-rs/defmt-app/src/bin/hello.rs:13
6 INFO  make a type specimen book.
```