### PR TITLE
Goodbye bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,2 +1,0 @@
-delete_merged_branches = true
-status = ["ci"]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,7 @@ on:
     # opened, reopened, synchronize are the default types for pull_request.
     # labeled, unlabeled ensure this check is also run if a label is added or removed.
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
 
 name: Changelog
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main, staging, trying]
   pull_request:
     branches: [main]
   schedule:
     # runs 1 min after 2 or 1 AM (summer/winter) berlin time
     - cron: "1 0 * * *"
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
@@ -114,21 +113,3 @@ jobs:
         run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
       - name: Run backward compatibility test
         run: cargo xtask test-backcompat
-
-  # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
-  # bors.tech integration
-  ci-success:
-    name: ci
-    if: ${{ success() }}
-    needs:
-      - host
-      - cross
-      - lint
-      - mdbook
-      - qemu-snapshot
-      - backcompat
-      - ui
-    runs-on: ubuntu-20.04
-    steps:
-      - name: CI succeeded
-        run: exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#xxx] Switch from bors to merge queue
 - [#753]: Add `defmt::Format` impls for `core::ptr::NonNull` and `fn(Args...) -> Ret` (up to 12 arguments)
 
+[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
 [#753]: https://github.com/knurling-rs/defmt/pull/753
 
 ## [v0.3.5] - 2023-05-05
 
-- [#xxx]: Release `defmt-decoder v0.3.7`, `defmt-macros v0.3.5`, `defmt-parser v0.3.3`, `defmt-print v0.3.7`
+- [#754]: Release `defmt-decoder v0.3.7`, `defmt-macros v0.3.5`, `defmt-parser v0.3.3`, `defmt-print v0.3.7`
 - [#750]: Add support for decoding wire format version 3
 
-[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
+[#754]: https://github.com/knurling-rs/defmt/pull/754
 [#750]: https://github.com/knurling-rs/defmt/pull/750
 
 ## [v0.3.4] - 2023-04-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [#xxx] Switch from bors to merge queue
+- [#756] Switch from bors to merge queue
 - [#753]: Add `defmt::Format` impls for `core::ptr::NonNull` and `fn(Args...) -> Ret` (up to 12 arguments)
 
-[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
+[#756]: https://github.com/knurling-rs/defmt/pull/756
 [#753]: https://github.com/knurling-rs/defmt/pull/753
 
 ## [v0.3.5] - 2023-05-05


### PR DESCRIPTION
The publicly hosted instance of bors-ng is deprecated. Therefore we switch to GitHub merge queue.

Two things are happening:

- This PR edits config files to switch from bors to the new github merge queue.
- Additionally the repository settings and in particular the branch protection rules are edited as described in [the docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

I am a bit unsure how to test this without creating a huge amount of pull requests, but I hope the changed settings already take effect for this PR.