### PR TITLE
Add support for zero-padded timestamps and Unix-style timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#780]: `defmt-decoder`: Add support for zero-padded timestamps and Unix-style timestamps
 - [#778]: `defmt-decoder`: Add support for nested log formatting
 - [#777]: `defmt-decoder`: Simplify StdoutLogger
 - [#775]: `defmt-decoder`: Ignore AArch64 mapping symbols
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
 - [#769]: `defmt-decoder`: Add support for color, style, width and alignment to format
 
+[#780]: https://github.com/knurling-rs/defmt/pull/780
 [#778]: https://github.com/knurling-rs/defmt/pull/778
 [#777]: https://github.com/knurling-rs/defmt/pull/777
 [#775]: https://github.com/knurling-rs/defmt/pull/775

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -206,10 +206,7 @@ impl LogMetadata {
     }
 
     pub fn is_timestamp(&self) -> bool {
-        matches!(
-            self,
-            LogMetadata::TimestampMs | LogMetadata::TimestampUnix
-        )
+        matches!(self, LogMetadata::TimestampMs | LogMetadata::TimestampUnix)
     }
 }
 
@@ -739,7 +736,10 @@ mod tests {
         let result = parse_width_and_alignment("12");
         assert_eq!(
             result,
-            Ok(("", IntermediateOutput::WidthAndAlignment((12, Padding::Space, None))))
+            Ok((
+                "",
+                IntermediateOutput::WidthAndAlignment((12, Padding::Space, None))
+            ))
         );
     }
 
@@ -748,7 +748,10 @@ mod tests {
         let result = parse_width_and_alignment("012");
         assert_eq!(
             result,
-            Ok(("", IntermediateOutput::WidthAndAlignment((12, Padding::Zero, None))))
+            Ok((
+                "",
+                IntermediateOutput::WidthAndAlignment((12, Padding::Zero, None))
+            ))
         );
     }
 

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -204,10 +204,6 @@ impl LogMetadata {
             LogMetadata::String(_) | LogMetadata::NestedLogSegments(_)
         )
     }
-
-    pub fn is_timestamp(&self) -> bool {
-        matches!(self, LogMetadata::TimestampMs | LogMetadata::TimestampUnix)
-    }
 }
 
 /// Coloring options for [LogSegment]s.

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -363,7 +363,7 @@ pub fn take_until_unbalanced(
 }
 
 fn parse_metadata(input: &str) -> IResult<&str, IntermediateOutput, ()> {
-    let mut parse_type = map_res(take_while(char::is_alphanumeric), move |s| {
+    let mut parse_type = map_res(take_while(char::is_alphabetic), move |s| {
         let metadata = match s {
             "f" => LogMetadata::FileName,
             "F" => LogMetadata::FilePath,

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -190,17 +190,15 @@ impl<'a> Printer<'a> {
         let s = match self.record {
             Record::Defmt(record) if !record.timestamp().is_empty() => {
                 match style {
-                    TimestampStyle::Normal => {
-                        match format.padding {
-                            Some(Padding::Space) | None => record.timestamp().to_string(),
-                            Some(Padding::Zero) => {
-                                let mut result = String::new();
-                                let width = format.width.unwrap_or(8);
-                                let timestamp = record.timestamp();
-                                write!(&mut result, "{timestamp:0>0$}", width)
-                                    .expect("failed to format timestamp");
-                                result
-                            }
+                    TimestampStyle::Normal => match format.padding {
+                        Some(Padding::Space) | None => record.timestamp().to_string(),
+                        Some(Padding::Zero) => {
+                            let mut result = String::new();
+                            let width = format.width.unwrap_or(8);
+                            let timestamp = record.timestamp();
+                            write!(&mut result, "{timestamp:0>0$}", width)
+                                .expect("failed to format timestamp");
+                            result
                         }
                     },
                     TimestampStyle::Unix => {

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -93,7 +93,7 @@ impl StdoutLogger {
     }
 
     pub fn info(&self) -> DefmtLoggerInfo {
-        fn has_timestamp(segments :&[LogSegment]) -> bool {
+        fn has_timestamp(segments: &[LogSegment]) -> bool {
             for segment in segments {
                 match &segment.metadata {
                     LogMetadata::TimestampMs | LogMetadata::TimestampUnix => return true,

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -93,7 +93,22 @@ impl StdoutLogger {
     }
 
     pub fn info(&self) -> DefmtLoggerInfo {
-        let has_timestamp = self.log_format.iter().any(|s| s.metadata.is_timestamp());
+        fn has_timestamp(segments :&[LogSegment]) -> bool {
+            for segment in segments {
+                match &segment.metadata {
+                    LogMetadata::TimestampMs | LogMetadata::TimestampUnix => return true,
+                    LogMetadata::NestedLogSegments(s) => {
+                        if has_timestamp(s) {
+                            return true;
+                        }
+                    }
+                    _ => continue,
+                }
+            }
+            false
+        }
+
+        let has_timestamp = has_timestamp(&self.log_format);
         DefmtLoggerInfo { has_timestamp }
     }
 


### PR DESCRIPTION
This PR adds a new format specifier to format the timestamp like this "01:42:56.643".

This PR also extends the parser to support parsing format parameters like `"{t:>08"}`, to zero-pad timestamps.

I also removed the `min_timestamp_width`/`timing_align` stuff that was previously needed for formatting timestamps.