### PR TITLE
Fix panic when trying to get location_info when the locations doesn't contain the frame index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#681]: https://github.com/knurling-rs/defmt/pull/681
 [#679]: https://github.com/knurling-rs/defmt/pull/679
 [#678]: https://github.com/knurling-rs/defmt/pull/678
-[#719]: https://github.com/knurling-rs/defmt/pull/678
+[#719]: https://github.com/knurling-rs/defmt/pull/719
 
 ## [0.3.2] - 2022-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#681]: Make use of i/o locking being static since rust `1.61`.
 - [#679]: Add changelog enforcer
 - [#678]: Satisfy clippy
+- [#719]: defmt-print: fix panic 
 
 [#692]: https://github.com/knurling-rs/defmt/pull/692
 [#690]: https://github.com/knurling-rs/defmt/pull/690
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#681]: https://github.com/knurling-rs/defmt/pull/681
 [#679]: https://github.com/knurling-rs/defmt/pull/679
 [#678]: https://github.com/knurling-rs/defmt/pull/678
+[#719]: https://github.com/knurling-rs/defmt/pull/678
 
 ## [0.3.2] - 2022-05-31
 

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -107,10 +107,9 @@ fn forward_to_logger(frame: &Frame, location_info: LocationInfo) {
 fn location_info(locs: &Option<Locations>, frame: &Frame, current_dir: &Path) -> LocationInfo {
     let (mut file, mut line, mut mod_path) = (None, None, None);
 
-    // NOTE(`[]` indexing) all indices in `table` have been verified to exist in the `locs` map
-    let loc = locs.as_ref().map(|locs| &locs[&frame.index()]);
+    let loc = locs.as_ref().map(|locs| locs.get(&frame.index()));
 
-    if let Some(loc) = loc {
+    if let Some(Some(loc)) = loc {
         // try to get the relative path, else the full one
         let path = loc.file.strip_prefix(&current_dir).unwrap_or(&loc.file);
 


### PR DESCRIPTION
Panics are observed when running defmt print while piping from a tcp socket from either an OpenOCD debugger or a J-Link debugger.

```
thread 'main' panicked at 'no entry found for key', print\src\main.rs:151:41
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The panic occurs because the map _doesn't_ contain the frame index, contrary to the comment that this PR also deletes.
```
// NOTE(`[]` indexing) all indices in `table` have been verified to exist in the `locs` map
let loc = locs.as_ref().map(|locs| &locs[&frame.index()]);
```

This PR uses `get` which returns an `Option::None` if the map doesn't contain the frame index, and then only uses the location if there was a) any locations, and b) the locations contained the frame index.

This fixes the panic and now I'm able to see the rest of the log which I wasn't previously able to see due to the panic.