### PR TITLE
`defmt-macros`: Upgrade to syn 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#760]: `defmt-macros`: Upgrade to syn 2
 - [#758]: `defmt-print`: Tidy up
 - [#757]: `defmt-print`: Allow reading from a tcp port
 - [#756]: `CI`: Switch from bors to merge queue
 - [#753]: `demft` Add `Format` impls for `core::ptr::NonNull` and `fn(Args...) -> Ret` (up to 12 arguments)
 
+[#760]: https://github.com/knurling-rs/defmt/pull/760
 [#758]: https://github.com/knurling-rs/defmt/pull/758
 [#757]: https://github.com/knurling-rs/defmt/pull/757
 [#756]: https://github.com/knurling-rs/defmt/pull/756

--- a/firmware/defmt-test/macros/Cargo.toml
+++ b/firmware/defmt-test/macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["extra-traits", "full"] }
+syn = { version = "2", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
 trybuild = "1"

--- a/firmware/defmt-test/macros/src/lib.rs
+++ b/firmware/defmt-test/macros/src/lib.rs
@@ -47,22 +47,22 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
                 let mut ignore = false;
 
                 f.attrs.retain(|attr| {
-                    if attr.path.is_ident("init") {
+                    if attr.path().is_ident("init") {
                         test_kind = Some(Attr::Init);
                         false
-                    } else if attr.path.is_ident("test") {
+                    } else if attr.path().is_ident("test") {
                         test_kind = Some(Attr::Test);
                         false
-                    } else if attr.path.is_ident("before_each") {
+                    } else if attr.path().is_ident("before_each") {
                         test_kind = Some(Attr::BeforeEach);
                         false
-                    } else if attr.path.is_ident("after_each") {
+                    } else if attr.path().is_ident("after_each") {
                         test_kind = Some(Attr::AfterEach);
                         false
-                    } else if attr.path.is_ident("should_error") {
+                    } else if attr.path().is_ident("should_error") {
                         should_error = true;
                         false
-                    } else if attr.path.is_ident("ignore") {
+                    } else if attr.path().is_ident("ignore") {
                         ignore = true;
                         false
                     } else {
@@ -520,7 +520,7 @@ fn extract_cfgs(attrs: &[Attribute]) -> Vec<Attribute> {
     let mut cfgs = vec![];
 
     for attr in attrs {
-        if attr.path.is_ident("cfg") {
+        if attr.path().is_ident("cfg") {
             cfgs.push(attr.clone());
         }
     }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,8 +21,7 @@ defmt-parser = { version = "=0.3.3", path = "../parser", features = ["unstable"]
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
-# we require at least 1.0.56; see https://github.com/knurling-rs/defmt/pull/684
-syn = { version = "1.0.101", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 maplit = "1"

--- a/macros/src/attributes/panic_handler.rs
+++ b/macros/src/attributes/panic_handler.rs
@@ -46,7 +46,7 @@ fn check_for_attribute_conflicts(
     reject_list: &[&str],
 ) {
     for attr in attrs_to_check {
-        if let Some(ident) = attr.path.get_ident() {
+        if let Some(ident) = attr.path().get_ident() {
             let ident = ident.to_string();
 
             if reject_list.contains(&ident.as_str()) {

--- a/macros/src/items/bitflags/input.rs
+++ b/macros/src/items/bitflags/input.rs
@@ -84,7 +84,7 @@ fn extract_cfgs(attrs: &[Attribute]) -> Vec<Attribute> {
     let mut cfgs = vec![];
 
     for attr in attrs {
-        if attr.path.is_ident("cfg") {
+        if attr.path().is_ident("cfg") {
             cfgs.push(attr.clone());
         }
     }


### PR DESCRIPTION
This performs the upgrade to syn 2.

I did this in two steps:

1. I upgraded to syn 2 by changing as little as possible about the code, while still passing all UI tests.
2. I migrated `get_defmt_format_option` to the new `parse_nested_meta` method. This makes the code much more readable while keeping the same behavior.

CC: @Urhengulas, I saw you started working on this on the [`syn2`](https://github.com/knurling-rs/defmt/tree/syn2) branch, after I already started on this.