### PR TITLE
Expose hard_fault panicking behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#737]: `panic-probe`: Add `hard_fault()` for use in `defmt::panic_handler`
 - [#733]: `defmt`: Add formatting for `core::net` with the `ip_in_core` feature
 
+[#737]: https://github.com/knurling-rs/defmt/pull/737
 [#733]: https://github.com/knurling-rs/defmt/pull/733
 
 ## defmt-decoder v0.3.4, defmt-print v0.3.4


### PR DESCRIPTION
This PR factors the hard-faulting logic out of the panic handler and makes it publicly available. The reasoning is that users may want to use that hard-faulting logic as the `defmt::panic_handler` to avoid double panic printing.

Alternative options:
1. Factor the hard-faulting logic out but don't expose it publicly. Instead, expose a feature that would define the hard-faulting logic as `defmt::panic_handler`.
2. Same as above, but reuse the `print-defmt` feature, essentially always setting the `defmt::panic_handler`.

Alternative (2) is probably the easiest for the user. The downside would be if for some reason the `defmt::panic_handler` should be set to something else instead. I don't see any examples, but that's a risk.

Alternative (1) is still easy (and that feature could be a default feature, or alternatively there could be a disabling feature) while keeping flexibility in case a user needs to define a custom `defmt::panic_handler`.

The current PR is the obvious non-breaking and flexible solution, but requires the user to define the `defmt::panic_handler` when needed.