### PR TITLE
Clean `xtask`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#739]: `xtask`: Clean up
 - [#737]: `panic-probe`: Add `hard_fault()` for use in `defmt::panic_handler`
 - [#733]: `defmt`: Add formatting for `core::net` with the `ip_in_core` feature
 - [#603]: `defmt`: Raw pointers now print as `0x1234` instead of `1234`
 - [#536]: `defmt-parser`: Switch to using an enum for errors, and add some help text pointing you to the defmt docs if you use the wrong type specifier in a format string.
 
+[#739]: https://github.com/knurling-rs/defmt/pull/739
 [#737]: https://github.com/knurling-rs/defmt/pull/737
 [#733]: https://github.com/knurling-rs/defmt/pull/733
 [#603]: https://github.com/knurling-rs/defmt/pull/734

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -444,7 +444,7 @@ where
     }
 }
 
-pub fn parse<'f>(format_string: &'f str, mode: ParserMode) -> Result<Vec<Fragment<'f>>, Error> {
+pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>, Error> {
     let mut fragments = Vec::new();
 
     // Index after the `}` of the last format specifier.

--- a/parser/src/types.rs
+++ b/parser/src/types.rs
@@ -1,6 +1,6 @@
 use std::{ops::Range, str::FromStr};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum Type {
     BitField(Range<u8>),
     Bool,
@@ -15,6 +15,7 @@ pub enum Type {
     F64,
 
     /// `{=?}` OR `{}`
+    #[default] // when not specified in the format string, this type is assumed
     Format,
     FormatArray(usize), // FIXME: This `usize` is not the target's `usize`; use `u64` instead?
     /// `{=[?]}`
@@ -76,12 +77,5 @@ impl FromStr for Type {
             "char" => Type::Char,
             _ => return Err(()),
         })
-    }
-}
-
-// when not specified in the format string, this type is assumed
-impl Default for Type {
-    fn default() -> Self {
-        Type::Format
     }
 }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -85,6 +85,8 @@ fn main() -> anyhow::Result<()> {
                     false => return Err(DecodeError::Malformed.into()),
                     // if recovery is possible, skip the current frame and continue with new data
                     true => {
+                        // bug: https://github.com/rust-lang/rust-clippy/issues/9810
+                        #[allow(clippy::print_literal)]
                         if show_skipped_frames || verbose {
                             println!("(HOST) malformed frame skipped");
                             println!("└─ {} @ {}:{}", env!("CARGO_PKG_NAME"), file!(), line!());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -207,6 +207,7 @@ fn test_cross() {
                     "check",
                     "--target",
                     "thumbv6m-none-eabi",
+                    "--workspace",
                     "--exclude",
                     "defmt-itm",
                     "--exclude",
@@ -265,7 +266,19 @@ fn test_cross() {
             )
         },
         "cross",
-    )
+    );
+
+    do_test(
+        || {
+            run_command(
+                "cargo",
+                &["clippy", "--target", "thumbv7m-none-eabi", "--", "-D", "warnings"],
+                Some("firmware/"),
+                &[],
+            )
+        },
+        "lint",
+    );
 }
 
 fn test_snapshot(overwrite: bool, snapshot: Option<Snapshot>) {
@@ -409,11 +422,16 @@ fn test_book() {
 
 fn test_lint() {
     println!("🧪 lint");
-    do_test(|| run_command("cargo", &["clean"], None, &[]), "lint");
-    do_test(
-        || run_command("cargo", &["fmt", "--", "--check"], None, &[]),
-        "lint",
-    );
+
+    // rustfmt
+    for cwd in [None, Some("firmware/")] {
+        do_test(
+            || run_command("cargo", &["fmt", "--", "--check"], cwd, &[]),
+            "lint",
+        );
+    }
+
+    // clippy
     do_test(
         || run_command("cargo", &["clippy", "--", "-D", "warnings"], None, &[]),
         "lint",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -414,8 +414,10 @@ fn test_lint() {
         || run_command("cargo", &["fmt", "--", "--check"], None, &[]),
         "lint",
     );
-
-    do_test(|| run_command("cargo", &["clippy"], None, &[]), "lint");
+    do_test(
+        || run_command("cargo", &["clippy", "--", "-D", "warnings"], None, &[]),
+        "lint",
+    );
 }
 
 fn test_ui() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -150,56 +150,25 @@ fn test_host(deny_warnings: bool) {
         vec![]
     };
 
+    do_test(|| run_command("cargo", &["check"], None, &env), "host");
+
     do_test(
-        || run_command("cargo", &["check", "--workspace"], None, &env),
+        || run_command("cargo", &["check", "--features", "unstable-test"], None, &env),
         "host",
     );
 
     do_test(
-        || {
-            run_command(
-                "cargo",
-                &["check", "--workspace", "--features", "unstable-test"],
-                None,
-                &env,
-            )
-        },
+        || run_command("cargo", &["check", "--features", "alloc"], None, &env),
         "host",
     );
 
     do_test(
-        || {
-            run_command(
-                "cargo",
-                &["check", "--workspace", "--features", "alloc"],
-                None,
-                &env,
-            )
-        },
+        || run_command("cargo", &["test", "--features", "unstable-test"], None, &[]),
         "host",
     );
 
     do_test(
-        || {
-            run_command(
-                "cargo",
-                &["test", "--workspace", "--features", "unstable-test"],
-                None,
-                &[],
-            )
-        },
-        "host",
-    );
-
-    do_test(
-        || {
-            run_command(
-                "cargo",
-                &["test", "--workspace", "--features", "unstable-test,alloc"],
-                None,
-                &[],
-            )
-        },
+        || run_command("cargo", &["test", "--features", "unstable-test,alloc"], None, &[]),
         "host",
     );
 }
@@ -238,7 +207,6 @@ fn test_cross() {
                     "check",
                     "--target",
                     "thumbv6m-none-eabi",
-                    "--workspace",
                     "--exclude",
                     "defmt-itm",
                     "--exclude",
@@ -255,7 +223,7 @@ fn test_cross() {
         || {
             run_command(
                 "cargo",
-                &["check", "--target", "thumbv7em-none-eabi", "--workspace"],
+                &["check", "--target", "thumbv7em-none-eabi"],
                 Some("firmware"),
                 &[],
             )
@@ -443,14 +411,11 @@ fn test_lint() {
     println!("🧪 lint");
     do_test(|| run_command("cargo", &["clean"], None, &[]), "lint");
     do_test(
-        || run_command("cargo", &["fmt", "--all", "--", "--check"], None, &[]),
+        || run_command("cargo", &["fmt", "--", "--check"], None, &[]),
         "lint",
     );
 
-    do_test(
-        || run_command("cargo", &["clippy", "--workspace"], None, &[]),
-        "lint",
-    );
+    do_test(|| run_command("cargo", &["clippy"], None, &[]), "lint");
 }
 
 fn test_ui() {


### PR DESCRIPTION
This PR
- makes `xtask test-lint` fail if a warning is present
- runs `clippy` in the `firmware/` directory
- remove unnecessary `--workspace` options
- fixes clippy lints