### PR TITLE
Raise the default log level from error to info if DEFMT_LOG was not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#782]: `defmt-macros`: Raise the default log level from error to info if DEFMT_LOG was not defined
 - [#778]: `defmt-decoder`: Add support for nested log formatting
 - [#777]: `defmt-decoder`: Simplify StdoutLogger
 - [#775]: `defmt-decoder`: Ignore AArch64 mapping symbols
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
 - [#769]: `defmt-decoder`: Add support for color, style, width and alignment to format
 
+[#782]: https://github.com/knurling-rs/defmt/pull/782
 [#778]: https://github.com/knurling-rs/defmt/pull/778
 [#777]: https://github.com/knurling-rs/defmt/pull/777
 [#775]: https://github.com/knurling-rs/defmt/pull/775

--- a/book/src/filtering.md
+++ b/book/src/filtering.md
@@ -10,8 +10,8 @@
 
 The logging macros `trace!`, `debug!`, `info!`, `warn!` and `error!` match these logging levels.
 
-By default, only `ERROR` level messages are emitted.
-All other logging levels are disabled.
+By default, only messages up to `INFO` level are emitted.
+Higher logging levels are disabled.
 
 Note that `defmt::println!` statements cannot be filtered and are always included in the output.
 

--- a/macros/src/function_like/log/env_filter.rs
+++ b/macros/src/function_like/log/env_filter.rs
@@ -27,9 +27,8 @@ impl EnvFilter {
     }
 
     fn new(defmt_log: Option<&str>, cargo_crate_name: &str) -> Self {
-        // match `env_logger` behavior
         const LEVEL_WHEN_LEVEL_IS_NOT_SPECIFIED: LogLevelOrOff = Some(Level::Trace);
-        const LEVEL_WHEN_NOTHING_IS_SPECIFIED: LogLevelOrOff = Some(Level::Error);
+        const LEVEL_WHEN_NOTHING_IS_SPECIFIED: LogLevelOrOff = Some(Level::Info);
 
         let caller_crate = cargo_crate_name;
 

--- a/macros/src/function_like/log/env_filter.rs
+++ b/macros/src/function_like/log/env_filter.rs
@@ -212,14 +212,14 @@ mod tests {
     }
 
     #[test]
-    fn when_empty_defmt_log_use_error() {
+    fn when_empty_defmt_log_use_info() {
         let env_filter = EnvFilter::new(None, "krate");
         let expected = [ModulePath::parse("krate")];
         assert_eq!(
             expected.iter().collect::<BTreeSet<_>>(),
-            env_filter.modules_on_for(Level::Error)
+            env_filter.modules_on_for(Level::Info)
         );
-        assert_eq!(btreeset![], env_filter.modules_on_for(Level::Warn));
+        assert_eq!(btreeset![], env_filter.modules_on_for(Level::Debug));
     }
 
     #[test]
@@ -346,9 +346,9 @@ mod tests {
         let expected = [ModulePath::parse("foo")];
         assert_eq!(
             expected.iter().collect::<BTreeSet<_>>(),
-            env_filter.modules_on_for(Level::Error)
+            env_filter.modules_on_for(Level::Info)
         );
-        assert_eq!(btreeset![], env_filter.modules_on_for(Level::Warn));
+        assert_eq!(btreeset![], env_filter.modules_on_for(Level::Debug));
     }
 
     // doesn't affect runtime performance but it makes the expanded code smaller


### PR DESCRIPTION
I realize this might be controversial, but I've personally _**never**_ had any use for the default behavior of printing only error-level logs. Not only with `defmt`, but generally with any logger I've ever used in embedded systems.

Every time I run a project, any of them, I always have to run it with at least `DEFMT_LOG=info` or `debug`.

I think might be one of the reasons why people default to using `defmt::println`, because `defmt` prints nothing by default. Most people likely do not test `defmt` by writing `defmt::error!("hello world");`.

Note that this wouldn't be an issue if we had proper module-level filtering with something like the proposal in #779 