### PR TITLE
make defmt::flush an no-operation when unstable-test feature is enabled

### DIFF
--- a/defmt/src/lib.rs
+++ b/defmt/src/lib.rs
@@ -375,19 +375,29 @@ fn default_panic() -> ! {
 /// This calls the method `flush` of the used "global [`Logger`]". The logger is likely provided by
 /// [`defmt-rtt`](https://crates.io/crates/defmt-rtt) or [`defmt-itm`](https://crates.io/crates/defmt-itm).
 pub fn flush() {
-    extern "Rust" {
-        fn _defmt_acquire();
-        fn _defmt_flush();
-        fn _defmt_release();
-    }
-    // SAFETY:
-    // * we call these function in the correct order: first acquire the lock, then flush and
-    //   finally release the lock
-    // * these function should be provided by the macro `#[global_logger]` and therefore
-    //   trustworthy to call through FFI-bounds
-    unsafe {
-        _defmt_acquire();
-        _defmt_flush();
-        _defmt_release()
+    match () {
+        #[cfg(feature = "unstable-test")]
+        () => {
+            // no-op when run on host
+        }
+
+        #[cfg(not(feature = "unstable-test"))]
+        () => {
+            extern "Rust" {
+                fn _defmt_acquire();
+                fn _defmt_flush();
+                fn _defmt_release();
+            }
+            // SAFETY:
+            // * we call these function in the correct order: first acquire the lock, then flush and
+            //   finally release the lock
+            // * these function should be provided by the macro `#[global_logger]` and therefore
+            //   trustworthy to call through FFI-bounds
+            unsafe {
+                _defmt_acquire();
+                _defmt_flush();
+                _defmt_release()
+            }
+        }
     }
 }


### PR DESCRIPTION
that feature is only enabled when running the test suite

defmt::flush was causing linker errors ("undefined symbol _defmt_acquire") on Windows with Rust
1.59.0+ when defmt is built with 'unstable-test' enabled. the linker errors are not observed in
binary builds that link to defmt when the feature is disabled

this commit removes the symbol dependencies to _defmt_acquire, etc. when 'unstable-test' is enabled