### PR TITLE
Bump wire version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#747]: Bump wire version
+
+[#747]: https://github.com/knurling-rs/defmt/pull/747
+
 ## [v0.3.3] - 2023-03-29
 
 - [#745]: Release `defmt-v0.3.3`, `defmt-decoder-v0.3.5`, `defmt-macros v0.3.4`, `defmt-parser v0.3.2`, `defmt-print v0.3.5` and `panic-probe v0.3.1`

--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -220,7 +220,7 @@ pub fn parse_impl(elf: &[u8], check_version: bool) -> Result<Option<Table>, anyh
 fn check_version(version: &str) -> Result<(), String> {
     if version != DEFMT_VERSION {
         let msg = format!(
-            "defmt wire format version mismatch: firmware is using {}, `probe-run` supports {}\nsuggestion: `cargo install` a different version of `probe-run` that supports defmt {}",
+            "defmt wire format version mismatch: firmware is using {}, `probe-run` supports {}\nsuggestion: use a newer version of `defmt` or `cargo install` a different version of `probe-run` that supports defmt {}",
             version, DEFMT_VERSION, version
         );
 

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(docsrs, doc(cfg(unstable)))]
 #![doc(html_logo_url = "https://knurling.ferrous-systems.com/knurling_logo_light_text.svg")]
 
-pub const DEFMT_VERSION: &str = "3";
+pub const DEFMT_VERSION: &str = "4";
 
 mod decoder;
 mod elf2table;

--- a/defmt/src/lib.rs
+++ b/defmt/src/lib.rs
@@ -30,7 +30,7 @@ extern crate alloc;
 #[used]
 #[cfg_attr(target_os = "macos", link_section = ".defmt,end.VERSION")]
 #[cfg_attr(not(target_os = "macos"), link_section = ".defmt.end")]
-#[export_name = "_defmt_version_ = 3"]
+#[export_name = "_defmt_version_ = 4"]
 static DEFMT_VERSION: u8 = 0;
 
 #[used]

--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -40,8 +40,8 @@ use crate::{ALL_ERRORS, ALL_SNAPSHOT_TESTS, SNAPSHOT_TESTS_DIRECTORY};
 const DISABLED: bool = false;
 
 // use this format: PR <number> - <what feature / change broke compatibility>
-// PR #569 - defmt::println!
-const REVISION_UNDER_TEST: &str = "8a6e8eebe40f943d9b0ba8725cd6da033b9c399e";
+// PR #742 - Adds `crate_name` to `Symbol`
+const REVISION_UNDER_TEST: &str = "c16f1b79d730749e1ca21c17e7fa27385e0f5b7d";
 
 // the target name is in `firmware/qemu/.cargo/config.toml` but it'd be hard to extract it from that file
 const RUNNER_ENV_VAR: &str = "CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER";

--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -40,8 +40,8 @@ use crate::{ALL_ERRORS, ALL_SNAPSHOT_TESTS, SNAPSHOT_TESTS_DIRECTORY};
 const DISABLED: bool = false;
 
 // use this format: PR <number> - <what feature / change broke compatibility>
-// PR #742 - Adds `crate_name` to `Symbol`
-const REVISION_UNDER_TEST: &str = "c16f1b79d730749e1ca21c17e7fa27385e0f5b7d";
+// PR #747 - Bump wire format
+const REVISION_UNDER_TEST: &str = "0e92d3a88aa472377b964979f522829d961d8986";
 
 // the target name is in `firmware/qemu/.cargo/config.toml` but it'd be hard to extract it from that file
 const RUNNER_ENV_VAR: &str = "CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER";


### PR DESCRIPTION
The changes introduced in https://github.com/knurling-rs/defmt/pull/742 add the field `crate_name` to the wire format. As far as I understand this requires a bump of the defmt version.

Also, is this a reason to yank version 0.3.5? This problem caused me quite some headache today and I hope this spares others from going through the same pain.