### PR TITLE
add defmt impls for `core::ptr::NonNull` and `fn(...) -> Ret`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#753]: Add `defmt::Format` impls for `core::ptr::NonNull` and `fn(Args...) -> Ret` (up to 12 arguments)
+
+[#753]: https://github.com/knurling-rs/defmt/pull/753
+
 ## [v0.3.5] - 2023-05-05
 
 - [#xxx]: Release `defmt-decoder v0.3.7`, `defmt-macros v0.3.5`, `defmt-parser v0.3.3`, `defmt-print v0.3.7`

--- a/defmt/src/impls/core_/mod.rs
+++ b/defmt/src/impls/core_/mod.rs
@@ -12,6 +12,7 @@ mod cell;
 mod net;
 mod num;
 mod ops;
+mod ptr;
 mod slice;
 
 use super::*;

--- a/defmt/src/impls/core_/ptr.rs
+++ b/defmt/src/impls/core_/ptr.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+impl<T> Format for core::ptr::NonNull<T> {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "{}", self.as_ptr())
+    }
+}
+
+#[cfg(c_variadic)]
+macro_rules! fnptr_format_cvariadic {
+    ($($Arg:ident),+) => {
+        impl<Ret, $($Arg),*> Format for extern "C" fn($($Arg),* , ...) -> Ret {
+            fn format(&self, fmt: Formatter) {
+                crate::write!(fmt, "{}", (*self as usize) as *const ())
+            }
+        }
+        impl<Ret, $($Arg),*> Format for unsafe extern "C" fn($($Arg),* , ...) -> Ret {
+            fn format(&self, fmt: Formatter) {
+                crate::write!(fmt, "{}", (*self as usize) as *const ())
+            }
+        }
+    };
+    () => {
+        // C variadics require at least one other argument
+    };
+}
+
+macro_rules! fnptr_format_args {
+    ($($Arg:ident),*) => {
+        impl<Ret, $($Arg),*> Format for extern "Rust" fn($($Arg),*) -> Ret {
+            fn format(&self, fmt: Formatter) {
+                crate::write!(fmt, "{}", (*self as usize) as *const ())
+            }
+        }
+        impl<Ret, $($Arg),*> Format for extern "C" fn($($Arg),*) -> Ret {
+            fn format(&self, fmt: Formatter) {
+                crate::write!(fmt, "{}", (*self as usize) as *const ())
+            }
+        }
+        impl<Ret, $($Arg),*> Format for unsafe extern "Rust" fn($($Arg),*) -> Ret {
+            fn format(&self, fmt: Formatter) {
+                crate::write!(fmt, "{}", (*self as usize) as *const ())
+            }
+        }
+        impl<Ret, $($Arg),*> Format for unsafe extern "C" fn($($Arg),*) -> Ret {
+            fn format(&self, fmt: Formatter) {
+                crate::write!(fmt, "{}", (*self as usize) as *const ())
+            }
+        }
+        #[cfg(c_variadic)]
+        fnptr_format_cvariadic!{ $($Arg),* }
+    };
+}
+
+// core::ptr has fnptr impls up to 12 arguments
+// https://doc.rust-lang.org/src/core/ptr/mod.rs.html#1994
+fnptr_format_args! {}
+fnptr_format_args! { A }
+fnptr_format_args! { A, B }
+fnptr_format_args! { A, B, C }
+fnptr_format_args! { A, B, C, D }
+fnptr_format_args! { A, B, C, D, E }
+fnptr_format_args! { A, B, C, D, E, F }
+fnptr_format_args! { A, B, C, D, E, F, G }
+fnptr_format_args! { A, B, C, D, E, F, G, H }
+fnptr_format_args! { A, B, C, D, E, F, G, H, I }
+fnptr_format_args! { A, B, C, D, E, F, G, H, I, J }
+fnptr_format_args! { A, B, C, D, E, F, G, H, I, J, K }
+fnptr_format_args! { A, B, C, D, E, F, G, H, I, J, K, L }

--- a/firmware/qemu/src/bin/log.out
+++ b/firmware/qemu/src/bin/log.out
@@ -155,4 +155,17 @@ INFO RefCell: RefCell { value: 43981 }
 INFO borrowed RefCell: RefCell { value: <borrowed> }
 INFO BorrowMutError: BorrowMutError
 INFO BorrowError: BorrowError
