### PR TITLE
`CI`: Temporarily disable `qemu-snapshot (nightly)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - nightly
+          # - nightly # disabled, see https://github.com/knurling-rs/defmt/issues/685
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#686]: `CI`: Temporarily disable `qemu-snapshot (nightly)`
 - [#682]: defmt-print: exit when stdin is closed
 - [#681]: Make use of i/o locking being static since rust `1.61`.
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#686]: https://github.com/knurling-rs/defmt/pull/686
 [#682]: https://github.com/knurling-rs/defmt/pull/682
 [#681]: https://github.com/knurling-rs/defmt/pull/681
 [#679]: https://github.com/knurling-rs/defmt/pull/679


### PR DESCRIPTION
See https://github.com/knurling-rs/defmt/issues/685 for details.