### PR TITLE
Atomic polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#xxx]: `defmt-rtt`: Switch to `atomic-polyfill` for better target support
 - [#701]: Pre-relase cleanup
 - [#695]: `defmt-rtt`: Refactor rtt [3/2]
 - [#689]: `defmt-rtt`: Update to critical-section 1.0
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#679]: `CI`: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
 [#701]: https://github.com/knurling-rs/defmt/pull/701
 [#695]: https://github.com/knurling-rs/defmt/pull/695
 [#692]: https://github.com/knurling-rs/defmt/pull/692

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -11,5 +11,6 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.3.2"
 
 [dependencies]
+atomic-polyfill = "1.0"
 defmt = { version = "0.3", path = "../../defmt" }
-critical-section = "1.1.1"
+critical-section = "1.1"

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -1,7 +1,6 @@
-use core::{
-    ptr,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use core::ptr;
+
+use atomic_polyfill::{AtomicUsize, Ordering};
 
 use crate::{consts::BUF_SIZE, MODE_BLOCK_IF_FULL, MODE_MASK};
 

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -36,7 +36,7 @@
 mod channel;
 mod consts;
 
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use atomic_polyfill::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::{channel::Channel, consts::BUF_SIZE};
 


### PR DESCRIPTION
This PR replaces `core::sync::atomic::*` with `atomic_polyfill::*`.

This change makes `defmt-rtt` available on targets without native atomics.
Fixes https://github.com/knurling-rs/defmt/issues/597.

There should be no negative impact on targets with atomic support, since in these cases the native atomics will be used.