### PR TITLE
Make use of i/o locking being static since rust `1.61`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#681]: Make use of i/o locking being static since rust `1.61`.
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#681]: https://github.com/knurling-rs/defmt/pull/681
 [#679]: https://github.com/knurling-rs/defmt/pull/679
 [#678]: https://github.com/knurling-rs/defmt/pull/678
 

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -23,17 +23,14 @@ impl Log for JsonLogger {
 
         if let Some(record) = DefmtRecord::new(record) {
             // defmt goes to stdout, since it's the primary output produced by this tool.
-            let stdout = io::stdout();
-            let mut sink = stdout.lock();
+            let mut sink = io::stdout().lock();
 
             let host_timestamp = Utc::now().timestamp_nanos();
             serde_json::to_writer(&mut sink, &create_json_frame(record, host_timestamp)).ok();
             writeln!(sink).ok();
         } else {
             // non-defmt logs go to stderr
-            let stderr = io::stderr();
-            let sink = stderr.lock();
-
+            let sink = io::stderr().lock();
             self.host_logger.print_host_record(record, sink);
         }
     }
@@ -50,8 +47,7 @@ impl JsonLogger {
     }
 
     pub fn print_schema_version() {
-        let stdout = io::stdout();
-        let mut sink = stdout.lock();
+        let mut sink = io::stdout().lock();
         serde_json::to_writer(&mut sink, &SCHEMA_VERSION).ok();
         writeln!(sink).ok();
     }

--- a/decoder/src/log/pretty_logger.rs
+++ b/decoder/src/log/pretty_logger.rs
@@ -31,8 +31,7 @@ impl Log for PrettyLogger {
         match DefmtRecord::new(record) {
             Some(record) => {
                 // defmt goes to stdout, since it's the primary output produced by this tool.
-                let stdout = io::stdout();
-                let sink = stdout.lock();
+                let sink = io::stdout().lock();
 
                 match record.level() {
                     Some(level) => self.print_defmt_record(record, level, sink),
@@ -41,9 +40,7 @@ impl Log for PrettyLogger {
             }
             None => {
                 // non-defmt logs go to stderr
-                let stderr = io::stderr();
-                let sink = stderr.lock();
-
+                let sink = io::stderr().lock();
                 self.print_host_record(record, sink);
             }
         }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -64,8 +64,7 @@ fn main() -> anyhow::Result<()> {
     let mut stream_decoder = table.new_stream_decoder();
 
     let current_dir = env::current_dir()?;
-    let stdin = io::stdin();
-    let mut stdin = stdin.lock();
+    let mut stdin = io::stdin().lock();
 
     loop {
         // read from stdin and push it to the decoder


### PR DESCRIPTION
See https://blog.rust-lang.org/2022/05/19/Rust-1.61.0.html#static-handles-for-locked-stdio.