### PR TITLE
Fix #536 - add help for format string parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - [#733]: `defmt`: Add formatting for `core::net` with the `ip_in_core` feature
+- [#536]: `defmt-parser`: Switch to using an enum for errors, and add some help
+          text pointing you to the defmt docs if you use the wrong type
+          specifier in a format string.
 
 [#733]: https://github.com/knurling-rs/defmt/pull/733
+[#536]: https://github.com/knurling-rs/defmt/pull/735
 
 ## defmt-decoder v0.3.4, defmt-print v0.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - [#733]: `defmt`: Add formatting for `core::net` with the `ip_in_core` feature
-- [#536]: `defmt-parser`: Switch to using an enum for errors, and add some help
-          text pointing you to the defmt docs if you use the wrong type
-          specifier in a format string.
+- [#536]: `defmt-parser`: Switch to using an enum for errors, and add some help text pointing you to the defmt docs if you use the wrong type specifier in a format string.
 
 [#733]: https://github.com/knurling-rs/defmt/pull/733
 [#536]: https://github.com/knurling-rs/defmt/pull/735

--- a/macros/src/function_like/println.rs
+++ b/macros/src/function_like/println.rs
@@ -16,7 +16,20 @@ pub(crate) fn expand_parsed(args: Args) -> TokenStream2 {
     let format_string = args.format_string.value();
     let fragments = match defmt_parser::parse(&format_string, ParserMode::Strict) {
         Ok(args) => args,
-        Err(e) => abort!(args.format_string, "{}", e),
+        Err(e) => {
+            match &e {
+                defmt_parser::Error::UnknownDisplayHint(_s) => {
+                    abort!(
+                        args.format_string, "{}", e;
+                        help = "`defmt` uses a slightly different syntax than regular formatting in Rust. See https://defmt.ferrous-systems.com/macros.html for more details.";
+                    );
+                }
+                _ => {
+                    // No extra help
+                    abort!(args.format_string, "{}", e);
+                }
+            }
+        }
     };
 
     let formatting_exprs = args

--- a/macros/src/function_like/println.rs
+++ b/macros/src/function_like/println.rs
@@ -16,20 +16,11 @@ pub(crate) fn expand_parsed(args: Args) -> TokenStream2 {
     let format_string = args.format_string.value();
     let fragments = match defmt_parser::parse(&format_string, ParserMode::Strict) {
         Ok(args) => args,
-        Err(e) => {
-            match &e {
-                defmt_parser::Error::UnknownDisplayHint(_s) => {
-                    abort!(
-                        args.format_string, "{}", e;
-                        help = "`defmt` uses a slightly different syntax than regular formatting in Rust. See https://defmt.ferrous-systems.com/macros.html for more details.";
-                    );
-                }
-                _ => {
-                    // No extra help
-                    abort!(args.format_string, "{}", e);
-                }
-            }
-        }
+        Err(e @ defmt_parser::Error::UnknownDisplayHint(_)) => abort!(
+            args.format_string, "{}", e;
+            help = "`defmt` uses a slightly different syntax than regular formatting in Rust. See https://defmt.ferrous-systems.com/macros.html for more details.";
+        ),
+        Err(e) => abort!(args.format_string, "{}", e), // No extra help
     };
 
     let formatting_exprs = args

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,6 +9,9 @@ readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
 version = "0.3.1"
 
+[dependencies]
+thiserror = "1.0"
+
 [features]
 unstable = []
 


### PR DESCRIPTION
1) Replaces `Cow<str>` with an `enum Error` to accurately describe the parse error
2) Uses `thiserror` to convert the `Error` enum into strings, which match the strings previously returned from the `parse` function
3) Uses that enum to add help text for Error::UnknownDisplayHint.

Closes #536 