### PR TITLE
decoder: add support for nested log formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#778]: `defmt-decoder`: Add support for nested log formatting
 - [#777]: `defmt-decoder`: Simplify StdoutLogger
 - [#775]: `defmt-decoder`: Ignore AArch64 mapping symbols
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
 - [#769]: `defmt-decoder`: Add support for color, style, width and alignment to format
 
+[#778]: https://github.com/knurling-rs/defmt/pull/778
 [#777]: https://github.com/knurling-rs/defmt/pull/777
 [#775]: https://github.com/knurling-rs/defmt/pull/775
 [#771]: https://github.com/knurling-rs/defmt/pull/771

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -75,13 +75,14 @@
 //! The alignment can be specified to be left (`<`), right (`>`), or center-aligned (`^`).
 //! If no alignment is specified, left alignment is used by default.
 //!
-//! The minimum width is specified after the alignment
-//!
+//! The minimum width is specified after the alignment.
 //! For example, "{L} {f:>10}: {s}" is printed as follows:
 //!
 //! ```text
 //! [ERROR]    main.rs: hello
 //! ```
+//! 
+//! The log level format specifier is printed with a minimum width of 5 by default.
 //!
 //! ## Nested formatting
 //!

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -13,7 +13,7 @@
 //!
 //! The following log will be used as reference in the examples below:
 //!
-//! ```
+//! ```ignore
 //! defmt::error!("hello");
 //! ```
 //!
@@ -164,7 +164,7 @@ pub(super) enum LogMetadata {
     /// Prints the module path of the function where the log is coming from.
     /// For the following log:
     ///
-    /// ```
+    /// ```ignore
     /// // crate: my_crate
     /// mod foo {
     ///     fn bar() {

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -630,4 +630,33 @@ mod tests {
         let result = parse(log_template);
         assert_eq!(result, Ok(expected_output));
     }
+
+    #[test]
+    fn test_parse_triple_nested_format() {
+        let log_template = "{{{[{L:<5}]%bold} {f:>20}:%<30} {s}%werror}";
+        let expected_output = vec![LogSegment::new(LogMetadata::NestedLogSegments(vec![
+            LogSegment::new(LogMetadata::NestedLogSegments(vec![
+                LogSegment::new(LogMetadata::NestedLogSegments(vec![
+                    LogSegment::new(LogMetadata::String("[".to_string())),
+                    LogSegment::new(LogMetadata::LogLevel)
+                        .with_alignment(Alignment::Left)
+                        .with_width(5),
+                    LogSegment::new(LogMetadata::String("]".to_string())),
+                ]))
+                .with_style(colored::Styles::Bold),
+                LogSegment::new(LogMetadata::String(" ".to_string())),
+                LogSegment::new(LogMetadata::FileName)
+                    .with_alignment(Alignment::Right)
+                    .with_width(20),
+                LogSegment::new(LogMetadata::String(":".to_string())),
+            ]))
+            .with_alignment(Alignment::Left)
+            .with_width(30),
+            LogSegment::new(LogMetadata::String(" ".to_string())),
+            LogSegment::new(LogMetadata::Log),
+        ]))
+        .with_color(LogColor::WarnError)];
+        let result = parse(log_template);
+        assert_eq!(result, Ok(expected_output));
+    }
 }

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -109,8 +109,8 @@
 //!
 //! - Format strings *must* include the `{s}` format specifier (log specifier).
 //! - At the moment it is not possible to escape curly brackets (i.e. `{`, `}`)
-//! in the format string, therefore curly brackets cannot be printed as part
-//! of the logger format.
+//!   in the format string, therefore curly brackets cannot be printed as part
+//!   of the logger format.
 //! - The same restriction exists for the `%` character.
 //!
 //! [format specifiers]: LogMetadata

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -81,7 +81,7 @@
 //! ```text
 //! [ERROR]    main.rs: hello
 //! ```
-//! 
+//!
 //! The log level format specifier is printed with a minimum width of 5 by default.
 //!
 //! ## Nested formatting

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -48,7 +48,7 @@
 //! A log segment can be specified to be colored by providing a color in the format parameters.
 //!
 //! There are three different options for coloring a log segment:
-//! - a string that can be parsed by the FromStr implementation of [colored::Color].
+//! - a string that can be parsed by the FromStr implementation of [colored::Color] (`red`, `green` etc.).
 //! - `severity` colors the log segment using the predefined color for the log level of log.
 //! - `werror` is similar to `severity`, but it only applies the color if the log level is WARN or ERROR.
 //!

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -405,7 +405,11 @@ fn format_contains_log_specifier(segments: &[LogSegment]) -> bool {
     for segment in segments {
         match &segment.metadata {
             LogMetadata::Log => return true,
-            LogMetadata::NestedLogSegments(s) => return format_contains_log_specifier(s),
+            LogMetadata::NestedLogSegments(s) => {
+                if format_contains_log_specifier(s) {
+                    return true;
+                }
+            },
             _ => continue,
         }
     }

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -6,112 +6,112 @@
 //!
 //! A format string takes a set of [format specifiers] written
 //! in the way a log should be printed by the logger.
-//! 
+//!
 //! ## Basics
-//! 
+//!
 //! Format strings allow the customization of how the logger prints logs.
-//! 
+//!
 //! The following log will be used as reference in the examples below:
-//! 
+//!
 //! ```
 //! defmt::error!("hello");
 //! ```
-//! 
+//!
 //! The simplest format string is `"{s}"`. This prints the log and nothing else:
-//! 
+//!
 //! ```text
 //! hello
 //! ```
-//! 
+//!
 //! Arbitrary text can be added to the format string, which will be printed as specified with each log.
 //! For example, `"Log: {s}"`:
-//! 
+//!
 //! ```text
 //! Log: hello
 //! ```
-//! 
+//!
 //! Multiple specifiers can be included within a format string, in any order. For example `"[{L}] {s}"` prints:
-//! 
+//!
 //! ```text
 //! [ERROR] hello
 //! ```
-//! 
+//!
 //! ## Customizing log segments
-//! 
+//!
 //! The way a format specifier is printed can be customized by providing additional, optional [format parameters].
-//! 
+//!
 //! Format parameters are provided by adding the parameters after the format specifier, separated by colons (`:`),
 //! like this: `"{L:bold:5} {f:white:<10} {s}"`.
-//! 
+//!
 //! ### Color
-//! 
+//!
 //! A log segment can be specified to be colored by providing a color in the format parameters.
-//! 
+//!
 //! There are three different options for coloring a log segment:
 //! - a string that can be parsed by the FromStr implementation of [colored::Color].
 //! - `severity` colors the log segment using the predefined color for the log level of log.
 //! - `werror` is similar to `severity`, but it only applies the color if the log level is WARN or ERROR.
-//! 
+//!
 //! Only one coloring option can be provided in format parameters for a given format specifier.
-//! 
+//!
 //! ### Styles
-//! 
+//!
 //! A log segment can be specified to be printed with a given style by providing a style in the format parameters.
-//! 
+//!
 //! The style specifier must be one of the following strings:
 //! - `bold`
 //! - `italic`
 //! - `underline`
 //! - `strike`
 //! - `dimmed`
-//! 
+//!
 //! Multiple styles can be applied to a single format specifier, but they must not be repeated, i.e.
 //! `"{s:bold:underline:italic}"` is allowed, but `"{s:bold:bold}"` isn't.
-//! 
+//!
 //! ### Width and alignment
-//! 
+//!
 //! A log segment can be specified to be printed with a given minimum width and alignment by providing a format parameter.
-//! 
+//!
 //! The alignment can be specified to be left (`<`), right (`>`), or center-aligned (`^`).
 //! If no alignment is specified, left alignment is used by default.
-//! 
+//!
 //! The minimum width is specified after the alignment
-//! 
+//!
 //! For example, "{L} {f:>10}: {s}" is printed as follows:
-//! 
+//!
 //! ```text
 //! [ERROR]    main.rs: hello
 //! ```
-//! 
+//!
 //! ## Nested formatting
-//! 
+//!
 //! Log segments can be grouped and formatted together by nesting formats. Format parameters for the grouped log segments
 //! must be provided after the group, separated by `%`.
-//! 
+//!
 //! Nested formats allow for more intricate formatting. For example, `"{[{L:bold}]%underline} {s}"` prints
-//! 
+//!
 //! ```text
 //! [ERROR] hello
 //! ```
-//! 
+//!
 //! where `ERROR` is formatted bold, and `[ERROR]` is underlined.
-//! 
+//!
 //! Formats can be nested several levels. This provides a great level of flexibility to customize the logger formatting.
 //! For example, the width and alignment of a group of log segments can be specified with nested formats.
 //! `"{{[{L}]%bold} {f:>20}:%<35} {s}"` prints:
-//! 
+//!
 //! ```text
 //! [ERROR]              main.rs:       hello
 //! ```
-//! 
+//!
 //! ## Restrictions
-//! 
+//!
 //! - Format strings *must* include the `{s}` format specifier (log specifier).
 //! - At the moment it is not possible to escape curly brackets (i.e. `{`, `}`)
 //! in the format string, therefore curly brackets cannot be printed as part
 //! of the logger format.
 //! - The same restriction exists for the `%` character.
-//! 
+//!
 //! [format specifiers]: LogMetadata
 //! [format parameters]: LogFormat
 
@@ -202,7 +202,7 @@ impl LogMetadata {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(super) enum LogColor {
     /// User-defined color.
-    /// 
+    ///
     /// Use a string that can be parsed by the FromStr implementation
     /// of [colored::Color].
     Color(colored::Color),
@@ -213,7 +213,7 @@ pub(super) enum LogColor {
 
     /// Color matching the default color for the log level,
     /// but only if the log level is WARN or ERROR.
-    /// 
+    ///
     /// Use `"werror"` as a format parameter to use this option.
     WarnError,
 }
@@ -581,7 +581,7 @@ fn format_contains_log_specifier(segments: &[LogSegment]) -> bool {
                 if format_contains_log_specifier(s) {
                     return true;
                 }
-            },
+            }
             _ => continue,
         }
     }

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -3,10 +3,9 @@ use nom::{
     bytes::complete::{take_till1, take_while},
     character::complete::{char, digit1, one_of},
     combinator::{map, map_res, opt},
-    error::{Error, ErrorKind, ParseError},
     multi::{many0, separated_list1},
     sequence::{delimited, preceded},
-    Err, IResult, Parser,
+    IResult, Parser,
 };
 
 use std::str::FromStr;
@@ -29,10 +28,10 @@ impl LogMetadata {
     /// Checks whether this `LogMetadata` came from a specifier such as
     /// {t}, {f}, etc.
     fn is_metadata_specifier(&self) -> bool {
-        match self {
-            LogMetadata::String(_) | LogMetadata::NestedLogSegments(_) => false,
-            _ => true,
-        }
+        !matches!(
+            self,
+            LogMetadata::String(_) | LogMetadata::NestedLogSegments(_)
+        )
     }
 }
 
@@ -309,7 +308,7 @@ fn build_log_segment<const NEST: bool>(
         // If we have a nested segment there must be exactly one,
         // otherwise there's something weird going on
         if let Some(segments) = nested_segments {
-            if segments.iter().count() == 1 {
+            if segments.len() == 1 {
                 return Ok(segments[0].clone());
             } else {
                 return Err(nom::Err::Failure(()));

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -164,6 +164,7 @@ impl<'a> Printer<'a> {
                 LogMetadata::LineNumber => self.print_line_number(sink, &segment.format),
                 LogMetadata::LogLevel => self.print_log_level(sink, &segment.format),
                 LogMetadata::Log => self.print_log(sink, &segment.format),
+                _ => return Ok(())
             }?;
         }
         writeln!(sink)

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -165,7 +165,9 @@ impl<'a> Printer<'a> {
                 LogMetadata::LineNumber => self.build_line_number(&segment.format),
                 LogMetadata::LogLevel => self.build_log_level(&segment.format),
                 LogMetadata::Log => self.build_log(&segment.format),
-                LogMetadata::NestedLogSegments(segments) => self.build_nested(segments, &segment.format),
+                LogMetadata::NestedLogSegments(segments) => {
+                    self.build_nested(segments, &segment.format)
+                }
             };
 
             write!(sink, "{s}")?;
@@ -185,7 +187,9 @@ impl<'a> Printer<'a> {
                 LogMetadata::LineNumber => self.build_line_number(&segment.format),
                 LogMetadata::LogLevel => self.build_log_level(&segment.format),
                 LogMetadata::Log => self.build_log(&segment.format),
-                LogMetadata::NestedLogSegments(segments) => self.build_nested(segments, &segment.format),
+                LogMetadata::NestedLogSegments(segments) => {
+                    self.build_nested(segments, &segment.format)
+                }
             };
             result.push_str(&s);
         }
@@ -217,13 +221,7 @@ impl<'a> Printer<'a> {
 
         let color = format.color.unwrap_or(LogColor::SeverityLevel);
 
-        build_formatted_string(
-            s.as_str(),
-            format,
-            5,
-            self.record_log_level(),
-            Some(color),
-        )
+        build_formatted_string(s.as_str(), format, 5, self.record_log_level(), Some(color))
     }
 
     fn build_file_path(&self, format: &LogFormat) -> String {
@@ -281,13 +279,15 @@ impl<'a> Printer<'a> {
         match self.record {
             Record::Defmt(record) => match color_diff(record.args().to_string()) {
                 Ok(s) => s.to_string(),
-                Err(s) => {
-                    build_formatted_string(s.as_str(), format, 0, self.record_log_level(), format.color)
-                },
+                Err(s) => build_formatted_string(
+                    s.as_str(),
+                    format,
+                    0,
+                    self.record_log_level(),
+                    format.color,
+                ),
             },
-            Record::Host(record) => {
-                record.args().to_string()
-            }
+            Record::Host(record) => record.args().to_string(),
         }
     }
 
@@ -440,6 +440,7 @@ fn build_formatted_string(
         Alignment::Left => write!(&mut result, "{colored_str:<0$}", width),
         Alignment::Center => write!(&mut result, "{colored_str:^0$}", width),
         Alignment::Right => write!(&mut result, "{colored_str:>0$}", width),
-    }.expect("Failed to format string: \"{colored_str}\"");
+    }
+    .expect("Failed to format string: \"{colored_str}\"");
     result
 }


### PR DESCRIPTION
This PR is a follow-up for #769.

This adds support for nesting formats, allowing users to specify formatting for _groups_ of log segments at once.
For example, `"{[{L:bold}]%underline} {s}"` prints `"[ERROR] Something went wrong"` where `ERROR` is bold, and `[ERROR]` is underlined from `[`to `]`.

This nesting feature also enables aligning groups of log segments at once, which allows users to format their logs like this:

```
   54251 [INFO ] main.rs:543   Something happened
  400241 [ERROR] parser.rs:86  Failed to parse input 
```

I think the formatting feature is pretty much complete with this PR, and I don't have plans to extend it any further at this point.

That said, I do intend to submit a PR to propose a new default format after this is merged.

I'm looking forward to finally have this in defmt :)