### PR TITLE
Add `before_each` and `after_each` attributes.

### DIFF
--- a/firmware/defmt-test/README.md
+++ b/firmware/defmt-test/README.md
@@ -143,6 +143,20 @@ mod tests {
         }
     }
 
+    // This function is called before each test case.
+    // It accesses the state created in `init`,
+    // though like with `test`, state access is optional.
+    #[before_each]
+    fn before_each(state: &mut super::MyState) {
+        defmt::println!("State flag before is {}", state.flag);
+    }
+
+    // This function is called after each test
+    #[after_each]
+    fn after_each(state: &mut super::MyState) {
+        defmt::println!("State flag after is {}", state.flag);
+    }
+
     // this unit test doesn't access the state
     #[test]
     fn assert_true() {
@@ -153,18 +167,27 @@ mod tests {
     #[test]
     fn assert_flag(state: &mut super::MyState) {
         assert!(state.flag)
+        state.flag = false;
     }
 }
 ```
 
 ``` console
 $ cargo test -p testsuite
-0.000000 INFO  (1/2) running `assert_true`...
-└─ test::tests::__defmt_test_entry @ tests/test.rs:11
-0.000001 INFO  (2/2) running `assert_flag`...
-└─ test::tests::__defmt_test_entry @ tests/test.rs:11
-0.000002 INFO  all tests passed!
-└─ test::tests::__defmt_test_entry @ tests/test.rs:11
+0.000000 (1/2) running `assert_true`...
+└─ integration::tests::__defmt_test_entry @ tests/integration.rs:37
+0.000001 State flag before is true
+└─ integration::tests::before_each @ tests/integration.rs:26
+0.000002 State flag after is true
+└─ integration::tests::after_each @ tests/integration.rs:32
+0.000003 (2/2) running `assert_flag`...
+└─ integration::tests::__defmt_test_entry @ tests/integration.rs:43
+0.000004 State flag before is true
+└─ integration::tests::before_each @ tests/integration.rs:26
+0.000005 State flag after is false
+└─ integration::tests::after_each @ tests/integration.rs:32
+0.000006 all tests passed!
+└─ integration::tests::__defmt_test_entry @ tests/integration.rs:11
 ```
 
 ## Test Outcome

--- a/firmware/defmt-test/macros/src/lib.rs
+++ b/firmware/defmt-test/macros/src/lib.rs
@@ -153,6 +153,7 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
                         })
                     }
                     Attr::BeforeEach => {
+                        
                         if before_each.is_some() {
                             return Err(parse::Error::new(
                                 f.sig.ident.span(),
@@ -171,6 +172,13 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
                             return Err(parse::Error::new(
                                 f.sig.ident.span(),
                                 "`#[ignore]` is not allowed on the `#[before_each]` function",
+                            ));
+                        }
+
+                        if check_fn_sig(&f.sig).is_err() || f.sig.inputs.len() > 1 {
+                            return Err(parse::Error::new(
+                                f.sig.ident.span(),
+                                "`#[before_each]` function must have signature `fn([&mut Type])` (parameter is optional)",
                             ));
                         }
 
@@ -213,6 +221,13 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
                             return Err(parse::Error::new(
                                 f.sig.ident.span(),
                                 "`#[ignore]` is not allowed on the `#[after_each]` function",
+                            ));
+                        }
+
+                        if check_fn_sig(&f.sig).is_err() || f.sig.inputs.len() > 1 {
+                            return Err(parse::Error::new(
+                                f.sig.ident.span(),
+                                "`#[after_each]` function must have signature `fn([&mut Type])` (parameter is optional)",
                             ));
                         }
 

--- a/firmware/defmt-test/macros/tests/ui/after_each-duplicate.rs
+++ b/firmware/defmt-test/macros/tests/ui/after_each-duplicate.rs
@@ -1,0 +1,10 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[after_each]
+    fn first() {}
+
+    #[after_each]
+    fn second() {}
+}

