### PR TITLE
Fix syn dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#684]: Fix `syn` dependency version in `defmt-macros`.
 - [#682]: defmt-print: exit when stdin is closed
 - [#681]: Make use of i/o locking being static since rust `1.61`.
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#684]: https://github.com/knurling-rs/defmt/pull/684
 [#682]: https://github.com/knurling-rs/defmt/pull/682
 [#681]: https://github.com/knurling-rs/defmt/pull/681
 [#679]: https://github.com/knurling-rs/defmt/pull/679

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,7 +21,7 @@ defmt-parser = { path = "../parser", features = ["unstable"], version = "=0.3.1"
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full"] }
+syn = { version = "1.0.56", features = ["full"] }
 
 [dev_dependencies]
 maplit = "1"


### PR DESCRIPTION
`syn::Error::into_compile_error`, which is used in `defmt-macros`, is available since `1.0.56`, this PR updates the dependency version to fix build issues in some environments.