### PR TITLE
Satisfy clippy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#690]: Satisfy clippy
 - [#688]: Release `defmt-decoder 0.3.3`
 - [#687]: `CI`: Re-enable `qemu-snapshot (nightly)` tests
 - [#686]: `CI`: Temporarily disable `qemu-snapshot (nightly)`
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#690]: https://github.com/knurling-rs/defmt/pull/690
 [#688]: https://github.com/knurling-rs/defmt/pull/688
 [#687]: https://github.com/knurling-rs/defmt/pull/687
 [#686]: https://github.com/knurling-rs/defmt/pull/686

--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -269,7 +269,7 @@ pub fn get_locations(elf: &[u8], table: &Table) -> Result<Locations, anyhow::Err
     let borrow_section: &dyn for<'a> Fn(
         &'a Cow<[u8]>,
     ) -> gimli::EndianSlice<'a, gimli::RunTimeEndian> =
-        &|section| gimli::EndianSlice::new(&*section, endian);
+        &|section| gimli::EndianSlice::new(section, endian);
 
     let dwarf = dwarf_cow.borrow(&borrow_section);
 

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -76,7 +76,7 @@ impl Tag {
 }
 
 /// Entry in [`Table`] combining a format string with its raw symbol
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct TableEntry {
     string: StringEntry,
     raw_symbol: String,
@@ -97,7 +97,7 @@ impl TableEntry {
 }
 
 /// A format string and it's [`Tag`]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StringEntry {
     tag: Tag,
     string: String,
@@ -118,7 +118,7 @@ struct BitflagsKey {
     disambig: String,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Encoding {
     Raw,
@@ -147,7 +147,7 @@ impl Encoding {
 }
 
 /// Internal table that holds log levels and maps format strings to indices
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Table {
     timestamp: Option<TableEntry>,
     entries: BTreeMap<usize, TableEntry>,

--- a/decoder/src/log/pretty_logger.rs
+++ b/decoder/src/log/pretty_logger.rs
@@ -288,7 +288,7 @@ fn print_location<W: io::Write>(
         let mod_path = module_path.unwrap();
         let mut loc = file.to_string();
         if let Some(line) = line {
-            loc.push_str(&format!(":{}", line));
+            let _ = write!(loc, ":{}", line);
         }
         writeln!(sink, "{}", format!("└─ {} @ {}", mod_path, loc).dimmed())?;
     }

--- a/decoder/src/stream/rzcobs.rs
+++ b/decoder/src/stream/rzcobs.rs
@@ -57,7 +57,7 @@ impl<'a> StreamDecoder for Rzcobs<'a> {
     fn received(&mut self, mut data: &[u8]) {
         // Trim zeros from the left, start storing at first non-zero byte.
         if self.raw.is_empty() {
-            while data.get(0) == Some(&0) {
+            while data.first() == Some(&0) {
                 data = &data[1..]
             }
         }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -17,7 +17,7 @@ use std::{borrow::Cow, ops::Range, str::FromStr};
 pub use crate::types::Type;
 
 /// A parameter of the form `{{0=Type:hint}}` in a format string.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Parameter {
     /// The argument index to display at this position.
     pub index: usize,
@@ -28,14 +28,14 @@ pub struct Parameter {
 }
 
 /// Precision of ISO8601 datetime
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TimePrecision {
     Millis,
     Seconds,
 }
 
 /// All display hints
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DisplayHint {
     NoHint {
         zero_pad: usize,
@@ -133,7 +133,7 @@ fn parse_display_hint(mut s: &str) -> Option<DisplayHint> {
 }
 
 /// A part of a format string.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Fragment<'f> {
     /// A literal string (eg. `"literal "` in `"literal {:?}"`).
     Literal(Cow<'f, str>),
@@ -170,7 +170,7 @@ struct Param {
 }
 
 /// The log level
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub enum Level {
     Trace,
     Debug,
@@ -246,7 +246,7 @@ fn parse_array(mut s: &str) -> Result<usize, Cow<'static, str>> {
 
     // consume length
     let after_len = s
-        .find(|c: char| !c.is_digit(10))
+        .find(|c: char| !c.is_ascii_digit())
         .ok_or("invalid array specifier (missing `]`)")?;
     let len = s[..after_len].parse::<usize>().map_err(|e| e.to_string())?;
     s = &s[after_len..];
@@ -260,7 +260,7 @@ fn parse_array(mut s: &str) -> Result<usize, Cow<'static, str>> {
 }
 
 /// Parser mode
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ParserMode {
     /// Rejects unknown display hints
     Strict,
@@ -277,7 +277,9 @@ fn parse_param(mut input: &str, mode: ParserMode) -> Result<Param, Cow<'static, 
 
     // First, optional argument index.
     let mut index = None;
-    let index_end = input.find(|c: char| !c.is_digit(10)).unwrap_or(input.len());
+    let index_end = input
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(input.len());
 
     if index_end != 0 {
         index = Some(

--- a/parser/src/types.rs
+++ b/parser/src/types.rs
@@ -1,6 +1,6 @@
 use std::{ops::Range, str::FromStr};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Type {
     BitField(Range<u8>),
     Bool,


### PR DESCRIPTION
There are a couple of new clippy lints, most noticeable [warning: you are deriving `PartialEq` and can implement `Eq`](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq).