### PR TITLE
Allow defmt-print to connect to a TCP port.

### DIFF
--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -1,10 +1,12 @@
+use std::io::{Stdin, StdinLock};
+use std::net::TcpStream;
 use std::{
     env, fs,
     io::{self, Read},
     path::{Path, PathBuf},
 };
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Error};
 use clap::Parser;
 use defmt_decoder::{DecodeError, Frame, Locations, Table, DEFMT_VERSIONS};
 
@@ -26,6 +28,26 @@ struct Opts {
 
     #[arg(short = 'V', long)]
     version: bool,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Parser)]
+enum Command {
+    Stdin {},
+    Tcp {
+        #[structopt(short, long, env = "RTT_HOST")]
+        host: String,
+
+        #[structopt(short, long, env = "RTT_PORT")]
+        port: u16,
+    },
+}
+
+enum Source<'a> {
+    Stdin(StdinLock<'a>),
+    Tcp(TcpStream),
 }
 
 const READ_BUFFER_SIZE: usize = 1024;
@@ -37,6 +59,7 @@ fn main() -> anyhow::Result<()> {
         show_skipped_frames,
         verbose,
         version,
+        command,
     } = Opts::parse();
 
     if version {
@@ -64,15 +87,31 @@ fn main() -> anyhow::Result<()> {
     let mut stream_decoder = table.new_stream_decoder();
 
     let current_dir = env::current_dir()?;
-    let mut stdin = io::stdin().lock();
+    let stdin = io::stdin();
+
+    let mut source: Source = match command {
+        None => open_stdin(&stdin),
+        Some(Command::Stdin {}) => open_stdin(&stdin),
+        Some(Command::Tcp { host, port }) => open_tcp(host, port),
+    }?;
 
     loop {
-        // read from stdin and push it to the decoder
-        let n = stdin.read(&mut buf)?;
+        // read from stdin or tcpstream and push it to the decoder
+        let (n, eof) = match source {
+            Source::Stdin(ref mut stdin) => {
+                let n = stdin.read(&mut buf)?;
+                (n, n == 0)
+            },
+            Source::Tcp(ref mut tcpstream) => {
+                (tcpstream.read(&mut buf)?, false)
+            },
+        };
+
         // if 0 bytes where read, we reached EOF, so quit
-        if n == 0 {
-            break Ok(());
+        if eof {
+            break Ok(())
         }
+
         stream_decoder.received(&buf[..n]);
 
         // decode the received data
@@ -96,6 +135,17 @@ fn main() -> anyhow::Result<()> {
                 },
             }
         }
+    }
+}
+
+fn open_stdin(stdin: &Stdin) -> Result<Source, Error> {
+    Ok(Source::Stdin(stdin.lock()))
+}
+
+fn open_tcp<'a>(host: String, port: u16) -> Result<Source<'a>, Error> {
+    match TcpStream::connect(format!("{host}:{port}")) {
+        Ok(stream) => Ok(Source::Tcp(stream)),
+        Err(e) => Err(anyhow!(e)),
     }
 }
 


### PR DESCRIPTION
Why: The Segger J-Link debugger sessions listen on TCP port 19021 by default and dump RTT output to any client that connects to the port.

This allows defmt-print to log data so you can see it in real-time WHILE you are debugging in your IDE.

example:
```
$ defmt-print tcp --host=127.0.0.1 --port=19021
```

Output from `--help` is now:

```
defmt-print 0.3.2
Prints defmt-encoded logs to stdout

USAGE:
    defmt-print.exe [FLAGS] -e <elf> [SUBCOMMAND]

FLAGS:
    -h, --help                   Prints help information
        --json
        --show-skipped-frames
    -v, --verbose
    -V, --version

OPTIONS:
    -e <elf>

SUBCOMMANDS:
    help      Prints this message or the help of the given subcommand(s)
    std-in
    tcp
```

Default subcommand is `std-in` for backwards compatibility.

The host and port can read from your environment variables `RTT_HOST` and `RTT_PORT` respectively.

```
$ defmt-print tcp --help
defmt-print-tcp 0.3.2

USAGE:
    defmt-print -e <elf> tcp --host <host> --port <port>

FLAGS:
        --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -h, --host <host>     [env: RTT_HOST=]
    -p, --port <port>     [env: RTT_PORT=]
```

```
C:\> set RTT_HOST=127.0.0.1
C:\> set RTT_PORT=19021
```
or
```
$ export RTT_HOST=127.0.0.1
$ export RTT_PORT=19021
```

Once environment variables are set they are shown and used appropriately.
```
$ defmt-print tcp --help
defmt-print-tcp 0.3.2

USAGE:
    defmt-print -e <elf> tcp --host <host> --port <port>

FLAGS:
        --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -h, --host <host>     [env: RTT_HOST=127.0.0.1]
    -p, --port <port>     [env: RTT_PORT=19021]

$ defmt-print -e <elf> tcp
...
```

J-Link console:
![image](https://user-images.githubusercontent.com/57075/172225278-d06ca849-729b-4139-a61f-f7460fc70e1e.png)

CLion debug session of the target:
![image](https://user-images.githubusercontent.com/57075/172225496-8ec82972-453a-4aff-a6bc-e47b3ce74ec6.png)

defmt-print output:
![image](https://user-images.githubusercontent.com/57075/172225729-fc83a06e-dc44-42a7-8eed-8a44e36ef129.png)

This is a replacement PR for #676