### PR TITLE
Wrap const fn in const item to ensure compile-time-evaluation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#xxx]: Wrap const fn in const item to ensure compile-time-evaluation.
 - [#690]: Satisfy clippy
 - [#688]: Release `defmt-decoder 0.3.3`
 - [#687]: `CI`: Re-enable `qemu-snapshot (nightly)` tests
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
 [#690]: https://github.com/knurling-rs/defmt/pull/690
 [#688]: https://github.com/knurling-rs/defmt/pull/688
 [#687]: https://github.com/knurling-rs/defmt/pull/687

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [#xxx]: Wrap const fn in const item to ensure compile-time-evaluation.
+- [#692]: Wrap const fn in const item to ensure compile-time-evaluation.
 - [#690]: Satisfy clippy
 - [#688]: Release `defmt-decoder 0.3.3`
 - [#687]: `CI`: Re-enable `qemu-snapshot (nightly)` tests
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
 
-[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
+[#692]: https://github.com/knurling-rs/defmt/pull/692
 [#690]: https://github.com/knurling-rs/defmt/pull/690
 [#688]: https://github.com/knurling-rs/defmt/pull/688
 [#687]: https://github.com/knurling-rs/defmt/pull/687

--- a/macros/src/function_like/log/env_filter.rs
+++ b/macros/src/function_like/log/env_filter.rs
@@ -112,13 +112,15 @@ impl EnvFilter {
             .collect::<Vec<_>>();
 
         Some(quote!({
-            const fn check() -> bool {
-                let module_path = module_path!().as_bytes();
-                #(#checks)*
-                false
-            }
-
-            check()
+            const CHECK: bool = {
+                const fn check() -> bool {
+                    let module_path = module_path!().as_bytes();
+                    #(#checks)*
+                    false
+                }
+                check()
+            };
+            CHECK
         }))
     }
 


### PR DESCRIPTION
This reduces the size of the resulting binary in debug builds.

Fixes #691.