### PR TITLE
Add attributes for Format derive to use Debug2Format on specific fields

### DIFF
--- a/book/src/format.md
+++ b/book/src/format.md
@@ -83,12 +83,22 @@ When using `#[derive(Format)]` you may use the `#[defmt()]` attribute on specifi
 Example below:
 
 ``` rust
+# extern crate defmt;
+# use defmt::Format;
+# mod serde_json {
+#     #[derive(Debug)]
+#     pub enum Error {}
+# }
 #[derive(Format)]
 enum Error {
     Serde(#[defmt(Debug2Format)] serde_json::Error),
     ResponseTooLarge,
 }
 
+# struct Celsius();
+# impl std::fmt::Display for Celsius {
+#     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { Ok(()) }
+# }
 #[derive(Format)]
 struct Reading {
     #[defmt(Display2Format)]

--- a/book/src/format.md
+++ b/book/src/format.md
@@ -79,5 +79,22 @@ If you quickly want to get some code running and do not care about it being effi
 
 Note that this always uses `{:?}` to format the contained value, meaning that any provided defmt display hints will be ignored.
 
+When using `#[derive(Format)]` you may use the `#[defmt()]` attribute on specific fields to use these adapter types.
+Example below:
+
+``` rust
+#[derive(Format)]
+enum Error {
+    Serde(#[defmt(Debug2Format)] serde_json::Error),
+    ResponseTooLarge,
+}
+
+#[derive(Format)]
+struct Reading {
+    #[defmt(Display2Format)]
+    temperature: Celsius,
+}
+```
+
 [`Display2Format`]: https://docs.rs/defmt/*/defmt/struct.Display2Format.html
 [`Debug2Format`]: https://docs.rs/defmt/*/defmt/struct.Debug2Format.html

--- a/defmt/tests/encode.rs
+++ b/defmt/tests/encode.rs
@@ -152,6 +152,63 @@ fn bitfields_assert_range_exclusive() {
 }
 
 #[test]
