### PR TITLE
`defmt-macros`: Disable default features for `rstest `

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#741]: `defmt-macros`: Disable default-features for `rstest`
 - [#740]: Snapshot tests for `core::net`
 - [#739]: `xtask`: Clean up
 - [#737]: `panic-probe`: Add `hard_fault()` for use in `defmt::panic_handler`
@@ -14,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#603]: `defmt`: Raw pointers now print as `0x1234` instead of `1234`
 - [#536]: `defmt-parser`: Switch to using an enum for errors, and add some help text pointing you to the defmt docs if you use the wrong type specifier in a format string.
 
+[#741]: https://github.com/knurling-rs/defmt/pull/741
 [#740]: https://github.com/knurling-rs/defmt/pull/740
 [#739]: https://github.com/knurling-rs/defmt/pull/739
 [#737]: https://github.com/knurling-rs/defmt/pull/737

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,14 +17,16 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { path = "../parser", features = ["unstable"], version = "=0.3.1" }
+defmt-parser = { version = "0.3.1", path = "../parser", features = [
+    "unstable",
+] }
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
 # we require at least 1.0.56; see https://github.com/knurling-rs/defmt/pull/684
 syn = { version = "1.0.101", features = ["full"] }
 
-[dev_dependencies]
+[dev-dependencies]
 maplit = "1"
 pretty_assertions = "1"
-rstest = "0.15"
+rstest = { version = "0.16", default-features = false }


### PR DESCRIPTION
This PR removes a large junk of indirect dev-dependencies.
```diff
└── rstest v0.15.0
-   ├── futures v0.3.27
-   │   ├── futures-channel v0.3.27
-   │   │   ├── futures-core v0.3.27
-   │   │   └── futures-sink v0.3.27
-   │   ├── futures-core v0.3.27
-   │   ├── futures-executor v0.3.27
-   │   │   ├── futures-core v0.3.27
-   │   │   ├── futures-task v0.3.27
-   │   │   └── futures-util v0.3.27
-   │   │       ├── futures-channel v0.3.27 (*)
-   │   │       ├── futures-core v0.3.27
-   │   │       ├── futures-io v0.3.27
-   │   │       ├── futures-macro v0.3.27 (proc-macro)
-   │   │       │   ├── proc-macro2 v1.0.47 (*)
-   │   │       │   ├── quote v1.0.21 (*)
-   │   │       │   └── syn v1.0.105 (*)
-   │   │       ├── futures-sink v0.3.27
-   │   │       ├── futures-task v0.3.27
-   │   │       ├── memchr v2.5.0
-   │   │       ├── pin-project-lite v0.2.9
-   │   │       ├── pin-utils v0.1.0
-   │   │       └── slab v0.4.8
-   │   │           [build-dependencies]
-   │   │           └── autocfg v1.1.0
-   │   ├── futures-io v0.3.27
-   │   ├── futures-sink v0.3.27
-   │   ├── futures-task v0.3.27
-   │   └── futures-util v0.3.27 (*)
-   ├── futures-timer v3.0.2
    └── rstest_macros v0.14.0 (proc-macro)
        ├── cfg-if v1.0.0
        ├── proc-macro2 v1.0.47 (*)
        ├── quote v1.0.21 (*)
        └── syn v1.0.105 (*)
        [build-dependencies]
        └── rustc_version v0.4.0
            └── semver v1.0.14
```