### PR TITLE
decoder: allow disabling location printing for defmt frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.3.5] - 2023-06-19
 
+- [#762]: `defmt-decoder`: Make logging location optional for defmt frames
 - [#760]: `defmt-macros`: Upgrade to syn 2
 - [#759]: Release `defmt v0.3.5`, `defmt-macros 0.3.6` and `defmt-print 0.3.8`
 - [#758]: `defmt-print`: Tidy up

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -44,7 +44,7 @@ impl JsonLogger {
     pub fn new(should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static) -> Box<Self> {
         Box::new(Self {
             should_log: Box::new(should_log),
-            host_logger: PrettyLogger::new_unboxed(true, |_| true),
+            host_logger: PrettyLogger::new_unboxed(false, true, |_| true),
         })
     }
 

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -119,16 +119,19 @@ impl<'a> DefmtRecord<'a> {
 /// The caller has to provide a `should_log` closure that determines whether a log record should be
 /// printed.
 ///
-/// If `always_include_location` is `true`, a second line containing location information will be
-/// printed for *all* records, not just for defmt frames (defmt frames always get location info
-/// included if it is available, regardless of this setting).
+/// If `include_location` is `true`, a second line containing location information will be
+/// printed for defmt frames.
+///
+/// If `always_include_location` is also `true`, the second line containing location information
+/// will be printed for *all* records and not just for defmt frames.
 pub fn init_logger(
+    include_location: bool,
     always_include_location: bool,
     json: bool,
     should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
 ) {
     log::set_boxed_logger(match json {
-        false => PrettyLogger::new(always_include_location, should_log),
+        false => PrettyLogger::new(include_location, always_include_location, should_log),
         true => {
             JsonLogger::print_schema_version();
             JsonLogger::new(should_log)

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> anyhow::Result<()> {
         return print_version();
     }
 
-    defmt_decoder::log::init_logger(verbose, json, move |metadata| match verbose {
+    defmt_decoder::log::init_logger(false, verbose, json, move |metadata| match verbose {
         false => defmt_decoder::log::is_defmt_frame(metadata), // We display *all* defmt frames, but nothing else.
         true => true,                                          // We display *all* frames.
     });


### PR DESCRIPTION
This is a breaking change to the decoder but since decoder is entirely unstable that seems like it's not an issue.