### PR TITLE
Add `pub struct Formatter` to `defmt_decoder::log`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [#xxx]: `defmt-decoder`: Add `pub struct Formatter` to `defmt_decoder::log`
+- [#781]: `defmt-decoder`: Add `pub struct Formatter` to `defmt_decoder::log`
 - [#778]: `defmt-decoder`: Add support for nested log formatting
 - [#777]: `defmt-decoder`: Simplify StdoutLogger
 - [#775]: `defmt-decoder`: Ignore AArch64 mapping symbols
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
 - [#769]: `defmt-decoder`: Add support for color, style, width and alignment to format
 
-[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
+[#781]: https://github.com/knurling-rs/defmt/pull/781
 [#778]: https://github.com/knurling-rs/defmt/pull/778
 [#777]: https://github.com/knurling-rs/defmt/pull/777
 [#775]: https://github.com/knurling-rs/defmt/pull/775

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#xxx]: `defmt-decoder`: Add `pub struct Formatter` to `defmt_decoder::log`
 - [#778]: `defmt-decoder`: Add support for nested log formatting
 - [#777]: `defmt-decoder`: Simplify StdoutLogger
 - [#775]: `defmt-decoder`: Ignore AArch64 mapping symbols
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
 - [#769]: `defmt-decoder`: Add support for color, style, width and alignment to format
 
+[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
 [#778]: https://github.com/knurling-rs/defmt/pull/778
 [#777]: https://github.com/knurling-rs/defmt/pull/777
 [#775]: https://github.com/knurling-rs/defmt/pull/775

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -29,13 +29,15 @@ use std::{
 };
 
 use byteorder::{ReadBytesExt, LE};
-use decoder::Decoder;
 use defmt_parser::Level;
-use elf2table::parse_impl;
 
-pub use elf2table::{Location, Locations};
-pub use frame::Frame;
-pub use stream::StreamDecoder;
+use crate::{decoder::Decoder, elf2table::parse_impl};
+
+pub use crate::{
+    elf2table::{Location, Locations},
+    frame::Frame,
+    stream::StreamDecoder,
+};
 
 /// Specifies the origin of a format string
 #[derive(PartialEq, Eq, Debug)]

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -218,7 +218,6 @@ impl Formatter {
                     }
                 }
                 .format_frame()
-                .unwrap()
             }
         }
     }

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -31,7 +31,7 @@ pub fn log_defmt(
     line: Option<u32>,
     module_path: Option<&str>,
 ) {
-    let (timestamp, level) = timestamp_and_level_from_frame(&frame);
+    let (timestamp, level) = timestamp_and_level_from_frame(frame);
 
     let target = format!(
         "{}{}",
@@ -194,6 +194,7 @@ impl Formatter {
     ) -> String {
         let (timestamp, level) = timestamp_and_level_from_frame(&frame);
 
+        #[allow(clippy::match_single_binding)]
         match format_args!("{}", frame.display_message()) {
             args => {
                 let log_record = &Record::builder()

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -164,7 +164,7 @@ impl DefmtLoggerInfo {
     }
 }
 
-/// Format [DefmtRecord]s according to a `log_format`.
+/// Format [`Frame`]s according to a `log_format`.
 ///
 /// The `log_format` makes it possible to customize the defmt output.
 ///
@@ -209,17 +209,15 @@ impl Formatter {
                 };
 
                 match level {
-                    Some(_) => Printer::new_defmt(&record, &self.format)
-                        .format_frame()
-                        .unwrap(),
+                    Some(_) => Printer::new_defmt(&record, &self.format),
                     None => {
                         // handle defmt::println separately
                         const RAW_FORMAT: &[LogSegment] = &[LogSegment::new(LogMetadata::Log)];
                         Printer::new_defmt(&record, RAW_FORMAT)
-                            .format_frame()
-                            .unwrap()
                     }
                 }
+                .format_frame()
+                .unwrap()
             }
         }
     }

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -173,6 +173,7 @@ impl DefmtLoggerInfo {
 // - use two Formatter in StdoutLogger instead of the log format
 // - add fn format_to_sink
 // - specify log format
+#[derive(Debug)]
 pub struct Formatter {
     format: Vec<LogSegment>,
 }

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -57,7 +57,7 @@ pub fn is_defmt_frame(metadata: &Metadata) -> bool {
 }
 
 /// A `log` record representing a defmt log frame.
-pub struct DefmtRecord<'a> {
+struct DefmtRecord<'a> {
     log_record: &'a Record<'a>,
     payload: Payload,
 }

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -173,6 +173,7 @@ impl DefmtLoggerInfo {
 // - use two Formatter in StdoutLogger instead of the log format
 // - add fn format_to_sink
 // - specify log format
+// - clarify relationship between Formatter and Printer (https://github.com/knurling-rs/defmt/pull/781#discussion_r1343000073)
 #[derive(Debug)]
 pub struct Formatter {
     format: Vec<LogSegment>,

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -16,7 +16,7 @@ use log::{Level, LevelFilter, Log, Metadata, Record};
 use serde::{Deserialize, Serialize};
 
 use self::{
-    format::LogSegment,
+    format::{LogMetadata, LogSegment},
     json_logger::JsonLogger,
     stdout_logger::{Printer, StdoutLogger},
 };
@@ -208,9 +208,18 @@ impl Formatter {
                     payload: Payload { level, timestamp },
                 };
 
-                Printer::new_defmt(&record, &self.format)
-                    .format_frame()
-                    .unwrap()
+                match level {
+                    Some(_) => Printer::new_defmt(&record, &self.format)
+                        .format_frame()
+                        .unwrap(),
+                    None => {
+                        // handle defmt::println separately
+                        const RAW_FORMAT: &[LogSegment] = &[LogSegment::new(LogMetadata::Log)];
+                        Printer::new_defmt(&record, RAW_FORMAT)
+                            .format_frame()
+                            .unwrap()
+                    }
+                }
             }
         }
     }

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -194,6 +194,7 @@ impl Formatter {
     ) -> String {
         let (timestamp, level) = timestamp_and_level_from_frame(&frame);
 
+        // HACK: use match instead of let, because otherwise compilation fails
         #[allow(clippy::match_single_binding)]
         match format_args!("{}", frame.display_message()) {
             args => {

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -31,18 +31,7 @@ pub fn log_defmt(
     line: Option<u32>,
     module_path: Option<&str>,
 ) {
-    let timestamp = frame
-        .display_timestamp()
-        .map(|ts| ts.to_string())
-        .unwrap_or_default();
-
-    let level = frame.level().map(|level| match level {
-        crate::Level::Trace => Level::Trace,
-        crate::Level::Debug => Level::Debug,
-        crate::Level::Info => Level::Info,
-        crate::Level::Warn => Level::Warn,
-        crate::Level::Error => Level::Error,
-    });
+    let (timestamp, level) = timestamp_and_level_from_frame(&frame);
 
     let target = format!(
         "{}{}",
@@ -202,18 +191,7 @@ impl Formatter {
         line: Option<u32>,
         module_path: Option<&str>,
     ) -> String {
-        let timestamp = frame
-            .display_timestamp()
-            .map(|ts| ts.to_string())
-            .unwrap_or_default();
-
-        let level = frame.level().map(|level| match level {
-            crate::Level::Trace => Level::Trace,
-            crate::Level::Debug => Level::Debug,
-            crate::Level::Info => Level::Info,
-            crate::Level::Warn => Level::Warn,
-            crate::Level::Error => Level::Error,
-        });
+        let (timestamp, level) = timestamp_and_level_from_frame(&frame);
 
         match format_args!("{}", frame.display_message()) {
             args => {
@@ -235,4 +213,19 @@ impl Formatter {
             }
         }
     }
+}
+
+fn timestamp_and_level_from_frame(frame: &Frame<'_>) -> (String, Option<Level>) {
+    let timestamp = frame
+        .display_timestamp()
+        .map(|ts| ts.to_string())
+        .unwrap_or_default();
+    let level = frame.level().map(|level| match level {
+        crate::Level::Trace => Level::Trace,
+        crate::Level::Debug => Level::Debug,
+        crate::Level::Info => Level::Info,
+        crate::Level::Warn => Level::Warn,
+        crate::Level::Error => Level::Error,
+    });
+    (timestamp, level)
 }

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -166,13 +166,13 @@ impl<'a> Printer<'a> {
         writeln!(sink)
     }
 
-    pub(super) fn format_frame(&self) -> Result<String, std::fmt::Error> {
-        let mut sink = String::new();
+    pub(super) fn format_frame(&self) -> String {
+        let mut buf = String::new();
         for segment in self.format {
             let s = self.build_segment(segment);
-            write!(sink, "{s}")?;
+            write!(buf, "{s}").expect("writing to String cannot fail");
         }
-        Ok(sink)
+        buf
     }
 
     fn build_segment(&self, segment: &LogSegment) -> String {

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -147,11 +147,7 @@ impl<'a> Printer<'a> {
     }
 
     pub fn new_defmt(record: &'a DefmtRecord<'a>, format: &'a [LogSegment]) -> Self {
-        Self {
-            record: Record::Defmt(record),
-            format,
-            min_timestamp_width: 0,
-        }
+        Self::new(Record::Defmt(record), format)
     }
 
     /// Pads the defmt timestamp to take up at least the given number of characters.

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -138,7 +138,7 @@ pub(super) struct Printer<'a> {
 }
 
 impl<'a> Printer<'a> {
-    pub fn new(record: Record<'a>, format: &'a [LogSegment]) -> Self {
+    fn new(record: Record<'a>, format: &'a [LogSegment]) -> Self {
         Self {
             record,
             format,
@@ -156,7 +156,7 @@ impl<'a> Printer<'a> {
 
     /// Pads the defmt timestamp to take up at least the given number of characters.
     /// TODO: Remove this, shouldn't be needed now that we have width field support
-    pub fn min_timestamp_width(&mut self, min_timestamp_width: usize) -> &mut Self {
+    fn min_timestamp_width(&mut self, min_timestamp_width: usize) -> &mut Self {
         self.min_timestamp_width = min_timestamp_width;
         self
     }


### PR DESCRIPTION
The purpose of `Formatter` is to format defmt frames according to the log format. Specifically I will be using this to add custom log format support to `probe-rs`.

@andresovela Would you have time for a review?