### PR TITLE
`book`: Run code blocks if possible and unify style

### DIFF
--- a/book/src/duplicates.md
+++ b/book/src/duplicates.md
@@ -17,7 +17,7 @@ This produces two symbols with the name "X".
 How can this occur in logging?
 The user may write:
 
-``` rust,no_run,noplayground
+``` rust
 # extern crate defmt;
 fn foo() {
     defmt::info!("foo started ..");

--- a/book/src/filtering.md
+++ b/book/src/filtering.md
@@ -35,7 +35,9 @@ $ DEFMT_LOG=warn cargo run --bin app
 Enabling a logging level also enables higher severity logging levels.
 For example,
 
-``` rust,ignore
+``` rust
+# extern crate defmt;
+#
 defmt::trace!("trace");
 defmt::debug!("debug");
 defmt::info!("info");
@@ -62,7 +64,8 @@ A different logging level filter can be applied to different modules using *logg
 A logging directive has the syntax `krate::module::path=level`.
 `DEFMT_LOG` can contain a list of comma separated logging directives.
 
-``` rust,ignore
+``` rust
+# extern crate defmt;
 // crate-name = app
 
 mod important {
@@ -130,7 +133,8 @@ my-package # package-name = my-package
 
 Logging directives that appear later in the list override preceding instances.
 
-``` rust,ignore
+``` rust
+# extern crate defmt;
 // crate-name = app
 pub fn function() {
     defmt::trace!("root trace");

--- a/book/src/global-logger.md
+++ b/book/src/global-logger.md
@@ -13,7 +13,7 @@ The `global_logger` interface comprises the trait `Logger` and the `#[global_log
 
 `Logger` specifies how to acquire and release a handle to a global logger, as well as how the data is put on the wire.
 
-```rust
+``` rust
 # extern crate defmt;
 # struct Logger;
 #
@@ -47,7 +47,7 @@ See the API documentation for more details about the safety requirements of the 
 `#[global_logger]` must be used on a *unit* struct, a struct with no fields, which must implement the `Logger` trait.
 It's recommended that this struct is kept private.
 
-```rust
+``` rust
 # extern crate defmt;
 #
 #[defmt::global_logger]

--- a/book/src/json-output.md
+++ b/book/src/json-output.md
@@ -87,7 +87,7 @@ If you wish to deserialize the entire data back into a Rust program, you will ne
  
 You can use all of this together with `serde_json` like following:
 
-```rust
+``` rust
 # extern crate defmt_json_schema;
 # extern crate serde_json;
 

--- a/book/src/panic.md
+++ b/book/src/panic.md
@@ -19,13 +19,18 @@ For example:
 
 <!-- NOTE(ignore) we can't compile this test because the `panic_handler` defined here collides with the one in `std` -->
 
-```rust, ignore
+``` rust,ignore
 #[panic_handler] // built-in ("core") attribute
 fn core_panic(info: &core::panic::PanicInfo) -> ! {
     print(info); // e.g. using RTT
     reset()
 }
+```
 
+``` rust
+# extern crate defmt;
+# fn reset() -> ! { todo!() }
+#
 #[defmt::panic_handler] // defmt's attribute
 fn defmt_panic() -> ! {
     // leave out the printing part here

--- a/book/src/ser-format.md
+++ b/book/src/ser-format.md
@@ -4,7 +4,7 @@ The untyped argument (`=?`) requires one level of indirection during serializati
 
 First let's see how a primitive implements the `Format` trait:
 
-```rust
+``` rust
 # extern crate defmt;
 # macro_rules! internp { ($l:literal) => { defmt::export::make_istr(0) } }
 # trait Format { fn format(&self, fmt: defmt::Formatter); }
@@ -25,7 +25,7 @@ In general, `write!` can use `{=?}` so `Format` nesting is possible.
 
 Now let's look into a log invocation:
 
-```rust
+``` rust
 # extern crate defmt;
 defmt::error!("The answer is {=?}!", 42u8);
 // on the wire: [2, 1, 42]

--- a/book/src/ser-integers.md
+++ b/book/src/ser-integers.md
@@ -3,7 +3,7 @@
 Integers will be serialized in little endian order using `to_le_bytes()`.
 `usize` and `isize` values will be subject to LEB128 compression.
 
-```rust
+``` rust
 # extern crate defmt;
 defmt::error!("The answer is {=i16}!", 300);
 // on the wire: [3, 44, 1]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -396,12 +396,10 @@ fn test_book() {
                     "build",
                     "-p",
                     "defmt",
+                    "-p",
+                    "defmt-decoder",
                     "--features",
                     "unstable-test",
-                    "-p",
-                    "serde_json",
-                    "-p",
-                    "defmt-json-schema",
                 ],
                 None,
                 &[],
@@ -411,10 +409,25 @@ fn test_book() {
     );
 
     do_test(
+        || run_command("cargo", &["build", "-p", "cortex-m"], Some("firmware"), &[]),
+        "book",
+    );
+
+    do_test(
         || {
             run_command(
                 "mdbook",
-                &["test", "-L", "../target/debug", "-L", "../target/debug/deps"],
+                &[
+                    "test",
+                    "-L",
+                    "../target/debug",
+                    "-L",
+                    "../target/debug/deps",
+                    "-L",
+                    "../firmware/target/debug",
+                    "-L",
+                    "../firmware/target/debug/deps",
+                ],
                 Some("book"),
                 // logging macros need this but mdbook, not being Cargo, doesn't set the env var so
                 // we use a dummy value


### PR DESCRIPTION
Few cleanups for the defmt book
- unify "\`\`\`rust" and "\`\`\` rust` to the latter
- remove `ignore` attributes from some code blocks, which can be compiled
- add `cortex-m` to library search path; therefore we don't need to mock it anymore