### PR TITLE
`snapshot-tests`: Add tests for cell types

### DIFF
--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -150,4 +150,9 @@ INFO ccbbaadd
 INFO log data: 43981
 INFO flush! 🚽
 INFO log more data! 🎉
+INFO Cell: Cell { value: 43981 })
+INFO RefCell: RefCell { value: 43981 }
+INFO borrowed RefCell: RefCell { value: <borrowed> }
+INFO BorrowMutError: BorrowMutError
+INFO BorrowError: BorrowError
 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -716,6 +716,22 @@ fn main() -> ! {
     defmt::flush();
     defmt::info!("log more data! 🎉");
 
+    {
+        use core::cell;
+
+        let a = cell::Cell::new(0xABCD);
+        let b = cell::RefCell::new(0xABCD);
+        defmt::info!("Cell: {}", a);
+        defmt::info!("RefCell: {}", b);
+
+        let _c = b.try_borrow_mut().unwrap();
+        let d = b.try_borrow_mut().unwrap_err();
+        let e = b.try_borrow().unwrap_err();
+        defmt::info!("borrowed RefCell: {}", b);
+        defmt::info!("BorrowMutError: {}", d);
+        defmt::info!("BorrowError: {}", e);
+    }
+
     defmt::info!("QEMU test finished!");
 
     loop {


### PR DESCRIPTION
Follow-up to #656, which add snapshot tests for the new `defmt::Format` implementations.