### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
   host:
     strategy:
       matrix:
-        rust:
-          - stable
-          - nightly
         os:
           - ubuntu-latest
           - macOS-latest
@@ -36,7 +33,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           override: true
       - name: Install C libraries for tooling on ubuntu
         if: matrix.os == 'ubuntu-latest'
@@ -107,18 +104,13 @@ jobs:
         run: cargo xtask test-book
 
   qemu-snapshot:
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - nightly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           override: true
           target: ${{ env.QEMU_TARGET }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches: [main, staging, trying]
   pull_request:
     branches: [main]
-    # don't run CI when changing md-files, except they are part of the book
-    paths-ignore:
-      - "*.md"
-      - "!book/src/**"
   schedule:
     # runs 1 min after 2 or 1 AM (summer/winter) berlin time
     - cron: "1 0 * * *"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -44,7 +44,7 @@ jobs:
   cross:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -71,7 +71,7 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -90,7 +90,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -106,7 +106,7 @@ jobs:
   qemu-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -121,7 +121,7 @@ jobs:
   backcompat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
       - name: Install C libraries for tooling on ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
@@ -45,12 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: ${{ env.NO_STD_TARGET }}
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
+      - name: Install NO_STD_TARGET
+        run: rustup target add ${{ env.NO_STD_TARGET }}
       - name: Install Rust targets, build defmt crates for no_std targets, build defmt dependent crates for cortex-m targets, build panic-probe with different features
         run: cargo xtask test-cross
 
@@ -59,12 +54,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
       - name: Run rustfmt & clippy
         run: cargo xtask test-lint
 
@@ -72,11 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
       - name: Install Rust stable, run all UI tests on the host
         run: cargo xtask test-ui
 
@@ -91,11 +79,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
@@ -107,12 +92,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: ${{ env.QEMU_TARGET }}
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
+      - name: Install QEMU_TARGET
+        run: rustup target add ${{ env.QEMU_TARGET }}
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
       - name: Run QEMU snapshot tests
@@ -124,12 +107,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: ${{ env.QEMU_TARGET }}
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
+      - name: Install QEMU_TARGET
+        run: rustup target add ${{ env.QEMU_TARGET }}
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
       - name: Run backward compatibility test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#710]: Update CI
 - [#704]: Release `defmt-macros 0.3.3`, `defmt-print 0.3.3`, `defmt-rtt 0.4.0`
 - [#703]: `defmt-print`: Update to `clap 4.0`.
 - [#701]: Pre-relase cleanup
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#679]: `CI`: Add changelog enforcer
 - [#678]: Satisfy clippy
 
+[#710]: https://github.com/knurling-rs/defmt/pull/710
 [#704]: https://github.com/knurling-rs/defmt/pull/704
 [#703]: https://github.com/knurling-rs/defmt/pull/703
 [#701]: https://github.com/knurling-rs/defmt/pull/701

--- a/decoder/src/frame.rs
+++ b/decoder/src/frame.rs
@@ -397,9 +397,10 @@ impl<'t> Frame<'t> {
             TimePrecision::Seconds => chrono::SecondsFormat::Secs,
         };
         let date_time = match precision {
-            TimePrecision::Millis => chrono::Utc.timestamp_millis(timestamp as i64),
-            TimePrecision::Seconds => chrono::Utc.timestamp(timestamp as i64, 0),
-        };
+            TimePrecision::Millis => chrono::Utc.timestamp_millis_opt(timestamp as i64),
+            TimePrecision::Seconds => chrono::Utc.timestamp_opt(timestamp as i64, 0),
+        }
+        .unwrap();
         write!(buf, "{}", date_time.to_rfc3339_opts(format, true))
     }
 }


### PR DESCRIPTION
Changes
- Only run CI on stable Rust
- update to `actions/checkout@v3`
- use `rustup` instead of `actions-rs/toolchain`
- fix deprecated `chrono` functions
- drop `paths-ignore`

Future work: Run the CI against nightly Rust in scheduled runs, but not on PRs. They should not be blocked by nightly problems.