### PR TITLE
Doc-hide macro-generated idents

### DIFF
--- a/macros/src/function_like/internp.rs
+++ b/macros/src/function_like/internp.rs
@@ -16,6 +16,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
         quote!({ defmt::export::fetch_add_string_index() as u16 })
     } else {
         quote!({
+            #[doc(hidden)]
             #[cfg_attr(target_os = "macos", link_section = #section_for_macos)]
             #[cfg_attr(not(target_os = "macos"), link_section = #section)]
             #[export_name = #sym_name]

--- a/macros/src/function_like/log/env_filter.rs
+++ b/macros/src/function_like/log/env_filter.rs
@@ -111,7 +111,9 @@ impl EnvFilter {
             .collect::<Vec<_>>();
 
         Some(quote!({
+            #[doc(hidden)]
             const CHECK: bool = {
+                #[doc(hidden)]
                 const fn check() -> bool {
                     let module_path = module_path!().as_bytes();
                     #(#checks)*


### PR DESCRIPTION
When running `cargo doc` on a project using defmt, I saw a lot of automatically-generated identifiers in the resulting documentation. Cargo will by default emit documentation for private items in a crate, so items like `DEFMT_LOG_STATEMENT` or `CHECK` or `check()` are apparent there too, which are clearly an implementation detail and should not be exposed to library user (documentation bloat aside).

Hopefully this tiny PR fixes that.

We love defmt, thanks for your great work :)