### PR TITLE
defmt-rtt: Update to critical-section 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#689]: defmt-rtt: Update to critical-section 1.0
 - [#692]: Wrap const fn in const item to ensure compile-time-evaluation.
 - [#690]: Satisfy clippy
 - [#688]: Release `defmt-decoder 0.3.3`

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -12,4 +12,4 @@ version = "0.3.2"
 
 [dependencies]
 defmt = { version = "0.3", path = "../../defmt" }
-critical-section = "0.2.5"
+critical-section = "1.0.0"


### PR DESCRIPTION
This is a breaking change, because 1.0 no longer supplies any critical section implementation by default. The user has to opt-in to one instead (for example, by enabling the `critical-section-single-core` feature in `cortex-m`: https://github.com/rust-embedded/cortex-m/pull/447).

Thankfully it needs bumping only `defmt-rtt`, and not `defmt`. So it won't cause the painful ecosystem split like the `defmt 0.2 -> 0.3` update.

TODO before merging:

- [x] Wait for `critical-section 1.0` release https://github.com/rust-embedded/critical-section/pull/19