### PR TITLE
decoder: add support for customizable logger formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- [#765]: `defmt-decoder`: Add support for customizable logger formatting
+
+[#765]: https://github.com/knurling-rs/defmt/pull/765
 
 - [#766] `decoder::log`: Rename `PrettyLogger` to `StdoutLogger`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- [#765]: `defmt-decoder`: Add support for customizable logger formatting
-
-[#765]: https://github.com/knurling-rs/defmt/pull/765
 
 - [#766] `decoder::log`: Rename `PrettyLogger` to `StdoutLogger`
+- [#765]: `defmt-decoder`: Add support for customizable logger formatting
 
 [#766]: https://github.com/knurling-rs/defmt/pull/766
+[#765]: https://github.com/knurling-rs/defmt/pull/765
 
 ## [v0.3.5] - 2023-06-19
 

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -14,6 +14,7 @@ byteorder = "1"
 colored = "2"
 defmt-parser = { version = "=0.3.3", path = "../parser", features = ["unstable"] }
 ryu = "1"
+nom = "7"
 
 # display
 time = { version = "0.3", default-features = false, features = [

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -271,6 +271,10 @@ impl Table {
     pub fn encoding(&self) -> Encoding {
         self.encoding
     }
+
+    pub fn has_timestamp(&self) -> bool {
+        self.timestamp.is_some()
+    }
 }
 
 // NOTE follows `parser::Type`

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -1,0 +1,110 @@
+use nom::IResult;
+use nom::bytes::complete::{take, take_till1};
+use nom::character::complete::char;
+use nom::combinator::{map_res, map};
+use nom::error::{FromExternalError, ParseError};
+use nom::multi::many0;
+use nom::sequence::delimited;
+use nom::branch::alt;
+use nom::Parser;
+
+#[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
+pub enum LogSegment {
+    String(String),
+    Timestamp,
+    FileName,
+    FilePath,
+    ModulePath,
+    LineNumber,
+    LogLevel,
+    Log,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct InvalidArgument;
+
+fn parse_argument<'a, E>(input: &'a str) -> IResult<&'a str, LogSegment, E>
+where E: ParseError<&'a str> + FromExternalError<&'a str, InvalidArgument>, {
+    let parse_enclosed = delimited(char('{'), take(1u32), char('}'));
+    let mut parse_type = map_res(parse_enclosed, move |s| {
+        match s {
+            "t" => Ok(LogSegment::Timestamp),
+            "f" => Ok(LogSegment::FileName),
+            "F" => Ok(LogSegment::FilePath),
+            "m" => Ok(LogSegment::ModulePath),
+            "l" => Ok(LogSegment::LineNumber),
+            "L" => Ok(LogSegment::LogLevel),
+            "s" => Ok(LogSegment::Log),
+            _ => Err(InvalidArgument),
+        }
+    });
+
+    parse_type.parse(input)
+}
+
+fn parse_string_segment<'a, E>(input: &'a str) -> IResult<&'a str, LogSegment, E>
+where E: ParseError<&'a str>, {
+    map(take_till1(|c| c == '{'),|s: &str| LogSegment::String(s.to_string())).parse(input)
+}
+
+pub fn parse<'a>(input: &'a str) -> Result<Vec<LogSegment>, String> {
+    let mut parse_all = many0(alt((parse_argument::<()>, parse_string_segment)));
+
+    parse_all(input).map(|(_, output)| output).map_err(|e| e.to_string())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_log_template() {
+        let log_template = "{t} [{L}] {s}\n└─ {m} @ {F}:{l}";
+
+        let expected_output = vec![
+            LogSegment::Timestamp,
+            LogSegment::String(" [".to_string()),
+            LogSegment::LogLevel,
+            LogSegment::String("] ".to_string()),
+            LogSegment::Log,
+            LogSegment::String("\n└─ ".to_string()),
+            LogSegment::ModulePath,
+            LogSegment::String(" @ ".to_string()),
+            LogSegment::FilePath,
+            LogSegment::String(":".to_string()),
+            LogSegment::LineNumber,
+        ];
+
+        let result = parse(log_template);
+        assert_eq!(result, Ok(expected_output));
+    }
+
+    #[test]
+    fn test_parse_string_segment() {
+        let result = parse_string_segment::<()>("Log: {t}");
+        let (input, output) = result.unwrap();
+        assert_eq!(input, "{t}");
+        assert_eq!(output, LogSegment::String("Log: ".to_string()));
+    }
+
+    #[test]
+    fn test_parse_empty_string_segment() {
+        let result = parse_string_segment::<()>("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_timestamp_argument() {
+        let result = parse_argument::<()>("{t}");
+        assert_eq!(result, Ok(("", LogSegment::Timestamp)));
+    }
+
+    #[test]
+    fn test_parse_invalid_argument() {
+        let result = parse_argument::<()>("{foo}");
+        let result = dbg!(result);
+        assert_eq!(result, Result::Err(nom::Err::Error(())));
+    }
+}

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -1,60 +1,51 @@
-use nom::branch::alt;
-use nom::bytes::complete::{take, take_till1};
-use nom::character::complete::char;
-use nom::combinator::{map, map_res};
-use nom::error::{FromExternalError, ParseError};
-use nom::multi::many0;
-use nom::sequence::delimited;
-use nom::IResult;
-use nom::Parser;
+use nom::{
+    branch::alt,
+    bytes::complete::{take, take_till1},
+    character::complete::char,
+    combinator::{map, map_res},
+    multi::many0,
+    sequence::delimited,
+    IResult, Parser,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 #[non_exhaustive]
-pub enum LogSegment {
-    String(String),
-    Timestamp,
+pub(super) enum LogSegment {
     FileName,
     FilePath,
-    ModulePath,
     LineNumber,
-    LogLevel,
     Log,
+    LogLevel,
+    ModulePath,
+    String(String),
+    Timestamp,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct InvalidArgument;
-
-fn parse_argument<'a, E>(input: &'a str) -> IResult<&'a str, LogSegment, E>
-where
-    E: ParseError<&'a str> + FromExternalError<&'a str, InvalidArgument>,
-{
+fn parse_argument(input: &str) -> IResult<&str, LogSegment, ()> {
     let parse_enclosed = delimited(char('{'), take(1u32), char('}'));
     let mut parse_type = map_res(parse_enclosed, move |s| match s {
-        "t" => Ok(LogSegment::Timestamp),
         "f" => Ok(LogSegment::FileName),
         "F" => Ok(LogSegment::FilePath),
-        "m" => Ok(LogSegment::ModulePath),
         "l" => Ok(LogSegment::LineNumber),
-        "L" => Ok(LogSegment::LogLevel),
         "s" => Ok(LogSegment::Log),
-        _ => Err(InvalidArgument),
+        "L" => Ok(LogSegment::LogLevel),
+        "m" => Ok(LogSegment::ModulePath),
+        "t" => Ok(LogSegment::Timestamp),
+        _ => Err(()),
     });
 
     parse_type.parse(input)
 }
 
-fn parse_string_segment<'a, E>(input: &'a str) -> IResult<&'a str, LogSegment, E>
-where
-    E: ParseError<&'a str>,
-{
+fn parse_string_segment(input: &str) -> IResult<&str, LogSegment, ()> {
     map(take_till1(|c| c == '{'), |s: &str| {
         LogSegment::String(s.to_string())
     })
     .parse(input)
 }
 
-pub fn parse(input: &str) -> Result<Vec<LogSegment>, String> {
-    let mut parse_all = many0(alt((parse_argument::<()>, parse_string_segment)));
+pub(super) fn parse(input: &str) -> Result<Vec<LogSegment>, String> {
+    let mut parse_all = many0(alt((parse_argument, parse_string_segment)));
 
     parse_all(input)
         .map(|(_, output)| output)
@@ -89,7 +80,7 @@ mod tests {
 
     #[test]
     fn test_parse_string_segment() {
-        let result = parse_string_segment::<()>("Log: {t}");
+        let result = parse_string_segment("Log: {t}");
         let (input, output) = result.unwrap();
         assert_eq!(input, "{t}");
         assert_eq!(output, LogSegment::String("Log: ".to_string()));
@@ -97,19 +88,19 @@ mod tests {
 
     #[test]
     fn test_parse_empty_string_segment() {
-        let result = parse_string_segment::<()>("");
+        let result = parse_string_segment("");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_parse_timestamp_argument() {
-        let result = parse_argument::<()>("{t}");
+        let result = parse_argument("{t}");
         assert_eq!(result, Ok(("", LogSegment::Timestamp)));
     }
 
     #[test]
     fn test_parse_invalid_argument() {
-        let result = parse_argument::<()>("{foo}");
+        let result = parse_argument("{foo}");
         assert_eq!(result, Result::Err(nom::Err::Error(())));
     }
 }

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -110,7 +110,6 @@ mod tests {
     #[test]
     fn test_parse_invalid_argument() {
         let result = parse_argument::<()>("{foo}");
-        let result = dbg!(result);
         assert_eq!(result, Result::Err(nom::Err::Error(())));
     }
 }

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -48,7 +48,7 @@ where E: ParseError<&'a str>, {
     map(take_till1(|c| c == '{'),|s: &str| LogSegment::String(s.to_string())).parse(input)
 }
 
-pub fn parse<'a>(input: &'a str) -> Result<Vec<LogSegment>, String> {
+pub fn parse(input: &str) -> Result<Vec<LogSegment>, String> {
     let mut parse_all = many0(alt((parse_argument::<()>, parse_string_segment)));
 
     parse_all(input).map(|(_, output)| output).map_err(|e| e.to_string())

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -41,7 +41,10 @@ impl Log for JsonLogger {
 }
 
 impl JsonLogger {
-    pub fn new(log_format: Option<&str>, should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static) -> Box<Self> {
+    pub fn new(
+        log_format: Option<&str>,
+        should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
+    ) -> Box<Self> {
         Box::new(Self {
             should_log: Box::new(should_log),
             host_logger: StdoutLogger::new_unboxed(log_format, |_| true),

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -4,7 +4,7 @@ use time::OffsetDateTime;
 
 use std::io::{self, Write};
 
-use super::{stdout_logger::StdoutLogger, DefmtRecord};
+use super::{DefmtRecord, StdoutLogger};
 
 pub(crate) struct JsonLogger {
     should_log: Box<dyn Fn(&Metadata) -> bool + Sync + Send>,

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -43,11 +43,12 @@ impl Log for JsonLogger {
 impl JsonLogger {
     pub fn new(
         log_format: Option<&str>,
+        host_log_format: Option<&str>,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Box<Self> {
         Box::new(Self {
             should_log: Box::new(should_log),
-            host_logger: StdoutLogger::new_unboxed(log_format, |_| true),
+            host_logger: StdoutLogger::new_unboxed(log_format, host_log_format, |_| true),
         })
     }
 

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -41,7 +41,7 @@ impl Log for JsonLogger {
 }
 
 impl JsonLogger {
-    pub fn new<'a>(log_format: Option<&'a str>, should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static) -> Box<Self> {
+    pub fn new(log_format: Option<&str>, should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static) -> Box<Self> {
         Box::new(Self {
             should_log: Box::new(should_log),
             host_logger: StdoutLogger::new_unboxed(log_format, |_| true),

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -4,7 +4,7 @@ use time::OffsetDateTime;
 
 use std::io::{self, Write};
 
-use super::{DefmtRecord, StdoutLogger};
+use super::{DefmtLoggerInfo, DefmtRecord, StdoutLogger};
 
 pub(crate) struct JsonLogger {
     should_log: Box<dyn Fn(&Metadata) -> bool + Sync + Send>,
@@ -56,6 +56,10 @@ impl JsonLogger {
         let mut sink = io::stdout().lock();
         serde_json::to_writer(&mut sink, &SCHEMA_VERSION).ok();
         writeln!(sink).ok();
+    }
+
+    pub fn info(&self) -> DefmtLoggerInfo {
+        self.host_logger.info()
     }
 }
 

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -4,7 +4,7 @@ use time::OffsetDateTime;
 
 use std::io::{self, Write};
 
-use super::{DefmtRecord, StdoutLogger};
+use super::{stdout_logger::StdoutLogger, DefmtRecord};
 
 pub(crate) struct JsonLogger {
     should_log: Box<dyn Fn(&Metadata) -> bool + Sync + Send>,
@@ -41,10 +41,10 @@ impl Log for JsonLogger {
 }
 
 impl JsonLogger {
-    pub fn new(should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static) -> Box<Self> {
+    pub fn new<'a>(log_format: Option<&'a str>, should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static) -> Box<Self> {
         Box::new(Self {
             should_log: Box::new(should_log),
-            host_logger: StdoutLogger::new_unboxed(true, |_| true),
+            host_logger: StdoutLogger::new_unboxed(log_format, |_| true),
         })
     }
 

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -126,13 +126,13 @@ impl<'a> DefmtRecord<'a> {
 ///
 /// The arguments between curly braces are placeholders for log metadata.
 /// The following arguments are supported:
-/// - {t} : log timestamp
 /// - {f} : file name (e.g. "main.rs")
-/// - {F} : file path (e.g. "home/app/main.rs")
-/// - {m} : module path (e.g. "foo::bar::some_function")
+/// - {F} : file path (e.g. "src/bin/main.rs")
 /// - {l} : line number
 /// - {L} : log level (e.g. "INFO", "DEBUG", etc)
+/// - {m} : module path (e.g. "foo::bar::some_function")
 /// - {s} : the actual log
+/// - {t} : log timestamp
 ///
 /// For example, with the log format shown above, a log would look like this:
 /// "23124 [INFO] Location<main.rs:23> Hello, world!"

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -136,8 +136,8 @@ impl<'a> DefmtRecord<'a> {
 /// 
 /// For example, with the log format shown above, a log would look like this:
 /// "23124 [INFO] Location<main.rs:23> Hello, world!"
-pub fn init_logger<'a>(
-    log_format: Option<&'a str>,
+pub fn init_logger(
+    log_format: Option<&str>,
     json: bool,
     should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
 ) {

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -138,14 +138,15 @@ impl<'a> DefmtRecord<'a> {
 /// "23124 [INFO] Location<main.rs:23> Hello, world!"
 pub fn init_logger(
     log_format: Option<&str>,
+    host_log_format: Option<&str>,
     json: bool,
     should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
 ) {
     log::set_boxed_logger(match json {
-        false => StdoutLogger::new(log_format, should_log),
+        false => StdoutLogger::new(log_format, host_log_format, should_log),
         true => {
             JsonLogger::print_schema_version();
-            JsonLogger::new(log_format, should_log)
+            JsonLogger::new(log_format, host_log_format, should_log)
         }
     })
     .unwrap();

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -6,9 +6,9 @@
 //! [`log`]: https://crates.io/crates/log
 //! [`defmt`]: https://crates.io/crates/defmt
 
+mod format;
 mod json_logger;
 mod stdout_logger;
-mod format;
 
 use log::{Level, LevelFilter, Metadata, Record};
 use serde::{Deserialize, Serialize};
@@ -116,10 +116,10 @@ impl<'a> DefmtRecord<'a> {
 /// Initializes a `log` sink that handles defmt frames.
 ///
 /// Defmt frames will be printed to stdout, other logs to stderr.
-/// 
+///
 /// The caller has to provide a `should_log` closure that determines whether a log record should be
 /// printed.
-/// 
+///
 /// An optional `log_format` string can be provided to format the way
 /// logs are printed. A format string could look as follows:
 /// "{t} [{L}] Location<{f}:{l}> {s}"
@@ -133,7 +133,7 @@ impl<'a> DefmtRecord<'a> {
 /// - {l} : line number
 /// - {L} : log level (e.g. "INFO", "DEBUG", etc)
 /// - {s} : the actual log
-/// 
+///
 /// For example, with the log format shown above, a log would look like this:
 /// "23124 [INFO] Location<main.rs:23> Hello, world!"
 pub fn init_logger(

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -129,7 +129,7 @@ impl<'a> DefmtRecord<'a> {
 /// - {t} : log timestamp
 /// - {f} : file name (e.g. "main.rs")
 /// - {F} : file path (e.g. "home/app/main.rs")
-/// - {m} : module path (e.g. "foo/bar/some_function")
+/// - {m} : module path (e.g. "foo::bar::some_function")
 /// - {l} : line number
 /// - {L} : log level (e.g. "INFO", "DEBUG", etc)
 /// - {s} : the actual log

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -11,7 +11,7 @@ use std::{
 
 use super::{
     format::{self, LogSegment},
-    DefmtRecord,
+    DefmtLoggerInfo, DefmtRecord,
 };
 
 enum Record<'a> {
@@ -88,6 +88,11 @@ impl StdoutLogger {
             should_log: Box::new(should_log),
             timing_align: AtomicUsize::new(0),
         }
+    }
+
+    pub fn info(&self) -> DefmtLoggerInfo {
+        let has_timestamp = self.log_format.contains(&LogSegment::Timestamp);
+        DefmtLoggerInfo { has_timestamp }
     }
 
     fn print_defmt_record(&self, record: DefmtRecord, mut sink: StdoutLock) {

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -9,8 +9,10 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use super::format;
-use super::{format::LogSegment, DefmtRecord};
+use super::{
+    format::{self, LogSegment},
+    DefmtRecord,
+};
 
 enum Record<'a> {
     Defmt(&'a DefmtRecord<'a>),

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -131,8 +131,7 @@ impl<'a> Printer<'a> {
                 LogSegment::Log => self.print_log(sink),
             }?;
         }
-        writeln!(sink)?;
-        Ok(())
+        writeln!(sink)
     }
 
     fn print_string<W: io::Write>(&self, sink: &mut W, s: &str) -> io::Result<()> {

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -166,9 +166,14 @@ impl<'a> Printer<'a> {
 
     fn print_timestamp<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
         let timestamp = match self.record {
-            Record::Defmt(record) => record.timestamp().to_string(),
-            // TODO: Is there a timestamp for host messages?
-            Record::Host(_) => String::from("<time>"),
+            Record::Defmt(record) => {
+                if record.timestamp().is_empty() {
+                    String::from("0")
+                } else {
+                    record.timestamp().to_string()
+                }
+            }
+            Record::Host(_) => String::from("0"),
         };
 
         write!(sink, "{timestamp:>0$}", self.min_timestamp_width,)

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -187,9 +187,7 @@ impl<'a> Printer<'a> {
 
         let level = if let Some(level) = level {
             // TODO: Should the color be customizable via the format too?
-            level
-                .to_string()
-                .color(color_for_log_level(level))
+            level.to_string().color(color_for_log_level(level))
         } else {
             ColoredString::from("<lvl>")
         };

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -65,7 +65,7 @@ impl StdoutLogger {
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Self {
         const DEFAULT_LOG_FORMAT: &str = "{t} {L} {s}\n└─ {m} @ {F}:{l}";
-        
+
         let format = log_format.unwrap_or(DEFAULT_LOG_FORMAT);
         let format = format::parse(format).unwrap_or_else(|_| {
             // Use the default format if the user-provided format is invalid

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -173,12 +173,12 @@ impl<'a> Printer<'a> {
         let timestamp = match self.record {
             Record::Defmt(record) => {
                 if record.timestamp().is_empty() {
-                    String::from("0")
+                    String::from("<time>")
                 } else {
                     record.timestamp().to_string()
                 }
             }
-            Record::Host(_) => String::from("0"),
+            Record::Host(_) => String::from("<time>"),
         };
 
         write!(sink, "{timestamp:>0$}", self.min_timestamp_width,)

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -249,12 +249,12 @@ impl<'a> Printer<'a> {
     }
 
     fn print_log<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
-        let args = match self.record {
-            Record::Defmt(record) => record.args(),
-            Record::Host(record) => record.args(),
+        let log = match self.record {
+            Record::Defmt(record) => color_diff(record.args().to_string()),
+            Record::Host(record) => record.args().to_string(),
         };
 
-        write!(sink, "{log}", log = color_diff(args.to_string()),)
+        write!(sink, "{log}")
     }
 }
 

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -52,15 +52,15 @@ impl Log for StdoutLogger {
 }
 
 impl StdoutLogger {
-    pub fn new<'a>(
-        log_format: Option<&'a str>,
+    pub fn new(
+        log_format: Option<&str>,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Box<Self> {
         Box::new(Self::new_unboxed(log_format, should_log))
     }
 
-    pub fn new_unboxed<'a>(
-        log_format: Option<&'a str>,
+    pub fn new_unboxed(
+        log_format: Option<&str>,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Self {
         let format = log_format.unwrap_or("{t} [{L}] {s}\n└─ {m} @ {F}:{l}");
@@ -87,7 +87,7 @@ impl StdoutLogger {
 
     pub(super) fn print_host_record(&self, record: &LogRecord, mut sink: StderrLock) {
         let min_timestamp_width = self.timing_align.load(Ordering::Relaxed);
-        Printer::new(Record::Host(&record), &self.format)
+        Printer::new(Record::Host(record), &self.format)
         .min_timestamp_width(min_timestamp_width)
         .print_frame(&mut sink)
         .ok();
@@ -120,7 +120,7 @@ impl<'a> Printer<'a> {
     pub fn print_frame<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
         for segment in self.format {
             match segment {
-                LogSegment::String(s) => self.print_string(sink, &s),
+                LogSegment::String(s) => self.print_string(sink, s),
                 LogSegment::Timestamp => self.print_timestamp(sink),
                 LogSegment::FileName => self.print_file_name(sink),
                 LogSegment::FilePath => self.print_file_path(sink),

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -1,4 +1,4 @@
-use colored::{Color, Colorize};
+use colored::{Color, ColoredString, Colorize};
 use dissimilar::Chunk;
 use log::{Level, Log, Metadata, Record as LogRecord};
 
@@ -190,9 +190,8 @@ impl<'a> Printer<'a> {
             level
                 .to_string()
                 .color(color_for_log_level(level))
-                .to_string()
         } else {
-            String::from("<lvl>")
+            ColoredString::from("<lvl>")
         };
 
         write!(sink, "{level:5}")

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -5,11 +5,12 @@ use log::{Level, Log, Metadata, Record as LogRecord};
 use std::{
     fmt::Write as _,
     io::{self, StderrLock, StdoutLock},
-    sync::atomic::{AtomicUsize, Ordering}, path::Path,
+    path::Path,
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
-use super::{DefmtRecord, format::LogSegment};
 use super::format;
+use super::{format::LogSegment, DefmtRecord};
 
 enum Record<'a> {
     Defmt(&'a DefmtRecord<'a>),
@@ -88,9 +89,9 @@ impl StdoutLogger {
     pub(super) fn print_host_record(&self, record: &LogRecord, mut sink: StderrLock) {
         let min_timestamp_width = self.timing_align.load(Ordering::Relaxed);
         Printer::new(Record::Host(record), &self.format)
-        .min_timestamp_width(min_timestamp_width)
-        .print_frame(&mut sink)
-        .ok();
+            .min_timestamp_width(min_timestamp_width)
+            .print_frame(&mut sink)
+            .ok();
     }
 }
 
@@ -143,12 +144,8 @@ impl<'a> Printer<'a> {
             Record::Defmt(record) => record.timestamp().to_string(),
             Record::Host(_) => String::from("(HOST)"),
         };
-        
-        write!(
-            sink,
-            "{timestamp:>0$}",
-            self.min_timestamp_width,
-        )
+
+        write!(sink, "{timestamp:>0$}", self.min_timestamp_width,)
     }
 
     fn print_log_level<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
@@ -156,10 +153,13 @@ impl<'a> Printer<'a> {
             Record::Defmt(record) => record.level(),
             Record::Host(record) => Some(record.level()),
         };
-    
+
         let level = if let Some(level) = level {
             // TODO: Should the color be customizable via the format too?
-            level.to_string().color(color_for_log_level(level)).to_string()
+            level
+                .to_string()
+                .color(color_for_log_level(level))
+                .to_string()
         } else {
             String::from("level")
         };
@@ -171,7 +171,8 @@ impl<'a> Printer<'a> {
         let file_path = match self.record {
             Record::Defmt(record) => record.file(),
             Record::Host(record) => record.file(),
-        }.unwrap_or("<file>");
+        }
+        .unwrap_or("<file>");
 
         write!(sink, "{file_path}")
     }
@@ -181,7 +182,7 @@ impl<'a> Printer<'a> {
             Record::Defmt(record) => record.file(),
             Record::Host(record) => record.file(),
         };
-        
+
         let file_name = if let Some(file) = file {
             let file_name = Path::new(file).file_name();
             if let Some(file_name) = file_name {
@@ -200,7 +201,8 @@ impl<'a> Printer<'a> {
         let module_path = match self.record {
             Record::Defmt(record) => record.module_path(),
             Record::Host(record) => record.module_path(),
-        }.unwrap_or("<mod path>");
+        }
+        .unwrap_or("<mod path>");
 
         write!(sink, "{module_path}")
     }
@@ -209,7 +211,8 @@ impl<'a> Printer<'a> {
         let line_number = match self.record {
             Record::Defmt(record) => record.line(),
             Record::Host(record) => record.line(),
-        }.unwrap_or(0);
+        }
+        .unwrap_or(0);
 
         write!(sink, "{line_number}")
     }
@@ -220,13 +223,8 @@ impl<'a> Printer<'a> {
             Record::Host(record) => record.args(),
         };
 
-        write!(
-            sink,
-            "{log}",
-            log = color_diff(args.to_string()),
-        )
+        write!(sink, "{log}", log = color_diff(args.to_string()),)
     }
-
 }
 
 // color the output of `defmt::assert_eq`

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -1,20 +1,26 @@
 use colored::{Color, Colorize};
 use dissimilar::Chunk;
-use log::{Level, Log, Metadata, Record};
+use log::{Level, Log, Metadata, Record as LogRecord};
 
 use std::{
     fmt::Write as _,
-    io::{self, StderrLock, StdoutLock, Write},
-    sync::atomic::{AtomicUsize, Ordering},
+    io::{self, StderrLock, StdoutLock},
+    sync::atomic::{AtomicUsize, Ordering}, path::Path,
 };
 
-use super::DefmtRecord;
+use super::{DefmtRecord, format::LogSegment};
+use super::format;
+
+enum Record<'a> {
+    Defmt(&'a DefmtRecord<'a>),
+    Host(&'a LogRecord<'a>),
+}
 
 pub(crate) struct StdoutLogger {
-    always_include_location: bool,
+    format: Vec<LogSegment>,
     should_log: Box<dyn Fn(&Metadata) -> bool + Sync + Send>,
-    /// Number of characters used by the timestamp. This may increase over time and is used to align
-    /// messages.
+    /// Number of characters used by the timestamp.
+    /// This may increase over time and is used to align messages.
     timing_align: AtomicUsize,
 }
 
@@ -23,7 +29,7 @@ impl Log for StdoutLogger {
         (self.should_log)(metadata)
     }
 
-    fn log(&self, record: &Record) {
+    fn log(&self, record: &LogRecord) {
         if !self.enabled(record.metadata()) {
             return;
         }
@@ -32,11 +38,7 @@ impl Log for StdoutLogger {
             Some(record) => {
                 // defmt goes to stdout, since it's the primary output produced by this tool.
                 let sink = io::stdout().lock();
-
-                match record.level() {
-                    Some(level) => self.print_defmt_record(record, level, sink),
-                    None => Self::print_println_record(record, sink),
-                };
+                self.print_defmt_record(record, sink);
             }
             None => {
                 // non-defmt logs go to stderr
@@ -50,106 +52,62 @@ impl Log for StdoutLogger {
 }
 
 impl StdoutLogger {
-    pub fn new(
-        always_include_location: bool,
+    pub fn new<'a>(
+        log_format: Option<&'a str>,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Box<Self> {
-        Box::new(Self::new_unboxed(always_include_location, should_log))
+        Box::new(Self::new_unboxed(log_format, should_log))
     }
 
-    pub fn new_unboxed(
-        always_include_location: bool,
+    pub fn new_unboxed<'a>(
+        log_format: Option<&'a str>,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Self {
+        let format = log_format.unwrap_or("{t} [{L}] {s}\n└─ {m} @ {F}:{l}");
+
+        // TODO: Handle errors
+        let format = format::parse(format).unwrap();
         Self {
-            always_include_location,
+            format,
             should_log: Box::new(should_log),
             timing_align: AtomicUsize::new(0),
         }
     }
 
-    fn print_defmt_record(&self, record: DefmtRecord, level: Level, mut sink: StdoutLock) {
+    fn print_defmt_record(&self, record: DefmtRecord, mut sink: StdoutLock) {
         let len = record.timestamp().len();
         self.timing_align.fetch_max(len, Ordering::Relaxed);
         let min_timestamp_width = self.timing_align.load(Ordering::Relaxed);
 
-        Printer::new(&record, level)
-            .include_location(true) // always include location for defmt output
+        Printer::new(Record::Defmt(&record), &self.format)
             .min_timestamp_width(min_timestamp_width)
-            .print_colored(&mut sink)
+            .print_frame(&mut sink)
             .ok();
     }
 
-    pub(super) fn print_host_record(&self, record: &Record, mut sink: StderrLock) {
+    pub(super) fn print_host_record(&self, record: &LogRecord, mut sink: StderrLock) {
         let min_timestamp_width = self.timing_align.load(Ordering::Relaxed);
-
-        writeln!(
-            sink,
-            "{timestamp:>0$} {level:5} {args}",
-            min_timestamp_width,
-            timestamp = "(HOST)",
-            level = record
-                .level()
-                .to_string()
-                .color(color_for_log_level(record.level())),
-            args = record.args()
-        )
-        .ok();
-
-        if self.always_include_location {
-            print_location(
-                &mut sink,
-                record.file(),
-                record.line(),
-                record.module_path(),
-            )
-            .ok();
-        }
-    }
-
-    fn print_println_record(record: DefmtRecord, mut sink: StdoutLock) {
-        let timestamp = match record.timestamp().is_empty() {
-            true => record.timestamp().to_string(),
-            false => format!("{} ", record.timestamp()),
-        };
-
-        writeln!(&mut sink, "{timestamp}{}", record.args()).ok();
-        print_location(
-            &mut sink,
-            record.file(),
-            record.line(),
-            record.module_path(),
-        )
+        Printer::new(Record::Host(&record), &self.format)
+        .min_timestamp_width(min_timestamp_width)
+        .print_frame(&mut sink)
         .ok();
     }
 }
 
 /// Printer for `DefmtRecord`s.
-pub struct Printer<'a> {
-    record: &'a DefmtRecord<'a>,
-    include_location: bool,
-    level: Level,
+struct Printer<'a> {
+    record: Record<'a>,
+    format: &'a [LogSegment],
     min_timestamp_width: usize,
 }
 
 impl<'a> Printer<'a> {
-    pub fn new(record: &'a DefmtRecord, level: Level) -> Self {
+    pub fn new(record: Record<'a>, format: &'a [LogSegment]) -> Self {
         Self {
             record,
-            include_location: false,
-            level,
+            format,
             min_timestamp_width: 0,
         }
-    }
-
-    /// Configure whether to include location info (file, line) in the output.
-    ///
-    /// If `true`, an additional line will be included in the output that contains file and line
-    /// information of the logging statement.
-    /// By default, this is `false`.
-    pub fn include_location(&mut self, include_location: bool) -> &mut Self {
-        self.include_location = include_location;
-        self
     }
 
     /// Pads the defmt timestamp to take up at least the given number of characters.
@@ -158,44 +116,117 @@ impl<'a> Printer<'a> {
         self
     }
 
-    /// Prints the colored log frame to `sink`.
-    ///
-    /// The format is as follows (this is not part of the stable API and may change):
-    ///
-    /// ```text
-    /// <timestamp> <level> <args>
-    /// └─ <module> @ <file>:<line>
-    /// ```
-    pub fn print_colored<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
-        writeln!(
-            sink,
-            "{timestamp:>0$}{spacing}{level:5} {args}",
-            self.min_timestamp_width,
-            timestamp = self.record.timestamp(),
-            spacing = if self.record.timestamp().is_empty() {
-                ""
-            } else {
-                " "
-            },
-            level = self
-                .level
-                .to_string()
-                .color(color_for_log_level(self.level)),
-            args = color_diff(self.record.args().to_string()),
-        )?;
-
-        if self.include_location {
-            let log_record = self.record.log_record;
-            print_location(
-                sink,
-                log_record.file(),
-                log_record.line(),
-                log_record.module_path(),
-            )?;
+    /// Prints the formatted log frame to `sink`.
+    pub fn print_frame<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        for segment in self.format {
+            match segment {
+                LogSegment::String(s) => self.print_string(sink, &s),
+                LogSegment::Timestamp => self.print_timestamp(sink),
+                LogSegment::FileName => self.print_file_name(sink),
+                LogSegment::FilePath => self.print_file_path(sink),
+                LogSegment::ModulePath => self.print_module_path(sink),
+                LogSegment::LineNumber => self.print_line_number(sink),
+                LogSegment::LogLevel => self.print_log_level(sink),
+                LogSegment::Log => self.print_log(sink),
+            }?;
         }
-
+        writeln!(sink)?;
         Ok(())
     }
+
+    fn print_string<W: io::Write>(&self, sink: &mut W, s: &str) -> io::Result<()> {
+        write!(sink, "{s}")
+    }
+
+    fn print_timestamp<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        let timestamp = match self.record {
+            Record::Defmt(record) => record.timestamp().to_string(),
+            Record::Host(_) => String::from("(HOST)"),
+        };
+        
+        write!(
+            sink,
+            "{timestamp:>0$}",
+            self.min_timestamp_width,
+        )
+    }
+
+    fn print_log_level<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        let level = match self.record {
+            Record::Defmt(record) => record.level(),
+            Record::Host(record) => Some(record.level()),
+        };
+    
+        let level = if let Some(level) = level {
+            // TODO: Should the color be customizable via the format too?
+            level.to_string().color(color_for_log_level(level)).to_string()
+        } else {
+            String::from("level")
+        };
+
+        write!(sink, "{level:5}")
+    }
+
+    fn print_file_path<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        let file_path = match self.record {
+            Record::Defmt(record) => record.file(),
+            Record::Host(record) => record.file(),
+        }.unwrap_or("<file>");
+
+        write!(sink, "{file_path}")
+    }
+
+    fn print_file_name<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        let file = match self.record {
+            Record::Defmt(record) => record.file(),
+            Record::Host(record) => record.file(),
+        };
+        
+        let file_name = if let Some(file) = file {
+            let file_name = Path::new(file).file_name();
+            if let Some(file_name) = file_name {
+                file_name.to_str().unwrap_or("<file>")
+            } else {
+                "<file>"
+            }
+        } else {
+            "<file>"
+        };
+
+        write!(sink, "{file_name}")
+    }
+
+    fn print_module_path<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        let module_path = match self.record {
+            Record::Defmt(record) => record.module_path(),
+            Record::Host(record) => record.module_path(),
+        }.unwrap_or("<mod path>");
+
+        write!(sink, "{module_path}")
+    }
+
+    fn print_line_number<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        let line_number = match self.record {
+            Record::Defmt(record) => record.line(),
+            Record::Host(record) => record.line(),
+        }.unwrap_or(0);
+
+        write!(sink, "{line_number}")
+    }
+
+    fn print_log<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
+        let args = match self.record {
+            Record::Defmt(record) => record.args(),
+            Record::Host(record) => record.args(),
+        };
+
+        write!(
+            sink,
+            "{log}",
+            log = color_diff(args.to_string()),
+        )
+    }
+
 }
 
 // color the output of `defmt::assert_eq`
@@ -275,23 +306,4 @@ fn color_for_log_level(level: Level) -> Color {
         Level::Debug => Color::BrightWhite,
         Level::Trace => Color::BrightBlack,
     }
-}
-
-fn print_location<W: io::Write>(
-    sink: &mut W,
-    file: Option<&str>,
-    line: Option<u32>,
-    module_path: Option<&str>,
-) -> io::Result<()> {
-    if let Some(file) = file {
-        // NOTE will always be `Some` if `file` is `Some`
-        let mod_path = module_path.unwrap();
-        let mut loc = file.to_string();
-        if let Some(line) = line {
-            let _ = write!(loc, ":{line}");
-        }
-        writeln!(sink, "{}", format!("└─ {mod_path} @ {loc}").dimmed())?;
-    }
-
-    Ok(())
 }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -23,6 +23,9 @@ struct Opts {
     log_format: Option<String>,
 
     #[arg(long)]
+    host_log_format: Option<String>,
+
+    #[arg(long)]
     show_skipped_frames: bool,
 
     #[arg(short, long)]
@@ -84,6 +87,7 @@ fn main() -> anyhow::Result<()> {
         elf,
         json,
         log_format,
+        host_log_format,
         show_skipped_frames,
         verbose,
         version,
@@ -94,10 +98,15 @@ fn main() -> anyhow::Result<()> {
         return print_version();
     }
 
-    defmt_decoder::log::init_logger(log_format.as_deref(), json, move |metadata| match verbose {
-        false => defmt_decoder::log::is_defmt_frame(metadata), // We display *all* defmt frames, but nothing else.
-        true => true,                                          // We display *all* frames.
-    });
+    defmt_decoder::log::init_logger(
+        log_format.as_deref(),
+        host_log_format.as_deref(),
+        json,
+        move |metadata| match verbose {
+            false => defmt_decoder::log::is_defmt_frame(metadata), // We display *all* defmt frames, but nothing else.
+            true => true,                                          // We display *all* frames.
+        },
+    );
 
     // read and parse elf file
     let bytes = fs::read(elf.unwrap())?;

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -20,6 +20,9 @@ struct Opts {
     json: bool,
 
     #[arg(long)]
+    log_format: Option<String>,
+
+    #[arg(long)]
     show_skipped_frames: bool,
 
     #[arg(short, long)]
@@ -80,6 +83,7 @@ fn main() -> anyhow::Result<()> {
     let Opts {
         elf,
         json,
+        log_format,
         show_skipped_frames,
         verbose,
         version,
@@ -90,7 +94,9 @@ fn main() -> anyhow::Result<()> {
         return print_version();
     }
 
-    defmt_decoder::log::init_logger(verbose, json, move |metadata| match verbose {
+    let log_format = log_format.as_ref().map(|s| s.as_str());
+
+    defmt_decoder::log::init_logger(log_format, json, move |metadata| match verbose {
         false => defmt_decoder::log::is_defmt_frame(metadata), // We display *all* defmt frames, but nothing else.
         true => true,                                          // We display *all* frames.
     });

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -94,9 +94,7 @@ fn main() -> anyhow::Result<()> {
         return print_version();
     }
 
-    let log_format = log_format.as_ref().map(|s| s.as_str());
-
-    defmt_decoder::log::init_logger(log_format, json, move |metadata| match verbose {
+    defmt_decoder::log::init_logger(log_format.as_deref(), json, move |metadata| match verbose {
         false => defmt_decoder::log::is_defmt_frame(metadata), // We display *all* defmt frames, but nothing else.
         true => true,                                          // We display *all* frames.
     });


### PR DESCRIPTION
A pain point for me when using `defmt` is that I can't easily customize the format in which the logs are printed.

This PR replaces the current `PrettyLogger` with a new `StdoutLogger` (seemed like a better name to me since the other logger is called `JsonLogger`), that supports an optional format string. If no format string is provided, a default format is used that looks pretty much the same as the current format, with the exception that the location is not "dimmed".

The formatting options I added are completely arbitrary and not set in stone. I just chose what made sense to me. This is from what I wrote in the docs:

```
 /// An optional `log_format` string can be provided to format the way
 /// logs are printed. A format string could look as follows:
 /// "{t} [{L}] Location<{f}:{l}> {s}"
 ///
 /// The arguments between curly braces are placeholders for log metadata.
 /// The following arguments are supported:
 /// - {t} : log timestamp
 /// - {f} : file name (e.g. "main.rs")
 /// - {F} : file path (e.g. "home/app/main.rs")
 /// - {m} : module path (e.g. "foo::bar::some_function")
 /// - {l} : line number
 /// - {L} : log level (e.g. "INFO", "DEBUG", etc)
 /// - {s} : the actual log
 ///
 /// For example, with the log format shown above, a log would look like this:
 /// "23124 [INFO] Location<main.rs:23> Hello, world!"
```

The new format is easily changeable and extendable. Some things that I think could be implemented but I chose not to waste time on before getting community feedback are:

- Support for a new formatting option to set/reset colors
- Support for escaped curly braces (the parser currently does not support random curly braces in the format string)
- Support for field widths (e.g. `{t:8}` or something like that to specify that the timestamp must be at least 8 characters wide)

This PR is also an alternative to #762 (I think)