### PR TITLE
decoder: Ignore AArch64 mapping symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#775]: `defmt-decoder`: Ignore AArch64 mapping symbols
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
 
+[#775]: https://github.com/knurling-rs/defmt/pull/775
 [#771]: https://github.com/knurling-rs/defmt/pull/771
 
 ## defmt-decoder v0.3.8, defmt-print v0.3.8 - 2023-08-01

--- a/firmware/qemu/src/bin/bitflags.rs
+++ b/firmware/qemu/src/bin/bitflags.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(clippy::bad_bit_mask)]
 
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;


### PR DESCRIPTION
The AArch64 ELF spec includes "mapping symbols" for identifying contiguous data/code regions in a binary:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst#mapping-symbols

Ignore these if we encounter them in the ".defmt" section rather than returning an error such as
`Error: failed to demangle defmt symbol '$d.3': expected value at line 1 column 1`