### PR TITLE
Use atomic_polyfill on targets without atomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#707]: `defmt-rtt`: Use `atomic-polyfill`
 - [#704]: Release `defmt-macros 0.3.3`, `defmt-print 0.3.3`, `defmt-rtt 0.4.0`
 - [#703]: `defmt-print`: Update to `clap 4.0`.
 - [#701]: Pre-relase cleanup

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.4.0"
 
 [dependencies]
+atomic-polyfill = "1"
 defmt = { version = "0.3", path = "../../defmt" }
 critical-section = "1.1"
-atomic-polyfill = "1"

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -13,3 +13,4 @@ version = "0.4.0"
 [dependencies]
 defmt = { version = "0.3", path = "../../defmt" }
 critical-section = "1.1"
+atomic-polyfill = "1"

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -1,7 +1,5 @@
-use core::{
-    ptr,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use atomic_polyfill::{AtomicUsize, Ordering};
+use core::ptr;
 
 use crate::{consts::BUF_SIZE, MODE_BLOCK_IF_FULL, MODE_MASK};
 

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -1,5 +1,6 @@
-use atomic_polyfill::{AtomicUsize, Ordering};
 use core::ptr;
+
+use atomic_polyfill::{AtomicUsize, Ordering};
 
 use crate::{consts::BUF_SIZE, MODE_BLOCK_IF_FULL, MODE_MASK};
 

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -36,7 +36,7 @@
 mod channel;
 mod consts;
 
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use atomic_polyfill::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::{channel::Channel, consts::BUF_SIZE};
 


### PR DESCRIPTION
Most targets, even those without atomic instructions, support atomic load and stores. RISC-V is one of the few platforms that lacks this ability, and rustc is planning on solving that in the future (https://github.com/rust-lang/rust/issues/99668).

However, in the meantime it is impossible to use `defmt-rtt` on the riscv non-atomic platform, such as the ESP32-C3.

`atomic-polyfill` is a useful crate that emulates the atomics via `critical_section`, *but only on platforms without atomic support*. On platforms with atomic support, it just re-exports the types from `core::sync::atomic`.

Would this PR be considered for inclusion in `defmt-rtt`? A prior PR was rejected here: https://github.com/knurling-rs/defmt/pull/702