### PR TITLE
Add changelog enforcer

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,28 @@
+# Check that the changelog is updated for all changes.
+#
+# This is only run for PRs.
+
+on:
+  pull_request:
+    # opened, reopened, synchronize are the default types for pull_request.
+    # labeled, unlabeled ensure this check is also run if a label is added or removed.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+name: Changelog
+
+jobs:
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Check that changelog updated
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: CHANGELOG.md
+          skipLabels: "skip-changelog"
+          missingUpdateErrorMessage: "Please add a changelog entry in the CHANGELOG.md file."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#679]: Add changelog enforcer
+- [#678]: Satisfy clippy
+
+[#679]: https://github.com/knurling-rs/defmt/pull/679
+[#678]: https://github.com/knurling-rs/defmt/pull/678
+
 ## [0.3.2] - 2022-05-31
 
-- [#675] Release `defmt 0.3.2` and fix `defmt-macros`-releated compile-error
-- [#669] Refine docs for `--json` flag
+- [#675]: Release `defmt 0.3.2` and fix `defmt-macros`-releated compile-error
+- [#669]: Refine docs for `--json` flag
 
 ## [0.3.1] - 2022-03-10
 


### PR DESCRIPTION
Note: We not only have `./CHANGELOG.md` in this repo, but also `./firmware/defmt-test/CHANGELOG.md`. If one makes changes to `defmt-test` and adds them to the second changelog file, the changelog-enforcer will fail. This is not ideal, but okay, since the check can be skipped by labeling the PR with "skip-changelog".