### PR TITLE
Ignore empty items in DEFMT_LOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
+
+[#771]: https://github.com/knurling-rs/defmt/pull/771
+
 ## defmt-decoder v0.3.8, defmt-print v0.3.8 - 2023-08-01
 
 - [#766] `decoder::log`: Rename `PrettyLogger` to `StdoutLogger`


### PR DESCRIPTION
There are a several ways that the DEFMT_LOG environment variable could have an empty item, for example:
- `DEFMT_LOG=`
- `DEFMT_LOG=info,`
- `DEFMT_LOG=info,,app::noisy=error`

Previously, an empty item would be incorrectly parsed as a module path, causing the macro to panic.

With this patch, empty items are simply ignored.