+INFO NonNull: 0xccbbaadd
+INFO fn() -> i32: 0xccbbaadd
+INFO extern "C" fn() -> i32: 0xccbbaadd
+INFO unsafe fn() -> i32: 0xccbbaadd
+INFO unsafe extern "C" fn() -> i32: 0xccbbaadd
+INFO fn(i32) -> i32: 0xccbbaadd
+INFO extern "C" fn(i32) -> i32: 0xccbbaadd
+INFO unsafe fn(i32) -> i32: 0xccbbaadd
+INFO unsafe extern "C" fn(i32) -> i32: 0xccbbaadd
+INFO fn(i32, i32, i32, i32, i32) -> i32: 0xccbbaadd
+INFO extern "C" fn(i32, i32, i32, i32, i32) -> i32: 0xccbbaadd
+INFO unsafe fn(i32, i32, i32, i32, i32) -> i32: 0xccbbaadd
+INFO unsafe extern "C" fn(i32, i32, i32, i32, i32) -> i32: 0xccbbaadd
 INFO QEMU test finished!

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -731,6 +731,52 @@ fn main() -> ! {
         defmt::info!("BorrowMutError: {}", d);
         defmt::info!("BorrowError: {}", e);
     }
+    // core::ptr
+    {
+        let ptr_addr: usize = 0xCCBBAADD;
+        defmt::info!(
+            "NonNull: {}",
+            core::ptr::NonNull::new(ptr_addr as *mut NotFormatType).unwrap()
+        );
+        // fn pointers
+        // no params
+        let rust_fn: fn() -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        let c_fn: extern "C" fn() -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        let unsafe_rust_fn: unsafe fn() -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        let unsafe_c_fn: unsafe extern "C" fn() -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        defmt::info!("fn() -> i32: {}", rust_fn);
+        defmt::info!("extern \"C\" fn() -> i32: {}", c_fn);
+        defmt::info!("unsafe fn() -> i32: {}", unsafe_rust_fn);
+        defmt::info!("unsafe extern \"C\" fn() -> i32: {}", unsafe_c_fn);
+        // 1 param
+        let rust_fn: fn(i32) -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        let c_fn: extern "C" fn(i32) -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        let unsafe_rust_fn: unsafe fn(i32) -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        let unsafe_c_fn: unsafe extern "C" fn(i32) -> i32 =
+            unsafe { core::mem::transmute(ptr_addr) };
+        defmt::info!("fn(i32) -> i32: {}", rust_fn);
+        defmt::info!("extern \"C\" fn(i32) -> i32: {}", c_fn);
+        defmt::info!("unsafe fn(i32) -> i32: {}", unsafe_rust_fn);
+        defmt::info!("unsafe extern \"C\" fn(i32) -> i32: {}", unsafe_c_fn);
+        // 5 params
+        let rust_fn: fn(i32, i32, i32, i32, i32) -> i32 = unsafe { core::mem::transmute(ptr_addr) };
+        let c_fn: extern "C" fn(i32, i32, i32, i32, i32) -> i32 =
+            unsafe { core::mem::transmute(ptr_addr) };
+        let unsafe_rust_fn: unsafe fn(i32, i32, i32, i32, i32) -> i32 =
+            unsafe { core::mem::transmute(ptr_addr) };
+        let unsafe_c_fn: unsafe extern "C" fn(i32, i32, i32, i32, i32) -> i32 =
+            unsafe { core::mem::transmute(ptr_addr) };
+        defmt::info!("fn(i32, i32, i32, i32, i32) -> i32: {}", rust_fn);
+        defmt::info!("extern \"C\" fn(i32, i32, i32, i32, i32) -> i32: {}", c_fn);
+        defmt::info!(
+            "unsafe fn(i32, i32, i32, i32, i32) -> i32: {}",
+            unsafe_rust_fn
+        );
+        defmt::info!(
+            "unsafe extern \"C\" fn(i32, i32, i32, i32, i32) -> i32: {}",
+            unsafe_c_fn
+        );
+    }
 
     defmt::info!("QEMU test finished!");
 


### PR DESCRIPTION
Fixes #752

NonNull and fn pointers formatted like a raw pointer. This matches the [behaviour of `Debug`](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9ef1d891fe9ae31b46512ded1e5ff5fc) for these types