### PR TITLE
`xtask`:  Run rustfmt and clippy also in `firmware/`

### DIFF
--- a/firmware/qemu/src/bin/dbg.rs
+++ b/firmware/qemu/src/bin/dbg.rs
@@ -11,9 +11,11 @@ use defmt_semihosting as _; // global logger
 fn main() -> ! {
     // return value
     let x: i32 = 42;
+    #[allow(clippy::double_parens)]
     foo(dbg!(x + 1));
 
     // dbg! in log statement
+    #[allow(clippy::double_parens)]
     defmt::info!("the answer is {}", dbg!(x - 1));
 
     // dbg! with multiple arguments
@@ -23,6 +25,7 @@ fn main() -> ! {
     let _: () = dbg!();
 
     // dbg! with trailing comma
+    #[allow(clippy::double_parens)]
     foo(dbg!(x,));
 
     loop {

--- a/firmware/qemu/src/bin/defmt-test.rs
+++ b/firmware/qemu/src/bin/defmt-test.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::AtomicBool;
 
 use defmt_semihosting as _; // global logger
 
@@ -40,7 +40,7 @@ mod tests {
     }
 
     #[test]
-    fn assert_true() -> () {
+    fn assert_true() {
         assert!(true);
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -402,14 +402,13 @@ fn test_book() {
 
 fn test_lint() {
     println!("🧪 lint");
-    do_test(|| run_command("cargo", &["clean"], None, &[]), "lint");
-    do_test(
-        || run_command("cargo", &["fmt", "--all", "--", "--check"], None, &[]),
-        "lint",
-    );
 
-    do_test(
-        || run_command("cargo", &["clippy", "--workspace"], None, &[]),
-        "lint",
-    );
+    for cwd in [None, Some("firmware")] {
+        do_test(|| run_command("cargo", &["clean"], cwd, &[]), "lint");
+        do_test(
+            || run_command("cargo", &["fmt", "--", "--check"], cwd, &[]),
+            "lint",
+        );
+        do_test(|| run_command("cargo", &["clippy"], cwd, &[]), "lint");
+    }
 }


### PR DESCRIPTION
So far the linting step of our CI only checked the host crates and not the firmware ones. This PR fixes that.

**TODO**
- [ ] fix "error: language item required, but not found: `eh_personality`"
- [ ] fix "error: `#[panic_handler]` function required, but not found"