### PR TITLE
bump crate versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2022-03-10
+
 ### Added
 
 - [#662]: `#[derive(Format)]` now accepts attribute fields to format fields using the `Debug2Format` adapter instead of a `Format` implementation.
@@ -454,7 +456,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.1...main
+[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.2...main
+[v0.3.2]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.1...defmt-v0.3.2
 [v0.3.1]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.0...defmt-v0.3.1
 [v0.3.0]: https://github.com/knurling-rs/defmt/compare/defmt-v0.2.3...defmt-v0.3.0
 [v0.2.3]: https://github.com/knurling-rs/defmt/compare/defmt-v0.2.2...defmt-v0.2.3

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,10 +7,10 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
-defmt-parser = { path = "../parser", features = ["unstable"], version = "=0.3.0" }
+defmt-parser = { path = "../parser", features = ["unstable"], version = "=0.3.1" }
 byteorder = "1"
 colored = "2"
 ryu = "1"

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "0.3.0"
+version = "0.3.1"
 
 [features]
 alloc = []
@@ -23,7 +23,7 @@ alloc = []
 # Encoding feature flags. These should only be set by end-user crates, not by library crates.
 #
 # If no encoding is selected, `defmt` will assume the encoding is "don't care" and
-# will pick a default one. The current default is `encoding-rzcobs`. The default may change 
+# will pick a default one. The current default is `encoding-rzcobs`. The default may change
 # in minor releases, changing it is not considered a breaking change since all encodings
 # are guaranteed to be supported by the corresponding `defmt-decoder` version.
 

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 defmt = { version = "0.3", path = "../../defmt" }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.1"
+version = "0.3.2"
 
 [lib]
 proc-macro = true
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { path = "../parser", features = ["unstable"], version = "=0.3.0" }
+defmt-parser = { path = "../parser", features = ["unstable"], version = "=0.3.1" }
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-parser"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.0"
+version = "0.3.1"
 
 [features]
 unstable = []

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.1"
+version = "0.3.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { path = "../decoder", features = ["unstable"], version = "=0.3.1" }
+defmt-decoder = { path = "../decoder", features = ["unstable"], version = "=0.3.2" }
 log = "0.4"
 structopt = "0.3"

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { path = "../decoder", features = ["unstable"], version = "=0.3.1" }
+defmt-decoder = { path = "../decoder", features = ["unstable"], version = "=0.3.2" }


### PR DESCRIPTION
in preparation for crates.io release. release order: 
- defmt-json-schema 0.1.0
- defmt-parser 0.3.1
- defmt-decoder 0.3.2
- defmt-macros 0.3.2
- defmt-print 0.3.2
- defmt 0.3.1
- defmt-rtt 0.3.2