--- a/firmware/defmt-test/macros/tests/ui/after_each-duplicate.stderr
+++ b/firmware/defmt-test/macros/tests/ui/after_each-duplicate.stderr
@@ -1,0 +1,5 @@
+error: only a single `#[after_each]` function can be defined
+ --> tests/ui/after_each-duplicate.rs:9:8
+  |
+9 |     fn second() {}
+  |        ^^^^^^

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-ignore-macro.rs
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-ignore-macro.rs
@@ -1,0 +1,8 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[after_each]
+    #[ignore]
+    fn init() {}
+}

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-ignore-macro.stderr
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-ignore-macro.stderr
@@ -1,0 +1,5 @@
+error: `#[ignore]` is not allowed on the `#[after_each]` function
+ --> tests/ui/after_each-has-ignore-macro.rs:7:8
+  |
+7 |     fn init() {}
+  |        ^^^^

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-immutable-param.rs
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-immutable-param.rs
@@ -1,0 +1,9 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[after_each]
+    fn say(name: &str) {
+        assert_eq!("name", name);
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-immutable-param.stderr
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-immutable-param.stderr
@@ -1,0 +1,5 @@
+error: parameter must be a mutable reference (`&mut $Type`)
+ --> tests/ui/after_each-has-immutable-param.rs:6:12
+  |
+6 |     fn say(name: &str) {
+  |            ^^^^

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-incompatible-init-signature.rs
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-incompatible-init-signature.rs
@@ -1,0 +1,14 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[init]
+    fn init() -> u32 {
+        0_u32
+    }
+
+    #[after_each]
+    fn say(value: &mut u16) {
+        assert!(true);
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-incompatible-init-signature.stderr
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-incompatible-init-signature.stderr
@@ -1,0 +1,5 @@
+error: this type must match `#[init]`s return type
+  --> tests/ui/after_each-has-incompatible-init-signature.rs:11:24
+   |
+11 |     fn say(value: &mut u16) {
+   |                        ^^^

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-invalid-function-signature.rs
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-invalid-function-signature.rs
@@ -1,0 +1,9 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[after_each]
+    fn hello(a: i32, b: i32) -> i32 {
+        a + b
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-invalid-function-signature.stderr
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-invalid-function-signature.stderr
@@ -1,0 +1,5 @@
+error: `#[after_each]` function must have signature `fn([&mut Type])` (parameter is optional)
+ --> tests/ui/after_each-has-invalid-function-signature.rs:6:8
+  |
+6 |     fn hello(a: i32, b: i32) -> i32 {
+  |        ^^^^^

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-non-empty-signature.rs
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-non-empty-signature.rs
@@ -1,0 +1,14 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[init]
+    fn init() {
+        // empty
+    }
+
+    #[after_each]
+    fn test(arg: &mut u8) {
+        assert!(true);
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-non-empty-signature.stderr
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-non-empty-signature.stderr
@@ -1,0 +1,5 @@
+error: no state was initialized by `#[init]`; signature must be `fn()`
+  --> tests/ui/after_each-has-non-empty-signature.rs:11:8
+   |
+11 |     fn test(arg: &mut u8) {
+   |        ^^^^

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-should-error-macro.rs
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-should-error-macro.rs
@@ -1,0 +1,8 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[after_each]
+    #[should_error]
+    fn init() {}
+}

--- a/firmware/defmt-test/macros/tests/ui/after_each-has-should-error-macro.stderr
+++ b/firmware/defmt-test/macros/tests/ui/after_each-has-should-error-macro.stderr
@@ -1,0 +1,5 @@
+error: `#[should_error]` is not allowed on the `#[after_each]` function
+ --> tests/ui/after_each-has-should-error-macro.rs:7:8
+  |
+7 |     fn init() {}
+  |        ^^^^

--- a/firmware/defmt-test/macros/tests/ui/before_each-duplicate.rs
+++ b/firmware/defmt-test/macros/tests/ui/before_each-duplicate.rs
@@ -1,0 +1,10 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[before_each]
+    fn first() {}
+
+    #[before_each]
+    fn second() {}
+}

--- a/firmware/defmt-test/macros/tests/ui/before_each-duplicate.stderr
+++ b/firmware/defmt-test/macros/tests/ui/before_each-duplicate.stderr
@@ -1,0 +1,5 @@
+error: only a single `#[before_each]` function can be defined
+ --> tests/ui/before_each-duplicate.rs:9:8
+  |
+9 |     fn second() {}
+  |        ^^^^^^

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-ignore-macro.rs
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-ignore-macro.rs
@@ -1,0 +1,8 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[before_each]
+    #[ignore]
+    fn init() {}
+}

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-ignore-macro.stderr
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-ignore-macro.stderr
@@ -1,0 +1,5 @@
+error: `#[ignore]` is not allowed on the `#[before_each]` function
+ --> tests/ui/before_each-has-ignore-macro.rs:7:8
+  |
+7 |     fn init() {}
+  |        ^^^^

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-immutable-param.rs
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-immutable-param.rs
@@ -1,0 +1,9 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[before_each]
+    fn say(name: &str) {
+        assert_eq!("name", name);
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-immutable-param.stderr
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-immutable-param.stderr
@@ -1,0 +1,5 @@
+error: parameter must be a mutable reference (`&mut $Type`)
+ --> tests/ui/before_each-has-immutable-param.rs:6:12
+  |
+6 |     fn say(name: &str) {
+  |            ^^^^

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-incompatible-init-signature.rs
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-incompatible-init-signature.rs
@@ -1,0 +1,14 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[init]
+    fn init() -> u32 {
+        0_u32
+    }
+
+    #[before_each]
+    fn say(value: &mut u16) {
+        assert!(true);
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-incompatible-init-signature.stderr
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-incompatible-init-signature.stderr
@@ -1,0 +1,5 @@
+error: this type must match `#[init]`s return type
+  --> tests/ui/before_each-has-incompatible-init-signature.rs:11:24
+   |
+11 |     fn say(value: &mut u16) {
+   |                        ^^^

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-invalid-function-signature.rs
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-invalid-function-signature.rs
@@ -1,0 +1,9 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[before_each]
+    fn hello(a: i32, b: i32) -> i32 {
+        a + b
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-invalid-function-signature.stderr
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-invalid-function-signature.stderr
@@ -1,0 +1,5 @@
+error: `#[before_each]` function must have signature `fn([&mut Type])` (parameter is optional)
+ --> tests/ui/before_each-has-invalid-function-signature.rs:6:8
+  |
+6 |     fn hello(a: i32, b: i32) -> i32 {
+  |        ^^^^^

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-non-empty-signature.rs
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-non-empty-signature.rs
@@ -1,0 +1,14 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[init]
+    fn init() {
+        // empty
+    }
+
+    #[before_each]
+    fn test(arg: &mut u8) {
+        assert!(true);
+    }
+}

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-non-empty-signature.stderr
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-non-empty-signature.stderr
@@ -1,0 +1,5 @@
+error: no state was initialized by `#[init]`; signature must be `fn()`
+  --> tests/ui/before_each-has-non-empty-signature.rs:11:8
+   |
+11 |     fn test(arg: &mut u8) {
+   |        ^^^^

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-should-error-macro.rs
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-should-error-macro.rs
@@ -1,0 +1,8 @@
+fn main() {}
+
+#[defmt_test_macros::tests]
+mod tests {
+    #[before_each]
+    #[should_error]
+    fn init() {}
+}

--- a/firmware/defmt-test/macros/tests/ui/before_each-has-should-error-macro.stderr
+++ b/firmware/defmt-test/macros/tests/ui/before_each-has-should-error-macro.stderr
@@ -1,0 +1,5 @@
+error: `#[should_error]` is not allowed on the `#[before_each]` function
+ --> tests/ui/before_each-has-should-error-macro.rs:7:8
+  |
+7 |     fn init() {}
+  |        ^^^^

--- a/firmware/defmt-test/macros/tests/ui/tests-without-annotated-function.stderr
+++ b/firmware/defmt-test/macros/tests/ui/tests-without-annotated-function.stderr
@@ -1,4 +1,4 @@
-error: function requires `#[init]` or `#[test]` attribute
+error: function requires `#[init]`, `#[before_each]`, `#[after_each]`, or `#[test]` attribute
  --> tests/ui/tests-without-annotated-function.rs:5:5
   |
 5 |     fn some_function() {


### PR DESCRIPTION
Add `before_each` and `after_each` attributes. These attributes define functions that are called before and after each test case respectively.

I use them myself to alter a pin state, signaling my power profiler whether an actual test is running, but this feature can be used in many other situations.

I have some doubt about (not completely, but mostly) duplicated code, but I'm not sure adding macros would make it any better. Any suggestions on cleaning that up are very welcome!

And of course, thanks to the Knurling team for setting up a great set of crates! 