### PR TITLE
Make sure the whole RTT structure is in RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#683]: defmt-rtt: Make sure the whole RTT structure is in RAM
 - [#682]: defmt-print: exit when stdin is closed
 - [#681]: Make use of i/o locking being static since rust `1.61`.
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#683]: https://github.com/knurling-rs/defmt/pull/683
 [#682]: https://github.com/knurling-rs/defmt/pull/682
 [#681]: https://github.com/knurling-rs/defmt/pull/681
 [#679]: https://github.com/knurling-rs/defmt/pull/679

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -111,7 +111,7 @@ unsafe fn handle() -> &'static Channel {
         max_up_channels: 1,
         max_down_channels: 0,
         up_channel: Channel {
-            name: NAME as *const _ as *const u8,
+            name: &NAME as *const _ as *const u8,
             buffer: unsafe { &mut BUFFER as *mut _ as *mut u8 },
             size: BUF_SIZE,
             write: AtomicUsize::new(0),
@@ -124,7 +124,8 @@ unsafe fn handle() -> &'static Channel {
     #[cfg_attr(not(target_os = "macos"), link_section = ".uninit.defmt-rtt.BUFFER")]
     static mut BUFFER: [u8; BUF_SIZE] = [0; BUF_SIZE];
 
-    static NAME: &[u8] = b"defmt\0";
+    #[link_section = ".data"]
+    static NAME: [u8; 6] = *b"defmt\0";
 
     &_SEGGER_RTT.up_channel
 }

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -124,6 +124,8 @@ unsafe fn handle() -> &'static Channel {
     #[cfg_attr(not(target_os = "macos"), link_section = ".uninit.defmt-rtt.BUFFER")]
     static mut BUFFER: [u8; BUF_SIZE] = [0; BUF_SIZE];
 
+    // Place NAME in data section, so the whole RTT header can be read from RAM.
+    // This is useful if flash access gets disabled by the firmware at runtime.
     #[link_section = ".data"]
     static NAME: [u8; 6] = *b"defmt\0";
 


### PR DESCRIPTION
Currently, the name field of the RTT channel will be placed in
flash (rodata). That causes the debug probe to read from flash while
parsing the RTT header.

Usually this doesn't matter, but if the firmware disables flash access
before the debug probe scanned the header, it will break.

The situation where I stumbled over this was writing a firmware which
writes to flash on an RP2040. While writing to the (external) flash
chip, no concurrent flash accesses must happen.

This patch forces the name to the `.data` section, so the whole RTT
header can be read from RAM.