+fn debug_struct() {
+    #[derive(Debug)]
+    struct DebugOnly {
+        _a: i32,
+    }
+
+    #[derive(Format)]
+    struct X {
+        y: bool,
+        #[defmt(Debug2Format)]
+        d: DebugOnly,
+    }
+
+    let index = fetch_string_index();
+    check_format!(
+        &X {
+            y: false,
+            d: DebugOnly { _a: 3 }
+        },
+        [
+            index, 0b0u8, // y
+            0b1u8, 0b0u8, // Format
+            b'D', b'e', b'b', b'u', b'g', b'O', b'n', b'l', b'y', b' ', b'{', b' ', b'_', b'a',
+            b':', b' ', b'3', b' ', b'}', 0xffu8
+        ],
+    )
+}
+
+#[test]
+fn display_struct() {
+    struct DisplayOnly {}
+
+    impl std::fmt::Display for DisplayOnly {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("Display")
+        }
+    }
+
+    #[derive(Format)]
+    enum X {
+        #[allow(dead_code)]
+        Bool(bool),
+        Display(#[defmt(Display2Format)] DisplayOnly),
+    }
+
+    let index = fetch_string_index();
+    check_format!(
+        &X::Display(DisplayOnly {}),
+        [
+            index, 0b1u8, // Variant: Display
+            0b1u8, 0b0u8, // Format
+            b'D', b'i', b's', b'p', b'l', b'a', b'y', 0xffu8
+        ],
+    )
+}
+
+#[test]
 fn boolean_struct() {
     #[derive(Format)]
     struct X {

--- a/defmt/tests/encode.rs
+++ b/defmt/tests/encode.rs
@@ -152,7 +152,7 @@ fn bitfields_assert_range_exclusive() {
 }
 
 #[test]
-fn debug_struct() {
+fn debug_attr_struct() {
     #[derive(Debug)]
     struct DebugOnly {
         _a: i32,
@@ -172,20 +172,40 @@ fn debug_struct() {
             d: DebugOnly { _a: 3 }
         },
         [
-            index, 0b0u8, // y
-            0b1u8, 0b0u8, // Format
-            b'D', b'e', b'b', b'u', b'g', b'O', b'n', b'l', b'y', b' ', b'{', b' ', b'_', b'a',
-            b':', b' ', b'3', b' ', b'}', 0xffu8
+            index,         // "X {{ y: {=bool}, d: {=?} }}"
+            0b0u8,         // y
+            inc(index, 1), // DebugOnly's format string
+            b'D',          // Text of the Debug output
+            b'e',
+            b'b',
+            b'u',
+            b'g',
+            b'O',
+            b'n',
+            b'l',
+            b'y',
+            b' ',
+            b'{',
+            b' ',
+            b'_',
+            b'a',
+            b':',
+            b' ',
+            b'3',
+            b' ',
+            b'}',
+            0xffu8
         ],
     )
 }
 
 #[test]
-fn display_struct() {
+fn display_attr_enum() {
+    use std::fmt;
     struct DisplayOnly {}
 
-    impl std::fmt::Display for DisplayOnly {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl fmt::Display for DisplayOnly {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.write_str("Display")
         }
     }
@@ -201,9 +221,17 @@ fn display_struct() {
     check_format!(
         &X::Display(DisplayOnly {}),
         [
-            index, 0b1u8, // Variant: Display
-            0b1u8, 0b0u8, // Format
-            b'D', b'i', b's', b'p', b'l', b'a', b'y', 0xffu8
+            index,         // "Bool({=bool})|Display({=?})"
+            0b1u8,         // Variant: Display
+            inc(index, 1), // DisplayOnly's format string
+            b'D',          // Text of the Display output
+            b'i',
+            b's',
+            b'p',
+            b'l',
+            b'a',
+            b'y',
+            0xffu8
         ],
     )
 }
@@ -220,7 +248,7 @@ fn boolean_struct() {
     check_format!(
         &X { y: false, z: true },
         [
-            index, // "X {{ x: {=bool}, y: {=bool} }}"
+            index, // "X {{ y: {=bool}, z: {=bool} }}"
             0b0u8, // y
             0b1u8, // z
         ],
@@ -239,7 +267,7 @@ fn single_struct() {
     check_format!(
         &X { y: 1, z: 2 },
         [
-            index, // "X {{ x: {=u8}, y: {=u16} }}"
+            index, // "X {{ y: {=u8}, z: {=u16} }}"
             1u8,   // x
             2u8,   // y.low
             0u8,   // y.high

--- a/defmt/tests/ui/derive-empty-attr.rs
+++ b/defmt/tests/ui/derive-empty-attr.rs
@@ -1,0 +1,7 @@
+#[derive(defmt::Format)]
+struct S {
+    #[defmt()]
+    f: bool,
+}
+
+fn main() {}

--- a/defmt/tests/ui/derive-empty-attr.stderr
+++ b/defmt/tests/ui/derive-empty-attr.stderr
@@ -1,0 +1,5 @@
+error: expected 1 attribute argument
+ --> $DIR/derive-empty-attr.rs:3:7
+  |
+3 |     #[defmt()]
+  |       ^^^^^^^

--- a/defmt/tests/ui/derive-invalid-attr-arg.rs
+++ b/defmt/tests/ui/derive-invalid-attr-arg.rs
@@ -1,0 +1,7 @@
+#[derive(defmt::Format)]
+struct S {
+    #[defmt(FooBar)]
+    f: bool,
+}
+
+fn main() {}

--- a/defmt/tests/ui/derive-invalid-attr-arg.stderr
+++ b/defmt/tests/ui/derive-invalid-attr-arg.stderr
@@ -1,0 +1,5 @@
+error: expected `Debug2Format` or `Display2Format`
+ --> $DIR/derive-invalid-attr-arg.rs:3:13
+  |
+3 |     #[defmt(FooBar)]
+  |             ^^^^^^

--- a/defmt/tests/ui/derive-multi-attr.rs
+++ b/defmt/tests/ui/derive-multi-attr.rs
@@ -1,0 +1,8 @@
+#[derive(defmt::Format)]
+struct S {
+    #[defmt(Debug2Format)]
+    #[defmt()]
+    f: bool,
+}
+
+fn main() {}

--- a/defmt/tests/ui/derive-multi-attr.stderr
+++ b/defmt/tests/ui/derive-multi-attr.stderr
@@ -1,0 +1,7 @@
+error: multiple `defmt` attributes not supported
+ --> $DIR/derive-multi-attr.rs:3:5
+  |
+3 | /     #[defmt(Debug2Format)]
+4 | |     #[defmt()]
+5 | |     f: bool,
+  | |___________^

--- a/macros/src/derives/format/codegen.rs
+++ b/macros/src/derives/format/codegen.rs
@@ -14,13 +14,13 @@ pub(crate) struct EncodeData {
     pub(crate) stmts: Vec<TokenStream2>,
 }
 
-pub(crate) fn encode_struct_data(ident: &Ident, data: &DataStruct) -> EncodeData {
+pub(crate) fn encode_struct_data(ident: &Ident, data: &DataStruct) -> syn::Result<EncodeData> {
     let mut format_string = ident.to_string();
     let mut stmts = vec![];
     let mut field_patterns = vec![];
 
     let encode_fields_stmts =
-        fields::codegen(&data.fields, &mut format_string, &mut field_patterns);
+        fields::codegen(&data.fields, &mut format_string, &mut field_patterns)?;
 
     stmts.push(quote!(match self {
         Self { #(#field_patterns),* } => {
@@ -29,7 +29,7 @@ pub(crate) fn encode_struct_data(ident: &Ident, data: &DataStruct) -> EncodeData
     }));
 
     let format_tag = construct::interned_string(&format_string, "derived", false);
-    EncodeData { format_tag, stmts }
+    Ok(EncodeData { format_tag, stmts })
 }
 
 pub(crate) struct Generics<'a> {

--- a/macros/src/derives/format/codegen/enum_data.rs
+++ b/macros/src/derives/format/codegen/enum_data.rs
@@ -7,12 +7,12 @@ use crate::construct;
 
 use super::EncodeData;
 
-pub(crate) fn encode(ident: &Ident, data: &DataEnum) -> EncodeData {
+pub(crate) fn encode(ident: &Ident, data: &DataEnum) -> syn::Result<EncodeData> {
     if data.variants.is_empty() {
-        return EncodeData {
+        return Ok(EncodeData {
             stmts: vec![quote!(match *self {})],
             format_tag: construct::interned_string("!", "derived", false),
-        };
+        });
     }
 
     let mut format_string = String::new();
@@ -33,7 +33,7 @@ pub(crate) fn encode(ident: &Ident, data: &DataEnum) -> EncodeData {
 
         let mut field_patterns = vec![];
         let encode_fields_stmts =
-            super::fields::codegen(&variant.fields, &mut format_string, &mut field_patterns);
+            super::fields::codegen(&variant.fields, &mut format_string, &mut field_patterns)?;
         let pattern = quote!( { #(#field_patterns),* } );
 
         let encode_discriminant_stmt = discriminant_encoder.encode(index);
@@ -51,7 +51,7 @@ pub(crate) fn encode(ident: &Ident, data: &DataEnum) -> EncodeData {
         #(#match_arms)*
     })];
 
-    EncodeData { format_tag, stmts }
+    Ok(EncodeData { format_tag, stmts })
 }
 
 enum DiscriminantEncoder {

--- a/macros/src/derives/format/codegen/fields.rs
+++ b/macros/src/derives/format/codegen/fields.rs
@@ -38,7 +38,10 @@ pub(crate) fn codegen(
 
         let format_opt = get_defmt_format_option(field)?;
         let ty = as_native_type(&field.ty).unwrap_or_else(|| consts::TYPE_FORMAT.to_string());
-        let ident = field.ident.clone().unwrap_or_else(|| format_ident!("arg{}", index));
+        let ident = field
+            .ident
+            .clone()
+            .unwrap_or_else(|| format_ident!("arg{}", index));
 
         if let Some(FormatOption::Debug2Format) = format_opt {
             stmts.push(quote!(defmt::export::fmt(&defmt::Debug2Format(&#ident))));
@@ -106,7 +109,7 @@ fn get_defmt_format_option(field: &Field) -> syn::Result<Option<FormatOption>> {
     };
     if args.len() != 1 {
         return Err(syn::Error::new_spanned(
-            args,
+            attr,
             "expected 1 attribute argument",
         ));
     }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -34,7 +34,7 @@ pub fn panic_handler(args: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /* # Derives */
-#[proc_macro_derive(Format)]
+#[proc_macro_derive(Format, attributes(defmt))]
 #[proc_macro_error]
 pub fn format(input: TokenStream) -> TokenStream {
     derives::format::expand(input)


### PR DESCRIPTION
I often have structs or enums where most fields impl `Format`, but a few third-party types do not. It is a pain to have to manually impl `Format` for the whole type when only one field doesn't work. I added an attribute that lets you override specific fields to use `Debug2Format` or `Display2Format` like so:

```rust
#[derive(defmt::Format)]
pub enum Error {
    Serial(serial::Error),
    Timeout(us_timer::TimeoutError),
    Serde(#[defmt(Debug2Format)] serde_json::Error),
    ResponseTooLarge,
}
```