### PR TITLE
--json docs + Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The fastest way to get started with `defmt` is to use our [app-template] to set 
 
 To include `defmt` in your existing project, follow our [Application Setup guide].
 
-[Application Setup guide]: https://defmt.ferrous-systems.com/setup-app.html
+[Application Setup guide]: https://defmt.ferrous-systems.com/setup.html
 
 ## MSRV
 `defmt` always compiles on the [latest `stable` rust release](https://github.com/rust-lang/rust/releases/latest). This is enforced by our CI building and testing against this version.

--- a/book/src/json-output.md
+++ b/book/src/json-output.md
@@ -71,13 +71,7 @@ Afterwards `levels.json` looks like this:
 {"data":"println","host_timestamp":1643113389707313290,"level":null,"location":{"file":"src/bin/levels.rs","line":15,"module_path":{"crate_name":"levels","modules":[],"function":"__cortex_m_rt_main"}},"target_timestamp":"4"}
 ```
 
-> 🤔: That seems convenient, but what is this schema version in the first line?
-
-It indicates the version of the json format you are using. `probe-run` will always output it as a header at the beginning of each stream of logs. We anticipate that the format will slightly change while `probe-run` and `defmt` evolve. Using this version you always know which revision is in use and can act upon that.
-
-> 🤔: What if I want formatted output?
-
-You can use `probe-run --chip some-chip --json my-elf | my-formatter`, with for example `jq` on Linux. It will give you this output.
+One use case is changing the human readable output with a piped command. 
 
 ```json
 {
@@ -85,36 +79,14 @@ You can use `probe-run --chip some-chip --json my-elf | my-formatter`, with for 
   "host_timestamp": 1647942992494142200,
   "level": null,
   "location": {
-    "file": "src/bin/hello.rs",
-    "line": 9,
-    "module_path": {
-      "crate_name": "hello",
-      "modules": [],
-      "function": "__cortex_m_rt_main"
+    //...
     }
   },
-  "target_timestamp": ""
 }
-{
-  "data": "panicked at 'P A N I C', src/bin/hello.rs:16:5",
-  "host_timestamp": 1647942992494198500,
-  "level": "ERROR",
-  "location": {
-    "file": "/home/user/.cargo/registry/src/github.com-.../panic-probe-0.3.0/src/lib.rs",
-    "line": 91,
-    "module_path": {
-      "crate_name": "panic_probe",
-      "modules": [
-        "print_defmt"
-      ],
-      "function": "print"
-    }
-  },
-  "target_timestamp": ""
-}
-
 ```
+> 🤔: That seems convenient, but what is this schema version in the first line?
 
+It indicates the version of the json format you are using. `probe-run` will always output it as a header at the beginning of each stream of logs. We anticipate that the format will slightly change while `probe-run` and `defmt` evolve. Using this version you always know which revision is in use and can act upon that.
 
 > 🤗: Sounds great!
 

--- a/book/src/json-output.md
+++ b/book/src/json-output.md
@@ -6,6 +6,9 @@ As an alternative to its human-focused output, `probe-run` offers structured JSO
 - building software on top of `probe-run`
 - storing `probe-run`'s output, in order to analyze it over time
 
+⚠️ `probe-run` v0.3.3+ is necessary to use this feature!
+
+
 ## How to use it?
 
 > 😁: Sounds great, how can I use it?
@@ -71,6 +74,47 @@ Afterwards `levels.json` looks like this:
 > 🤔: That seems convenient, but what is this schema version in the first line?
 
 It indicates the version of the json format you are using. `probe-run` will always output it as a header at the beginning of each stream of logs. We anticipate that the format will slightly change while `probe-run` and `defmt` evolve. Using this version you always know which revision is in use and can act upon that.
+
+> 🤔: What if I want formatted output?
+
+You can use `probe-run --chip some-chip --json my-elf | my-formatter`, with for example `jq` on Linux. It will give you this output.
+
+```json
+{
+  "data": "I am a PRINTLN-statement",
+  "host_timestamp": 1647942992494142200,
+  "level": null,
+  "location": {
+    "file": "src/bin/hello.rs",
+    "line": 9,
+    "module_path": {
+      "crate_name": "hello",
+      "modules": [],
+      "function": "__cortex_m_rt_main"
+    }
+  },
+  "target_timestamp": ""
+}
+{
+  "data": "panicked at 'P A N I C', src/bin/hello.rs:16:5",
+  "host_timestamp": 1647942992494198500,
+  "level": "ERROR",
+  "location": {
+    "file": "/home/user/.cargo/registry/src/github.com-.../panic-probe-0.3.0/src/lib.rs",
+    "line": 91,
+    "module_path": {
+      "crate_name": "panic_probe",
+      "modules": [
+        "print_defmt"
+      ],
+      "function": "print"
+    }
+  },
+  "target_timestamp": ""
+}
+
+```
+
 
 > 🤗: Sounds great!
 

--- a/book/src/json-output.md
+++ b/book/src/json-output.md
@@ -70,37 +70,24 @@ Afterwards `levels.json` looks like this:
 {"data":"error","host_timestamp":1643113389707306961,"level":"ERROR","location":{"file":"src/bin/levels.rs","line":14,"module_path":{"crate_name":"levels","modules":[],"function":"__cortex_m_rt_main"}},"target_timestamp":"3"}
 {"data":"println","host_timestamp":1643113389707313290,"level":null,"location":{"file":"src/bin/levels.rs","line":15,"module_path":{"crate_name":"levels","modules":[],"function":"__cortex_m_rt_main"}},"target_timestamp":"4"}
 ```
-
-One use case is changing the human readable output with a piped command. 
-
-```json
-{
-  "data": "I am a PRINTLN-statement",
-  "host_timestamp": 1647942992494142200,
-  "level": null,
-  "location": {
-    //...
-    }
-  },
-}
-```
 > 🤔: That seems convenient, but what is this schema version in the first line?
 
 It indicates the version of the json format you are using. `probe-run` will always output it as a header at the beginning of each stream of logs. We anticipate that the format will slightly change while `probe-run` and `defmt` evolve. Using this version you always know which revision is in use and can act upon that.
 
 > 🤗: Sounds great!
-
 ## Data transfer objects
 
 > 🤔: So, what can I do with the JSON output?
 
-There really are no boundaries. You can process the JSON with any programming language you like and also store it any data store of your choice to process and analyze it later. If you are saving the output for later, it might make sense to store the schema version together with additional metadata like e.g. a device id or firmware version. 
+There really are no boundaries. You can process the JSON with any programming language you like and also store it any data store of your choice to process and analyze it later. If you are saving the output for later, it might make sense to store the schema version together with additional metadata like e.g. a device id or firmware version. One option is to use a program like jq to extract the parts of interest.
 
 If you wish to deserialize the entire data back into a Rust program, you will need to be able to decode the `SchemaVersion` object at the start of the stream, as well as the `JsonFrame` objects which follow after the schema version. To do that, we supply a few things in [`defmt_json_schema`]:
   - a `SchemaVersion` struct in `defmt_json_schema::SchemaVersion`,
   - a versioned `JsonFrame` struct in `defmt_json_schema::{schema_version}::JsonFrame` and
   - a `SCHEMA_VERSION` constant for each version of the `JsonFrame` in `defmt_json_schema::{version}::SCHEMA_VERSION`.
  
+[`defmt_json_schema`]: https://crates.io/crates/defmt-json-schema
+
 You can use all of this together with `serde_json` like following:
 
 ``` rust

--- a/book/src/printers.md
+++ b/book/src/printers.md
@@ -6,7 +6,8 @@ The following printers are currently available:
 - [`probe-run`], parses data sent over RTT (ARM Cortex-M only).
   > 💡 If you are using the git version of defmt, make sure you also install the tool from git and not crates.io.
   
-  Since v0.3.3, `probe-run` has now a [`--json`] flag to format the output.
+  Since v0.3.3, `probe-run` has now a [`--json`] flag to format the output. The main goal of `--json` is to produce machine readable output, that can be used to changing the human-readable format, a question [addressed here] for example.
+
 - [`defmt-print`], a generic command-line tool that decodes defmt data passed into its standard input.
 - [`qemu-run`], parses data sent by QEMU over semihosting (ARM Cortex-M only).
   > 💡 Used for internal testing and won't be published to crates.io
@@ -15,3 +16,4 @@ The following printers are currently available:
 [`defmt-print`]: https://github.com/knurling-rs/defmt/tree/main/print
 [`qemu-run`]: https://github.com/knurling-rs/defmt/tree/main/qemu-run
 [`--json`]: ./json-output.md
+[addressed here]: https://github.com/knurling-rs/defmt/issues/664

--- a/book/src/printers.md
+++ b/book/src/printers.md
@@ -5,6 +5,8 @@ The following printers are currently available:
 
 - [`probe-run`], parses data sent over RTT (ARM Cortex-M only).
   > 💡 If you are using the git version of defmt, make sure you also install the tool from git and not crates.io.
+  
+  Since v0.3.3, `probe-run` has now a [`--json`] flag to format the output.
 - [`defmt-print`], a generic command-line tool that decodes defmt data passed into its standard input.
 - [`qemu-run`], parses data sent by QEMU over semihosting (ARM Cortex-M only).
   > 💡 Used for internal testing and won't be published to crates.io
@@ -12,3 +14,4 @@ The following printers are currently available:
 [`probe-run`]: https://github.com/knurling-rs/probe-run
 [`defmt-print`]: https://github.com/knurling-rs/defmt/tree/main/print
 [`qemu-run`]: https://github.com/knurling-rs/defmt/tree/main/qemu-run
+[`--json`]: ./json-output.md


### PR DESCRIPTION
- completed documentation (v0.3.3+ is necessary to use the `--json` flag)
- example of json output with formatter
- small link broken in the readme
