### PR TITLE
Fix error message  in case of version-mismatch

### DIFF
--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -220,7 +220,7 @@ fn check_version(version: &str) -> Result<(), String> {
     if version != DEFMT_VERSION {
         let msg = format!(
             "defmt wire format version mismatch: firmware is using {}, `probe-run` supports {}\nsuggestion: `cargo install` a different version of `probe-run` that supports defmt {}",
-            version, DEFMT_VERSION, DEFMT_VERSION
+            version, DEFMT_VERSION, version
         );
 
         return Err(msg);


### PR DESCRIPTION
Make the error message more meaningful. 

Currently it tells you probe-run supports defmt X while the firmware supports defmt Y, which is reasonable. But the substitution then tells you to install a version of probe-run that supports X (the version you're already using), which is contradictory, since Y (firmware supported version) is the real version you need to install for.