### PR TITLE
decoder logging: add parameter to indicate defmt awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- `defmt-decoder`: add support for loggers that aren't `defmt` aware
 - [#715]: Update `clap` to version `4`
 - [#710]: Update CI
 - [#706]: Satisfy clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- `defmt-decoder`: add support for loggers that aren't `defmt` aware
+- `defmt-decoder`: preserve log levels with loggers that aren't `defmt` aware
 - [#715]: Update `clap` to version `4`
 - [#710]: Update CI
 - [#706]: Satisfy clippy

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -60,12 +60,13 @@ pub fn log_defmt(
                 .build(),
         );
     } else {
-        let level = level.unwrap_or(Level::Info);
+        let mut builder = Record::builder();
+        if let Some(level) = level {
+            builder.level(level);
+        }
         log::logger().log(
-            &Record::builder()
+            &builder
                 .args(format_args!("{}", frame.display_message()))
-                .level(level)
-                .target(&timestamp)
                 .module_path(module_path)
                 .file(file)
                 .line(line)

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -64,7 +64,7 @@ pub fn log_defmt(
         log::logger().log(
             &Record::builder()
                 .args(format_args!("{}", frame.display_message()))
-                .level(level) // no need to set the level, since it is transferred via payload
+                .level(level)
                 .target(&timestamp)
                 .module_path(module_path)
                 .file(file)

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -101,7 +101,7 @@ type LocationInfo = (Option<String>, Option<u32>, Option<String>);
 
 fn forward_to_logger(frame: &Frame, location_info: LocationInfo) {
     let (file, line, mod_path) = location_info;
-    defmt_decoder::log::log_defmt(frame, file.as_deref(), line, mod_path.as_deref());
+    defmt_decoder::log::log_defmt(frame, file.as_deref(), line, mod_path.as_deref(), true);
 }
 
 fn location_info(locs: &Option<Locations>, frame: &Frame, current_dir: &Path) -> LocationInfo {


### PR DESCRIPTION
[sometimes](https://twitter.com/pandora9001/status/1565774226417655809) it's preferable to use an existing logger instead of a bespoke defmt-aware one. This PR makes it possible to preserve log levels in this case. It breaks a public API so requires a version bump.