### PR TITLE
add serialport support to defmt-print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
+- [#767]: `defmt-print`: Add serialport support for logs over UART
 
 [#771]: https://github.com/knurling-rs/defmt/pull/771
+[#767]: https://github.com/knurling-rs/defmt/pull/767
 
 ## defmt-decoder v0.3.8, defmt-print v0.3.8 - 2023-08-01
 

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -19,3 +19,4 @@ defmt-decoder = { version = "=0.3.7", path = "../decoder", features = [
     "unstable",
 ] }
 log = "0.4"
+serialport = "4.2.1"

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -35,7 +35,7 @@ struct Opts {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Read defmt frames from stdin (the default)
+    /// Read defmt frames from stdin (default)
     Stdin,
     /// Read defmt frames from serial
     Serial {

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -3,6 +3,7 @@ use std::{
     io::{self, Read, StdinLock},
     net::TcpStream,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::anyhow;

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -130,7 +130,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut source = match command {
         None | Some(Command::Stdin) => Source::stdin(),
-        Some(Command::Serial { path }) => Source::Serial(serialport::new(path, 115_200).timeout(std::time::Duration::from_millis(10)).open().unwrap()),
+        Some(Command::Serial { path }) => Source::Serial(serialport::new(path, 115_200).timeout(Duration::from_millis(10)).open()?),
         Some(Command::Tcp { host, port }) => Source::tcp(host, port)?,
     };
 


### PR DESCRIPTION
I got the idea from https://github.com/gauteh/defmt-serial/blob/main/example-pi-pico/pico-elf2uf2-defmt-wrapper.sh except that didn't work for me on Mac OS X Ventura with a FT232RL USB device

Instead of trying to really get into the weeds and debug why that was doing nothing, this seemed easier.

Obviously we'd probably want this behind some feature flag to make this optional (or not at all)

Just figured this might help somebody developing on RP2040 who doesn't have a 2nd RP2040 laying around + doesn't feel like soldering wires to be able to hit the SWD RTT debugger thingie 