### PR TITLE
Add cargo audit GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,15 @@ jobs:
     steps:
       - name: CI succeeded
         run: exit 0
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/checkout@v3
+      - name: Use the latest stable release
+        run: rustup update stable && rustup default stable
+      - uses: actions-rust-lang/audit@v1
+        name: Audit Rust Dependencies


### PR DESCRIPTION
- Useful for tracking RUSTSEC advisories

Not sure if there is any interest in this.
There are at least two RUSTSEC advisories for defmt dependencies right now.

```bash
[main]: cargo audit                                                                                      [~/git/defmt](hyatt@Mas5950x:pts/3)
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 470 security advisories (from /home/hyatt/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (128 crate dependencies)
Crate:         ansi_term
Version:       0.12.1
Warning:       unmaintained
Title:         ansi_term is Unmaintained
Date:          2021-08-18
ID:            RUSTSEC-2021-0139
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0139
Dependency tree:
ansi_term 0.12.1
└── clap 2.34.0

Crate:         difference
Version:       2.0.0
Warning:       unmaintained
Title:         difference is unmaintained
Date:          2020-12-20
ID:            RUSTSEC-2020-0095
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0095
Dependency tree:
difference 2.0.0
└── defmt-decoder 0.3.3
    ├── qemu-run 0.1.0
    └── defmt-print 0.3.3

warning: 2 allowed warnings found
```