### PR TITLE
`defmt-rtt`: Refactor rtt [3/2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [#689]: defmt-rtt: Update to critical-section 1.0
-- [#692]: Wrap const fn in const item to ensure compile-time-evaluation.
+- [#695]: `defmt-rtt`: Refactor rtt [3/2]
+- [#689]: `defmt-rtt`: Update to critical-section 1.0
+- [#692]: `defmt-macros`: Wrap const fn in const item to ensure compile-time-evaluation.
 - [#690]: Satisfy clippy
 - [#688]: Release `defmt-decoder 0.3.3`
 - [#687]: `CI`: Re-enable `qemu-snapshot (nightly)` tests
 - [#686]: `CI`: Temporarily disable `qemu-snapshot (nightly)`
 - [#684]: Fix `syn` dependency version in `defmt-macros`.
-- [#683]: defmt-rtt: Make sure the whole RTT structure is in RAM
-- [#682]: defmt-print: exit when stdin is closed
+- [#683]: `defmt-rtt`: Make sure the whole RTT structure is in RAM
+- [#682]: `defmt-print`: exit when stdin is closed
 - [#681]: Make use of i/o locking being static since rust `1.61`.
-- [#679]: Add changelog enforcer
+- [#679]: `CI`: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#695]: https://github.com/knurling-rs/defmt/pull/695
 [#692]: https://github.com/knurling-rs/defmt/pull/692
 [#690]: https://github.com/knurling-rs/defmt/pull/690
 [#688]: https://github.com/knurling-rs/defmt/pull/688

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -60,7 +60,7 @@ impl Channel {
     fn nonblocking_write(&self, bytes: &[u8]) -> usize {
         let write = self.write.load(Ordering::Acquire);
 
-        // NOTE truncate atBUF_SIZE to avoid more than one "wrap-around" in a single `write` call
+        // NOTE truncate at BUF_SIZE to avoid more than one "wrap-around" in a single `write` call
         self.write_impl(bytes, write, BUF_SIZE)
     }
 

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -70,6 +70,7 @@ impl Channel {
     }
 
     fn write_impl(&self, bytes: &[u8], cursor: usize, len: usize) -> usize {
+        // copy `bytes[..len]` to the RTT buffer
         unsafe {
             if cursor + len > BUF_SIZE {
                 // split memcpy
@@ -81,9 +82,12 @@ impl Channel {
                 ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), len);
             }
         }
+
+        // adjust the write pointer, so the host knows that there is new data
         self.write
             .store(cursor.wrapping_add(len) % BUF_SIZE, Ordering::Release);
 
+        // return the number of bytes written
         len
     }
 


### PR DESCRIPTION
This is the second attempt to land #573. This time I am not touching atomic variables, but only de-duplicate the almost copy pasted parts of `blocking_write` and `nonblocking_write`. Especially the first commit makes the duplication quite clear.