### PR TITLE
`decoder`: Fix missing space in println frames

### DIFF
--- a/decoder/src/log/pretty_logger.rs
+++ b/decoder/src/log/pretty_logger.rs
@@ -111,7 +111,12 @@ impl PrettyLogger {
     }
 
     fn print_println_record(record: DefmtRecord, mut sink: StdoutLock) {
-        writeln!(&mut sink, "{}{}", record.timestamp(), record.args()).ok();
+        let timestamp = match record.timestamp().is_empty() {
+            true => record.timestamp().to_string(),
+            false => format!("{} ", record.timestamp()),
+        };
+
+        writeln!(&mut sink, "{}{}", timestamp, record.args()).ok();
         print_location(
             &mut sink,
             record.file(),


### PR DESCRIPTION
It seems that "past me" (#651) has introduced a regression, namely that there is no space in-between timestamp and log messages for println frames.

Before (how it should be):
```text
0 Hello, world!
└─ hello::__cortex_m_rt_main @ src/bin/hello.rs:8
```
After (how it currently is):
```text
0Hello, world!
└─ hello::__cortex_m_rt_main @ src/bin/hello.rs:8
```

This PR fixes that.