### PR TITLE
fix #628

### DIFF
--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -12,5 +12,4 @@ version = "0.3.0"
 
 [dependencies]
 cortex-m = "0.7"
-konst = "0.2"
 defmt = { version = "0.3", path = "../../defmt" }

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -12,4 +12,5 @@ version = "0.3.0"
 
 [dependencies]
 cortex-m = "0.7"
+konst = "0.2"
 defmt = { version = "0.3", path = "../../defmt" }

--- a/firmware/defmt-rtt/README.md
+++ b/firmware/defmt-rtt/README.md
@@ -14,9 +14,7 @@ For more details about the framework check the book at https://defmt.ferrous-sys
 
 ## Customization
 
-The RTT buffer size (default: 1024) can be configured with the `DEFMT_RTT_BUFFER_SIZE` environment variable. 
-- use a power of 2 for best performance
-- caution: the `sccache` compiler cache is not supported because [it does not honor environment variables](https://github.com/mozilla/sccache/blob/master/docs/Rust.md).
+The RTT buffer size (default: 1024) can be configured with the `DEFMT_RTT_BUFFER_SIZE` environment variable in a tight memory situation. Use a power of 2 for best performance.
 
 ## Support
 

--- a/firmware/defmt-rtt/README.md
+++ b/firmware/defmt-rtt/README.md
@@ -12,6 +12,12 @@ The fastest way to get started with `defmt` is to use our [app-template] to set 
 
 For more details about the framework check the book at https://defmt.ferrous-systems.com
 
+## Customization
+
+The RTT buffer size (default: 1024) can be configured with the `DEFMT_RTT_BUFFER_SIZE` environment variable. 
+- use a power of 2 for best performance
+- caution: the `sccache` compiler cache is not supported because [it does not honor environment variables](https://github.com/mozilla/sccache/blob/master/docs/Rust.md).
+
 ## Support
 
 `defmt-rtt` is part of the [Knurling] project, [Ferrous Systems]' effort at

--- a/firmware/defmt-rtt/build.rs
+++ b/firmware/defmt-rtt/build.rs
@@ -1,18 +1,16 @@
+use std::{env, path::PathBuf};
+
 fn main() {
     println!("cargo:rerun-if-env-changed=DEFMT_RTT_BUFFER_SIZE");
 
-    let size = option_env!("DEFMT_RTT_BUFFER_SIZE")
-        .map(|s| s.parse().ok())
-        .flatten()
+    let size = env::var("DEFMT_RTT_BUFFER_SIZE")
+        .map(|s| {
+            s.parse()
+                .expect("coult not parse DEFMT_RTT_BUFFER_SIZE as usize")
+        })
         .unwrap_or(1024_usize);
 
-    let non_power_of_two = (size & (size - 1)) != 0;
-
-    if non_power_of_two {
-        println!("cargo:warning=RTT buffer size of {} is not a power of two, performance will be degraded.", size)
-    }
-
-    let out_dir_path = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let out_dir_path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let out_file_path = out_dir_path.join("consts.rs");
 
     std::fs::write(

--- a/firmware/defmt-rtt/build.rs
+++ b/firmware/defmt-rtt/build.rs
@@ -1,0 +1,23 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=DEFMT_RTT_BUFFER_SIZE");
+
+    let size = option_env!("DEFMT_RTT_BUFFER_SIZE")
+        .map(|s| s.parse().ok())
+        .flatten()
+        .unwrap_or(1024_usize);
+
+    let non_power_of_two = (size & (size - 1)) != 0;
+
+    if non_power_of_two {
+        println!("cargo:warning=RTT buffer size of {} is not a power of two, performance will be degraded.", size)
+    }
+
+    let out_dir_path = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let out_file_path = out_dir_path.join("consts.rs");
+
+    std::fs::write(
+        out_file_path,
+        format!("pub(crate) const BUF_SIZE: usize = {};", size),
+    )
+    .unwrap();
+}

--- a/firmware/defmt-rtt/build.rs
+++ b/firmware/defmt-rtt/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let size = env::var("DEFMT_RTT_BUFFER_SIZE")
         .map(|s| {
             s.parse()
-                .expect("coult not parse DEFMT_RTT_BUFFER_SIZE as usize")
+                .expect("could not parse DEFMT_RTT_BUFFER_SIZE as usize")
         })
         .unwrap_or(1024_usize);
 

--- a/firmware/defmt-rtt/src/consts.rs
+++ b/firmware/defmt-rtt/src/consts.rs
@@ -1,0 +1,2 @@
+// see `build.rs` for contents
+include!(concat!(env!("OUT_DIR"), "/consts.rs"));

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -30,7 +30,7 @@ use crate::channel::Channel;
 
 mod consts;
 
-/// RTT buffer size. Default: 1024; can be customized by setting `DEFMT_RTT_BUFFER_SIZE`.
+/// RTT buffer size. Default: 1024; can be customized by setting the `DEFMT_RTT_BUFFER_SIZE` environment variable.
 /// Use a power of 2 for best performance.
 use crate::consts::BUF_SIZE;
 

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -94,9 +94,19 @@ const MODE_BLOCK_IF_FULL: usize = 2;
 /// Don't block if the RTT buffer is full. Truncate data to output as much as fits.
 const MODE_NON_BLOCKING_TRIM: usize = 1;
 
-// TODO make configurable
-// NOTE use a power of 2 for best performance
-const SIZE: usize = 1024;
+// buffer size. Default: 1024; can be customized by setting `DEFMT_RTT_BUFFER_SIZE`
+// NOTE
+// - use a power of 2 for best performance
+// - `sccache` does not honor environment variables, so unset `RUSTC_WRAPPER` when customizing.
+const SIZE: usize = size();
+const fn size() -> usize {
+    if let Some(size_s) = option_env!("DEFMT_RTT_BUFFER_SIZE") {
+        if let Ok(size) = konst::primitive::parse_usize(size_s) {
+            return size;
+        }
+    };
+    1024
+}
 
 // make sure we only get shared references to the header/channel (avoid UB)
 /// # Safety


### PR DESCRIPTION
open questions:

also make this honor the env var?
```rust
// print/src/main.rs:28
const READ_BUFFER_SIZE: usize = 1024;
```
(answered: no, irrelevant)

---

add some hints in the app template?
(answered: yes)