### PR TITLE
decoder: add support for color, style, width and alignment to format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#769]: `defmt-decoder`: Add support for color, style, width and alignment to format
+
+[#769]: https://github.com/knurling-rs/defmt/pull/769
+
 ## defmt-decoder v0.3.8, defmt-print v0.3.8 - 2023-08-01
 
 - [#766] `decoder::log`: Rename `PrettyLogger` to `StdoutLogger`

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -200,8 +200,10 @@ impl<'a> Printer<'a> {
             String::from("<lvl>")
         };
 
+        let color = format.color.unwrap_or(LogColor::SeverityLevel);
+
         let level = ColoredString::from(level.as_str());
-        let level = apply_color(level, format.color, self.record_log_level());
+        let level = apply_color(level, Some(color), self.record_log_level());
         let level = apply_style(level, format.style);
         let alignment = format.alignment.unwrap_or(Alignment::Left);
         let width = format.width.unwrap_or(5);

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -397,34 +397,25 @@ fn apply_color(
     log_color: Option<LogColor>,
     level: Option<Level>,
 ) -> ColoredString {
-    if let Some(log_color) = log_color {
-        match log_color {
-            LogColor::Color(color) => s.color(color),
-            LogColor::SeverityLevel => {
-                if let Some(level) = level {
-                    let color = color_for_log_level(level);
-                    s.color(color)
-                } else {
-                    s
-                }
-            }
-            LogColor::WarnError => {
-                if level.is_some_and(|l| l == Level::Warn || l == Level::Error) {
-                    let color = color_for_log_level(level.unwrap());
-                    s.color(color)
-                } else {
-                    s
-                }
-            }
-        }
-    } else {
-        s
+    match log_color {
+        Some(color) => match color {
+            LogColor::Color(c) => s.color(c),
+            LogColor::SeverityLevel => match level {
+                Some(level) => s.color(color_for_log_level(level)),
+                None => s,
+            },
+            LogColor::WarnError => match level {
+                Some(level @ (Level::Warn | Level::Error)) => s.color(color_for_log_level(level)),
+                _ => s,
+            },
+        },
+        None => s,
     }
 }
 
 fn apply_style(s: ColoredString, log_style: Option<Styles>) -> ColoredString {
-    if let Some(log_style) = log_style {
-        match log_style {
+    match log_style {
+        Some(log_style) => match log_style {
             Styles::Bold => s.bold(),
             Styles::Italic => s.italic(),
             Styles::Underline => s.underline(),
@@ -434,9 +425,8 @@ fn apply_style(s: ColoredString, log_style: Option<Styles>) -> ColoredString {
             Styles::Reversed => s.reversed(),
             Styles::Blink => s.blink(),
             Styles::Hidden => s.hidden(),
-        }
-    } else {
-        s
+        },
+        None => s,
     }
 }
 
@@ -447,14 +437,8 @@ fn write_string<W: io::Write>(
     alignment: Alignment,
 ) -> io::Result<()> {
     match alignment {
-        Alignment::Left => {
-            write!(sink, "{s:<0$}", width)
-        }
-        Alignment::Center => {
-            write!(sink, "{s:^0$}", width)
-        }
-        Alignment::Right => {
-            write!(sink, "{s:>0$}", width)
-        }
+        Alignment::Left => write!(sink, "{s:<0$}", width),
+        Alignment::Center => write!(sink, "{s:^0$}", width),
+        Alignment::Right => write!(sink, "{s:>0$}", width),
     }
 }

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -438,7 +438,7 @@ fn apply_color(
 }
 
 fn apply_styles(s: ColoredString, log_style: Option<&Vec<Styles>>) -> ColoredString {
-    let Some(log_styles) =  log_style else {
+    let Some(log_styles) = log_style else {
         return s;
     };
 

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -1,4 +1,4 @@
-use colored::{Color, ColoredString, Colorize};
+use colored::{Color, ColoredString, Colorize, Styles};
 use dissimilar::Chunk;
 use log::{Level, Log, Metadata, Record as LogRecord};
 
@@ -10,7 +10,7 @@ use std::{
 };
 
 use super::{
-    format::{self, Alignment, LogColor, LogFormat, LogMetadata, LogSegment, LogStyle},
+    format::{self, Alignment, LogColor, LogFormat, LogMetadata, LogSegment},
     DefmtLoggerInfo, DefmtRecord,
 };
 
@@ -399,22 +399,7 @@ fn apply_color(
 ) -> ColoredString {
     if let Some(log_color) = log_color {
         match log_color {
-            LogColor::Black => s.black(),
-            LogColor::Red => s.red(),
-            LogColor::Green => s.green(),
-            LogColor::Yellow => s.yellow(),
-            LogColor::Blue => s.blue(),
-            LogColor::Magenta => s.magenta(),
-            LogColor::Cyan => s.cyan(),
-            LogColor::White => s.white(),
-            LogColor::BrightBlack => s.bright_black(),
-            LogColor::BrightRed => s.bright_red(),
-            LogColor::BrightGreen => s.bright_green(),
-            LogColor::BrightYellow => s.bright_yellow(),
-            LogColor::BrightBlue => s.bright_blue(),
-            LogColor::BrightMagenta => s.bright_magenta(),
-            LogColor::BrightCyan => s.bright_cyan(),
-            LogColor::BrightWhite => s.bright_white(),
+            LogColor::Color(color) => s.color(color),
             LogColor::SeverityLevel => {
                 if let Some(level) = level {
                     let color = color_for_log_level(level);
@@ -437,14 +422,18 @@ fn apply_color(
     }
 }
 
-fn apply_style(s: ColoredString, log_style: Option<LogStyle>) -> ColoredString {
+fn apply_style(s: ColoredString, log_style: Option<Styles>) -> ColoredString {
     if let Some(log_style) = log_style {
         match log_style {
-            LogStyle::Bold => s.bold(),
-            LogStyle::Italic => s.italic(),
-            LogStyle::Underline => s.underline(),
-            LogStyle::Strikethrough => s.strikethrough(),
-            LogStyle::Dimmed => s.dimmed(),
+            Styles::Bold => s.bold(),
+            Styles::Italic => s.italic(),
+            Styles::Underline => s.underline(),
+            Styles::Strikethrough => s.strikethrough(),
+            Styles::Dimmed => s.dimmed(),
+            Styles::Clear => s.clear(),
+            Styles::Reversed => s.reversed(),
+            Styles::Blink => s.blink(),
+            Styles::Hidden => s.hidden(),
         }
     } else {
         s

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -187,7 +187,7 @@ impl<'a> Printer<'a> {
         let timestamp = apply_format(
             timestamp.as_str(),
             format.color,
-            format.style,
+            format.style.as_ref(),
             self.record_log_level(),
         );
         let width = format.width.unwrap_or(self.min_timestamp_width);
@@ -206,7 +206,7 @@ impl<'a> Printer<'a> {
         let level = apply_format(
             level.as_str(),
             Some(color),
-            format.style,
+            format.style.as_ref(),
             self.record_log_level(),
         );
         let width = format.width.unwrap_or(5);
@@ -224,7 +224,7 @@ impl<'a> Printer<'a> {
         let file_path = apply_format(
             file_path,
             format.color,
-            format.style,
+            format.style.as_ref(),
             self.record_log_level(),
         );
         let width = format.width.unwrap_or(0);
@@ -252,7 +252,7 @@ impl<'a> Printer<'a> {
         let file_name = apply_format(
             file_name,
             format.color,
-            format.style,
+            format.style.as_ref(),
             self.record_log_level(),
         );
         let width = format.width.unwrap_or(0);
@@ -270,7 +270,7 @@ impl<'a> Printer<'a> {
         let module_path = apply_format(
             module_path,
             format.color,
-            format.style,
+            format.style.as_ref(),
             self.record_log_level(),
         );
         let width = format.width.unwrap_or(0);
@@ -289,7 +289,7 @@ impl<'a> Printer<'a> {
         let line_number = apply_format(
             line_number.as_str(),
             format.color,
-            format.style,
+            format.style.as_ref(),
             self.record_log_level(),
         );
         let width = format.width.unwrap_or(4);
@@ -305,7 +305,7 @@ impl<'a> Printer<'a> {
                     let log = apply_format(
                         s.as_str(),
                         format.color,
-                        format.style,
+                        format.style.as_ref(),
                         self.record_log_level(),
                     );
                     let width = format.width.unwrap_or(0);
@@ -408,12 +408,12 @@ fn color_for_log_level(level: Level) -> Color {
 fn apply_format(
     s: &str,
     color: Option<LogColor>,
-    style: Option<Styles>,
+    styles: Option<&Vec<Styles>>,
     level: Option<Level>,
 ) -> ColoredString {
     let s = ColoredString::from(s);
     let s = apply_color(s, color, level);
-    apply_style(s, style)
+    apply_styles(s, styles)
 }
 
 fn apply_color(
@@ -437,21 +437,27 @@ fn apply_color(
     }
 }
 
-fn apply_style(s: ColoredString, log_style: Option<Styles>) -> ColoredString {
-    match log_style {
-        Some(log_style) => match log_style {
-            Styles::Bold => s.bold(),
-            Styles::Italic => s.italic(),
-            Styles::Underline => s.underline(),
-            Styles::Strikethrough => s.strikethrough(),
-            Styles::Dimmed => s.dimmed(),
-            Styles::Clear => s.clear(),
-            Styles::Reversed => s.reversed(),
-            Styles::Blink => s.blink(),
-            Styles::Hidden => s.hidden(),
-        },
-        None => s,
+fn apply_styles(s: ColoredString, log_style: Option<&Vec<Styles>>) -> ColoredString {
+    let Some(log_styles) =  log_style else {
+        return s;
+    };
+
+    let mut stylized_string = s;
+    for style in log_styles {
+        stylized_string = match style {
+            Styles::Bold => stylized_string.bold(),
+            Styles::Italic => stylized_string.italic(),
+            Styles::Underline => stylized_string.underline(),
+            Styles::Strikethrough => stylized_string.strikethrough(),
+            Styles::Dimmed => stylized_string.dimmed(),
+            Styles::Clear => stylized_string.clear(),
+            Styles::Reversed => stylized_string.reversed(),
+            Styles::Blink => stylized_string.blink(),
+            Styles::Hidden => stylized_string.hidden(),
+        };
     }
+
+    stylized_string
 }
 
 fn write_string<W: io::Write>(

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -413,8 +413,7 @@ fn apply_format(
 ) -> ColoredString {
     let s = ColoredString::from(s);
     let s = apply_color(s, color, level);
-    let s = apply_style(s, style);
-    s
+    apply_style(s, style)
 }
 
 fn apply_color(


### PR DESCRIPTION
This PR extends the functionality of the `--log-format` and `--host-log-format` options implemented in #765 by adding support for color, style, width and alignment options.

The format options are pretty much as described in [here](https://github.com/knurling-rs/defmt/pull/765#discussion_r1265257684):

> I can easily imagine assigning static colors, maybe like this "{t:black:bold} [{L:green:dimmed}] Location<{f:yellow:italic}:{l:#5F2A2A:normal}> {s:white:underline}". Note that I A) am using the terms from the colored crate, B) not particularly like that format, it is just what I came up with right now and C) would pick :black:normal as a default.

An example of what the new format could look like is:

```
{t:>8} [{L:severity:bold}] {f:white:underline}:{l:white:3} {s:werror}
```

The `#5F2A2A` variant for colors is not yet supported in this PR - I think the currently implemented options are more than enough.

Something else I still want to implement is support for nested format options or something similar that would allow users to align logs like this:

```
main.rs:15          This is a log
decoder.rs:345      This is another log
```

With the current formatting options this is not possible. I think something like `{{f}:{l}:20:white:underline}` would be a nice syntax to support formatting groups of segments at once.  I'll likely wait for this PR to be merged before working on that though.

One open question is how to implement support for styling `String` log segments, i.e. how do we allow the user to have something like `(HOST) [{L}] {s}` where the `(HOST)` part could be blue, dimmed, etc. It's probably not very important and I can't think of many use cases for this.


