### PR TITLE
defmt: add impl for core::net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#733]: `defmt`: Add formatting for `core::net` with the `ip_in_core` feature
+
+[#733]: https://github.com/knurling-rs/defmt/pull/733
+
 ## defmt-decoder v0.3.4, defmt-print v0.3.4
 
 - [#729]: Release `defmt-decoder v0.3.4`, `defmt-print v0.3.4`

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.3.2"
 
 [features]
 alloc = []
+ip_in_core = []
 
 # Encoding feature flags. These should only be set by end-user crates, not by library crates.
 #

--- a/defmt/src/impls/core_/mod.rs
+++ b/defmt/src/impls/core_/mod.rs
@@ -8,6 +8,8 @@
 mod alloc_;
 mod array;
 mod cell;
+#[cfg(feature = "ip_in_core")]
+mod net;
 mod num;
 mod ops;
 mod slice;

--- a/defmt/src/impls/core_/net.rs
+++ b/defmt/src/impls/core_/net.rs
@@ -1,0 +1,72 @@
+use core::net;
+
+use super::*;
+
+impl Format for net::AddrParseError {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "AddrParseError(_)");
+    }
+}
+
+impl Format for net::Ipv4Addr {
+    fn format(&self, fmt: Formatter) {
+        let [a, b, c, d] = self.octets();
+        crate::write!(fmt, "{}.{}.{}.{}", a, b, c, d);
+    }
+}
+
+impl Format for net::SocketAddrV4 {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "{}:{}", self.ip(), self.port());
+    }
+}
+
+impl Format for net::Ipv6Addr {
+    fn format(&self, fmt: Formatter) {
+        let octets: [u8; 16] = self.octets();
+        crate::write!(
+            fmt,
+            "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}",
+            octets[0],
+            octets[1],
+            octets[2],
+            octets[3],
+            octets[4],
+            octets[5],
+            octets[6],
+            octets[7],
+            octets[8],
+            octets[9],
+            octets[10],
+            octets[11],
+            octets[12],
+            octets[13],
+            octets[14],
+            octets[15]
+        );
+    }
+}
+
+impl Format for net::SocketAddrV6 {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "[{}]:{}", self.ip(), self.port());
+    }
+}
+
+impl Format for net::IpAddr {
+    fn format(&self, fmt: Formatter) {
+        match self {
+            net::IpAddr::V4(a) => crate::write!(fmt, "{}", a),
+            net::IpAddr::V6(a) => crate::write!(fmt, "{}", a),
+        }
+    }
+}
+
+impl Format for net::SocketAddr {
+    fn format(&self, fmt: Formatter) {
+        match self {
+            net::SocketAddr::V4(a) => crate::write!(fmt, "{}", a),
+            net::SocketAddr::V6(a) => crate::write!(fmt, "{}", a),
+        }
+    }
+}

--- a/defmt/src/lib.rs
+++ b/defmt/src/lib.rs
@@ -14,6 +14,7 @@
 // NOTE if you change this URL you'll also need to update all other crates in this repo
 #![doc(html_logo_url = "https://knurling.ferrous-systems.com/knurling_logo_light_text.svg")]
 #![warn(missing_docs)]
+#![cfg_attr(feature = "ip_in_core", feature(ip_in_core))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
This adds formatting for `core::net` types.  `core::net` is currently unstable, so this is feature gated.