### PR TITLE
enable GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "."
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/firmware"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
this ensures that the dependencies are kept up to date. see [the docs][] for further information.

note: changelog intentionally left away as this only touches the build infrastructure and has no direct impact on consumers of the library.

[the docs]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates