### PR TITLE
Non atomic RTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#699]: `defmt-rtt`: Non atomic RTT
 - [#695]: `defmt-rtt`: Refactor rtt [3/2]
 - [#689]: `defmt-rtt`: Update to critical-section 1.0
 - [#692]: `defmt-macros`: Wrap const fn in const item to ensure compile-time-evaluation.
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#679]: `CI`: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#699]: https://github.com/knurling-rs/defmt/pull/699
 [#695]: https://github.com/knurling-rs/defmt/pull/695
 [#692]: https://github.com/knurling-rs/defmt/pull/692
 [#690]: https://github.com/knurling-rs/defmt/pull/690

--- a/firmware/defmt-rtt/build.rs
+++ b/firmware/defmt-rtt/build.rs
@@ -15,7 +15,14 @@ fn main() {
 
     std::fs::write(
         out_file_path,
-        format!("pub(crate) const BUF_SIZE: usize = {};", size),
+        format!(
+            "/// RTT buffer size (default: 1024).
+            ///
+            /// Can be customized by setting the `DEFMT_RTT_BUFFER_SIZE` environment variable.
+            /// Use a power of 2 for best performance.
+            pub(crate) const BUF_SIZE: usize = {};",
+            size
+        ),
     )
     .unwrap();
 }

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -57,7 +57,7 @@ unsafe impl defmt::Logger for Logger {
         critical_section::with(|cs| {
             // safety: accessing the `static mut` is OK because we have acquired a critical section.
             let mut taken = TAKEN.borrow_ref_mut(cs);
-            if *taken == true {
+            if *taken {
                 panic!("defmt logger taken reentrantly")
             }
             *taken = true;

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -34,12 +34,11 @@
 #![no_std]
 
 mod channel;
+mod consts;
 
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::channel::Channel;
-
-mod consts;
 
 /// RTT buffer size. Default: 1024; can be customized by setting the `DEFMT_RTT_BUFFER_SIZE` environment variable.
 /// Use a power of 2 for best performance.

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -38,11 +38,7 @@ mod consts;
 
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use crate::channel::Channel;
-
-/// RTT buffer size. Default: 1024; can be customized by setting the `DEFMT_RTT_BUFFER_SIZE` environment variable.
-/// Use a power of 2 for best performance.
-use crate::consts::BUF_SIZE;
+use crate::{channel::Channel, consts::BUF_SIZE};
 
 #[defmt::global_logger]
 struct Logger;
@@ -57,11 +53,12 @@ unsafe impl defmt::Logger for Logger {
         // safety: Must be paired with corresponding call to release(), see below
         let restore = unsafe { critical_section::acquire() };
 
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
         if TAKEN.load(Ordering::Relaxed) {
             panic!("defmt logger taken reentrantly")
         }
 
-        // no need for CAS because interrupts are disabled
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
         TAKEN.store(true, Ordering::Relaxed);
 
         // safety: accessing the `static mut` is OK because we have acquired a critical section.
@@ -72,7 +69,7 @@ unsafe impl defmt::Logger for Logger {
     }
 
     unsafe fn flush() {
-        // SAFETY: if we get here, the global logger mutex is currently acquired
+        // safety: accessing the `&'static _` is OK because we have acquired a critical section.
         handle().flush();
     }
 
@@ -80,6 +77,7 @@ unsafe impl defmt::Logger for Logger {
         // safety: accessing the `static mut` is OK because we have acquired a critical section.
         ENCODER.end_frame(do_write);
 
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
         TAKEN.store(false, Ordering::Relaxed);
 
         // safety: accessing the `static mut` is OK because we have acquired a critical section.


### PR DESCRIPTION
This PR replaces all atomic variables with their non-atomic counterpart wrapped in a `critical_section::Mutex<RefCell<_>>`. The `RefCell` is needed, because `critical_section::Mutex` does not provide interior mutability.

This change makes `defmt-rtt` available on targets without native atomics. 
Fixes #597.

Atm, it is unclear what the runtime and code-size impact of that change is. Likely both would improve if using a `Cell`, instead of a `RefCell`, but it is unclear if that would be correct.