### PR TITLE
decoder: formatting improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - [#789]: `defmt`: Add support for new time-related display hints
+- [#783]: `defmt-decoder`: Move formatting logic to `Formatter`
 
 [#789]: https://github.com/knurling-rs/defmt/pull/789
+[#783]: https://github.com/knurling-rs/defmt/pull/783
 
 ## defmt-decoder v0.3.9, defmt-print v0.3.10 - 2023-10-04
 

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -473,11 +473,7 @@ impl InternalFormatter {
             let path_iter = Path::new(file).iter();
             let number_of_components = path_iter.clone().count();
 
-            let number_of_components_to_join = if number_of_components > level_of_detail as usize {
-                level_of_detail as usize
-            } else {
-                number_of_components
-            };
+            let number_of_components_to_join = number_of_components.min(level_of_detail as usize);
 
             let number_of_elements_to_skip =
                 number_of_components.saturating_sub(number_of_components_to_join);

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -239,14 +239,52 @@ enum Record<'a> {
     Host(&'a LogRecord<'a>),
 }
 
+#[derive(Debug)]
 pub enum FormatterFormat<'a> {
     Default { with_location: bool },
     Custom(&'a str),
 }
 
+impl Default for FormatterFormat<'_> {
+    fn default() -> Self {
+        FormatterFormat::Default {
+            with_location: false,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
 pub struct FormatterConfig<'a> {
     pub format: FormatterFormat<'a>,
     pub is_timestamp_available: bool,
+}
+
+impl<'a> FormatterConfig<'a> {
+    pub fn custom(format: &'a str) -> Self {
+        FormatterConfig {
+            format: FormatterFormat::Custom(format),
+            is_timestamp_available: false,
+        }
+    }
+
+    pub fn with_timestamp(mut self) -> Self {
+        self.is_timestamp_available = true;
+        self
+    }
+
+    pub fn with_location(mut self) -> Self {
+        // TODO: Should we warn the user that trying to set a location
+        //       for a custom format won't work?
+        match self.format {
+            FormatterFormat::Default { with_location: _ } => {
+                self.format = FormatterFormat::Default {
+                    with_location: true,
+                };
+                self
+            }
+            _ => self,
+        }
+    }
 }
 
 impl InternalFormatter {

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -161,14 +161,14 @@ impl LogSegment {
     }
 }
 
-pub struct DefmtFormatter {
-    formatter: Formatter,
+pub struct Formatter {
+    formatter: InternalFormatter,
 }
 
-impl DefmtFormatter {
+impl Formatter {
     pub fn new(config: FormatterConfig) -> Self {
         Self {
-            formatter: Formatter::new(config, Source::Defmt),
+            formatter: InternalFormatter::new(config, Source::Defmt),
         }
     }
 
@@ -208,13 +208,13 @@ impl DefmtFormatter {
 }
 
 pub struct HostFormatter {
-    formatter: Formatter,
+    formatter: InternalFormatter,
 }
 
 impl HostFormatter {
     pub fn new(config: FormatterConfig) -> Self {
         Self {
-            formatter: Formatter::new(config, Source::Host),
+            formatter: InternalFormatter::new(config, Source::Host),
         }
     }
 
@@ -224,7 +224,7 @@ impl HostFormatter {
 }
 
 #[derive(Debug)]
-struct Formatter {
+struct InternalFormatter {
     format: Vec<LogSegment>,
 }
 
@@ -249,7 +249,7 @@ pub struct FormatterConfig<'a> {
     pub is_timestamp_available: bool,
 }
 
-impl Formatter {
+impl InternalFormatter {
     fn new(config: FormatterConfig, source: Source) -> Self {
         const FORMAT: &str = "{L} {s}";
         const FORMAT_WITH_LOCATION: &str = "{L} {s}\n└─ {m} @ {F}:{l}";

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -424,7 +424,7 @@ impl InternalFormatter {
         build_formatted_string(
             s.as_str(),
             format,
-            8,
+            0,
             get_log_level_of_record(record),
             format.color,
         )

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -1,0 +1,627 @@
+use super::{DefmtRecord, Payload};
+use crate::Frame;
+use colored::{Color, ColoredString, Colorize, Styles};
+use dissimilar::Chunk;
+use log::{Level, Record as LogRecord};
+use std::{fmt::Write, path::Path};
+
+mod parser;
+
+/// Representation of what a [LogSegment] can be.
+#[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
+pub(super) enum LogMetadata {
+    /// `{f}` format specifier.
+    ///
+    /// For a file "src/foo/bar.rs", this option prints "bar.rs".
+    FileName,
+
+    /// `{F}` format specifier.
+    ///
+    /// For a file "src/foo/bar.rs", this option prints "src/foo/bar.rs".
+    FilePath,
+
+    /// `{l}` format specifier.
+    ///
+    /// Prints the line number where the log is coming from.
+    LineNumber,
+
+    /// `{s}` format specifier.
+    ///
+    /// Prints the actual log contents.
+    /// For `defmt::info!("hello")`, this prints "hello".
+    Log,
+
+    /// `{L}` format specifier.
+    ///
+    /// Prints the log level.
+    /// For `defmt::info!("hello")`, this prints "INFO".
+    LogLevel,
+
+    /// `{m}` format specifier.
+    ///
+    /// Prints the module path of the function where the log is coming from.
+    /// For the following log:
+    ///
+    /// ```ignore
+    /// // crate: my_crate
+    /// mod foo {
+    ///     fn bar() {
+    ///         defmt::info!("hello");
+    ///     }
+    /// }
+    /// ```
+    /// this prints "my_crate::foo::bar".
+    ModulePath,
+
+    /// Represents the parts of the formatting string that is not specifiers.
+    String(String),
+
+    /// `{t}` format specifier.
+    ///
+    /// Prints the timestamp at which something was logged.
+    /// For a log printed with a timestamp 123456 ms, this prints "123456".
+    Timestamp,
+
+    /// Represents formats specified within nested curly brackets in the formatting string.
+    NestedLogSegments(Vec<LogSegment>),
+}
+
+impl LogMetadata {
+    /// Checks whether this `LogMetadata` came from a specifier such as
+    /// {t}, {f}, etc.
+    fn is_metadata_specifier(&self) -> bool {
+        !matches!(
+            self,
+            LogMetadata::String(_) | LogMetadata::NestedLogSegments(_)
+        )
+    }
+}
+
+/// Coloring options for [LogSegment]s.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(super) enum LogColor {
+    /// User-defined color.
+    ///
+    /// Use a string that can be parsed by the FromStr implementation
+    /// of [colored::Color].
+    Color(colored::Color),
+
+    /// Color matching the default color for the log level.
+    /// Use `"severity"` as a format parameter to use this option.
+    SeverityLevel,
+
+    /// Color matching the default color for the log level,
+    /// but only if the log level is WARN or ERROR.
+    ///
+    /// Use `"werror"` as a format parameter to use this option.
+    WarnError,
+}
+
+/// Alignment options for [LogSegment]s.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(super) enum Alignment {
+    Center,
+    Left,
+    Right,
+}
+
+/// Representation of a segment of the formatting string.
+#[derive(Debug, PartialEq, Clone)]
+pub(super) struct LogSegment {
+    pub(super) metadata: LogMetadata,
+    pub(super) format: LogFormat,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(super) struct LogFormat {
+    pub(super) width: Option<usize>,
+    pub(super) color: Option<LogColor>,
+    pub(super) style: Option<Vec<colored::Styles>>,
+    pub(super) alignment: Option<Alignment>,
+}
+
+impl LogSegment {
+    pub(super) const fn new(metadata: LogMetadata) -> Self {
+        Self {
+            metadata,
+            format: LogFormat {
+                color: None,
+                style: None,
+                width: None,
+                alignment: None,
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_color(mut self, color: LogColor) -> Self {
+        self.format.color = Some(color);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_style(mut self, style: colored::Styles) -> Self {
+        let mut styles = self.format.style.unwrap_or_default();
+        styles.push(style);
+        self.format.style = Some(styles);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_width(mut self, width: usize) -> Self {
+        self.format.width = Some(width);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_alignment(mut self, alignment: Alignment) -> Self {
+        self.format.alignment = Some(alignment);
+        self
+    }
+}
+
+pub struct DefmtFormatter {
+    formatter: Formatter,
+}
+
+impl DefmtFormatter {
+    pub fn new(config: FormatterConfig) -> Self {
+        Self {
+            formatter: Formatter::new(config, Source::Defmt),
+        }
+    }
+
+    pub fn format_frame<'a>(
+        &self,
+        frame: Frame<'a>,
+        file: Option<&'a str>,
+        line: Option<u32>,
+        module_path: Option<&str>,
+    ) -> String {
+        let (timestamp, level) = super::timestamp_and_level_from_frame(&frame);
+
+        // HACK: use match instead of let, because otherwise compilation fails
+        #[allow(clippy::match_single_binding)]
+        match format_args!("{}", frame.display_message()) {
+            args => {
+                let log_record = &LogRecord::builder()
+                    .args(args)
+                    .module_path(module_path)
+                    .file(file)
+                    .line(line)
+                    .build();
+
+                let record = DefmtRecord {
+                    log_record,
+                    payload: Payload { level, timestamp },
+                };
+
+                self.format(&record)
+            }
+        }
+    }
+
+    pub(super) fn format(&self, record: &DefmtRecord) -> String {
+        self.formatter.format(&Record::Defmt(record))
+    }
+}
+
+pub struct HostFormatter {
+    formatter: Formatter,
+}
+
+impl HostFormatter {
+    pub fn new(config: FormatterConfig) -> Self {
+        Self {
+            formatter: Formatter::new(config, Source::Host),
+        }
+    }
+
+    pub fn format(&self, record: &LogRecord) -> String {
+        self.formatter.format(&Record::Host(record))
+    }
+}
+
+#[derive(Debug)]
+struct Formatter {
+    format: Vec<LogSegment>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Source {
+    Defmt,
+    Host,
+}
+
+enum Record<'a> {
+    Defmt(&'a DefmtRecord<'a>),
+    Host(&'a LogRecord<'a>),
+}
+
+pub enum FormatterFormat<'a> {
+    Default { with_location: bool },
+    Custom(&'a str),
+}
+
+pub struct FormatterConfig<'a> {
+    pub format: FormatterFormat<'a>,
+    pub is_timestamp_available: bool,
+}
+
+impl Formatter {
+    fn new(config: FormatterConfig, source: Source) -> Self {
+        const FORMAT: &str = "{L} {s}";
+        const FORMAT_WITH_LOCATION: &str = "{L} {s}\n└─ {m} @ {F}:{l}";
+        const FORMAT_WITH_TIMESTAMP: &str = "{t} {L} {s}";
+        const FORMAT_WITH_TIMESTAMP_AND_LOCATION: &str = "{t} {L} {s}\n└─ {m} @ {F}:{l}";
+
+        let format = match config.format {
+            FormatterFormat::Default { with_location } => {
+                let mut format = match (with_location, config.is_timestamp_available) {
+                    (false, false) => FORMAT,
+                    (false, true) => FORMAT_WITH_TIMESTAMP,
+                    (true, false) => FORMAT_WITH_LOCATION,
+                    (true, true) => FORMAT_WITH_TIMESTAMP_AND_LOCATION,
+                }
+                .to_string();
+
+                if source == Source::Host {
+                    format.insert_str(0, "(HOST) ");
+                }
+
+                format
+            }
+            FormatterFormat::Custom(format) => format.to_string(),
+        };
+
+        let format = parser::parse(&format).expect("log format is invalid '{format}'");
+
+        if matches!(config.format, FormatterFormat::Custom(_)) {
+            let format_has_timestamp = format_has_timestamp(&format);
+            if format_has_timestamp && !config.is_timestamp_available {
+                log::warn!(
+                    "logger format contains timestamp but no timestamp implementation \
+                    was provided; consider removing the timestamp (`{{t}}` or `{{T}}`) from the \
+                    logger format or provide a `defmt::timestamp!` implementation"
+                );
+            } else if !format_has_timestamp && config.is_timestamp_available {
+                log::warn!(
+                    "`defmt::timestamp!` implementation was found, but timestamp is not \
+                    part of the log format; consider adding the timestamp (`{{t}}` or `{{T}}`) \
+                    argument to the log format"
+                );
+            }
+        }
+
+        Self { format }
+    }
+
+    fn format(&self, record: &Record) -> String {
+        let mut buf = String::new();
+        for segment in &self.format {
+            let s = self.build_segment(record, segment);
+            write!(buf, "{s}").expect("writing to String cannot fail");
+        }
+        buf
+    }
+
+    fn build_segment(&self, record: &Record, segment: &LogSegment) -> String {
+        match &segment.metadata {
+            LogMetadata::String(s) => s.to_string(),
+            LogMetadata::Timestamp => self.build_timestamp(record, &segment.format),
+            LogMetadata::FileName => self.build_file_name(record, &segment.format),
+            LogMetadata::FilePath => self.build_file_path(record, &segment.format),
+            LogMetadata::ModulePath => self.build_module_path(record, &segment.format),
+            LogMetadata::LineNumber => self.build_line_number(record, &segment.format),
+            LogMetadata::LogLevel => self.build_log_level(record, &segment.format),
+            LogMetadata::Log => self.build_log(record, &segment.format),
+            LogMetadata::NestedLogSegments(segments) => {
+                self.build_nested(record, segments, &segment.format)
+            }
+        }
+    }
+
+    fn build_nested(&self, record: &Record, segments: &[LogSegment], format: &LogFormat) -> String {
+        let mut result = String::new();
+        for segment in segments {
+            let s = match &segment.metadata {
+                LogMetadata::String(s) => s.to_string(),
+                LogMetadata::Timestamp => self.build_timestamp(record, &segment.format),
+                LogMetadata::FileName => self.build_file_name(record, &segment.format),
+                LogMetadata::FilePath => self.build_file_path(record, &segment.format),
+                LogMetadata::ModulePath => self.build_module_path(record, &segment.format),
+                LogMetadata::LineNumber => self.build_line_number(record, &segment.format),
+                LogMetadata::LogLevel => self.build_log_level(record, &segment.format),
+                LogMetadata::Log => self.build_log(record, &segment.format),
+                LogMetadata::NestedLogSegments(segments) => {
+                    self.build_nested(record, segments, &segment.format)
+                }
+            };
+            result.push_str(&s);
+        }
+
+        build_formatted_string(
+            &result,
+            format,
+            0,
+            get_log_level_of_record(record),
+            format.color,
+        )
+    }
+
+    fn build_timestamp(&self, record: &Record, format: &LogFormat) -> String {
+        let s = match record {
+            Record::Defmt(record) if !record.timestamp().is_empty() => record.timestamp(),
+            _ => "<time>",
+        }
+        .to_string();
+
+        build_formatted_string(
+            s.as_str(),
+            format,
+            8,
+            get_log_level_of_record(record),
+            format.color,
+        )
+    }
+
+    fn build_log_level(&self, record: &Record, format: &LogFormat) -> String {
+        let s = match get_log_level_of_record(record) {
+            Some(level) => level.to_string(),
+            None => "<lvl>".to_string(),
+        };
+
+        let color = format.color.unwrap_or(LogColor::SeverityLevel);
+
+        build_formatted_string(
+            s.as_str(),
+            format,
+            5,
+            get_log_level_of_record(record),
+            Some(color),
+        )
+    }
+
+    fn build_file_path(&self, record: &Record, format: &LogFormat) -> String {
+        let file_path = match record {
+            Record::Defmt(record) => record.file(),
+            Record::Host(record) => record.file(),
+        }
+        .unwrap_or("<file>");
+
+        build_formatted_string(
+            file_path,
+            format,
+            0,
+            get_log_level_of_record(record),
+            format.color,
+        )
+    }
+
+    fn build_file_name(&self, record: &Record, format: &LogFormat) -> String {
+        let file = match record {
+            Record::Defmt(record) => record.file(),
+            Record::Host(record) => record.file(),
+        };
+
+        let s = if let Some(file) = file {
+            let file_name = Path::new(file).file_name();
+            if let Some(file_name) = file_name {
+                file_name.to_str().unwrap_or("<file>")
+            } else {
+                "<file>"
+            }
+        } else {
+            "<file>"
+        };
+
+        build_formatted_string(s, format, 0, get_log_level_of_record(record), format.color)
+    }
+
+    fn build_module_path(&self, record: &Record, format: &LogFormat) -> String {
+        let s = match record {
+            Record::Defmt(record) => record.module_path(),
+            Record::Host(record) => record.module_path(),
+        }
+        .unwrap_or("<mod path>");
+
+        build_formatted_string(s, format, 0, get_log_level_of_record(record), format.color)
+    }
+
+    fn build_line_number(&self, record: &Record, format: &LogFormat) -> String {
+        let s = match record {
+            Record::Defmt(record) => record.line(),
+            Record::Host(record) => record.line(),
+        }
+        .unwrap_or(0)
+        .to_string();
+
+        build_formatted_string(
+            s.as_str(),
+            format,
+            4,
+            get_log_level_of_record(record),
+            format.color,
+        )
+    }
+
+    fn build_log(&self, record: &Record, format: &LogFormat) -> String {
+        let log_level = get_log_level_of_record(record);
+        match record {
+            Record::Defmt(record) => match color_diff(record.args().to_string()) {
+                Ok(s) => s.to_string(),
+                Err(s) => build_formatted_string(s.as_str(), format, 0, log_level, format.color),
+            },
+            Record::Host(record) => record.args().to_string(),
+        }
+    }
+}
+
+fn get_log_level_of_record(record: &Record) -> Option<Level> {
+    match record {
+        Record::Defmt(record) => record.level(),
+        Record::Host(record) => Some(record.level()),
+    }
+}
+
+// color the output of `defmt::assert_eq`
+// HACK we should not re-parse formatted output but instead directly format into a color diff
+// template; that may require specially tagging log messages that come from `defmt::assert_eq`
+fn color_diff(text: String) -> Result<String, String> {
+    let lines = text.lines().collect::<Vec<_>>();
+    let nlines = lines.len();
+    if nlines > 2 {
+        let left = lines[nlines - 2];
+        let right = lines[nlines - 1];
+
+        const LEFT_START: &str = " left: `";
+        const RIGHT_START: &str = "right: `";
+        const END: &str = "`";
+        if left.starts_with(LEFT_START)
+            && left.ends_with(END)
+            && right.starts_with(RIGHT_START)
+            && right.ends_with(END)
+        {
+            // `defmt::assert_eq!` output
+            let left = &left[LEFT_START.len()..left.len() - END.len()];
+            let right = &right[RIGHT_START.len()..right.len() - END.len()];
+
+            let mut buf = lines[..nlines - 2].join("\n").bold().to_string();
+            buf.push('\n');
+
+            let diffs = dissimilar::diff(left, right);
+
+            writeln!(
+                buf,
+                "{} {} / {}",
+                "diff".bold(),
+                "< left".red(),
+                "right >".green()
+            )
+            .ok();
+            write!(buf, "{}", "<".red()).ok();
+            for diff in &diffs {
+                match diff {
+                    Chunk::Equal(s) => {
+                        write!(buf, "{}", s.red()).ok();
+                    }
+                    Chunk::Insert(_) => continue,
+                    Chunk::Delete(s) => {
+                        write!(buf, "{}", s.red().bold()).ok();
+                    }
+                }
+            }
+            buf.push('\n');
+
+            write!(buf, "{}", ">".green()).ok();
+            for diff in &diffs {
+                match diff {
+                    Chunk::Equal(s) => {
+                        write!(buf, "{}", s.green()).ok();
+                    }
+                    Chunk::Delete(_) => continue,
+                    Chunk::Insert(s) => {
+                        write!(buf, "{}", s.green().bold()).ok();
+                    }
+                }
+            }
+            return Ok(buf);
+        }
+    }
+
+    Err(text)
+}
+
+fn color_for_log_level(level: Level) -> Color {
+    match level {
+        Level::Error => Color::Red,
+        Level::Warn => Color::Yellow,
+        Level::Info => Color::Green,
+        Level::Debug => Color::BrightWhite,
+        Level::Trace => Color::BrightBlack,
+    }
+}
+
+fn apply_color(
+    s: ColoredString,
+    log_color: Option<LogColor>,
+    level: Option<Level>,
+) -> ColoredString {
+    match log_color {
+        Some(color) => match color {
+            LogColor::Color(c) => s.color(c),
+            LogColor::SeverityLevel => match level {
+                Some(level) => s.color(color_for_log_level(level)),
+                None => s,
+            },
+            LogColor::WarnError => match level {
+                Some(level @ (Level::Warn | Level::Error)) => s.color(color_for_log_level(level)),
+                _ => s,
+            },
+        },
+        None => s,
+    }
+}
+
+fn apply_styles(s: ColoredString, log_style: Option<&Vec<Styles>>) -> ColoredString {
+    let Some(log_styles) = log_style else {
+        return s;
+    };
+
+    let mut stylized_string = s;
+    for style in log_styles {
+        stylized_string = match style {
+            Styles::Bold => stylized_string.bold(),
+            Styles::Italic => stylized_string.italic(),
+            Styles::Underline => stylized_string.underline(),
+            Styles::Strikethrough => stylized_string.strikethrough(),
+            Styles::Dimmed => stylized_string.dimmed(),
+            Styles::Clear => stylized_string.clear(),
+            Styles::Reversed => stylized_string.reversed(),
+            Styles::Blink => stylized_string.blink(),
+            Styles::Hidden => stylized_string.hidden(),
+        };
+    }
+
+    stylized_string
+}
+
+fn build_formatted_string(
+    s: &str,
+    format: &LogFormat,
+    default_width: usize,
+    level: Option<Level>,
+    log_color: Option<LogColor>,
+) -> String {
+    let s = ColoredString::from(s);
+    let s = apply_color(s, log_color, level);
+    let colored_str = apply_styles(s, format.style.as_ref());
+
+    let alignment = format.alignment.unwrap_or(Alignment::Left);
+    let width = format.width.unwrap_or(default_width);
+
+    let mut result = String::new();
+    match alignment {
+        Alignment::Left => write!(&mut result, "{colored_str:<0$}", width),
+        Alignment::Center => write!(&mut result, "{colored_str:^0$}", width),
+        Alignment::Right => write!(&mut result, "{colored_str:>0$}", width),
+    }
+    .expect("Failed to format string: \"{colored_str}\"");
+    result
+}
+
+fn format_has_timestamp(segments: &[LogSegment]) -> bool {
+    for segment in segments {
+        match &segment.metadata {
+            LogMetadata::Timestamp => return true,
+            LogMetadata::NestedLogSegments(s) => {
+                if format_has_timestamp(s) {
+                    return true;
+                }
+            }
+            _ => continue,
+        }
+    }
+    false
+}

--- a/decoder/src/log/format/parser.rs
+++ b/decoder/src/log/format/parser.rs
@@ -116,6 +116,8 @@
 //! [format specifiers]: LogMetadata
 //! [format parameters]: LogFormat
 
+use super::{Alignment, LogColor, LogFormat, LogMetadata, LogSegment};
+
 use nom::{
     branch::alt,
     bytes::complete::{take_till1, take_while},
@@ -128,120 +130,6 @@ use nom::{
 
 use std::str::FromStr;
 
-/// Representation of what a [LogSegment] can be.
-#[derive(Debug, PartialEq, Clone)]
-#[non_exhaustive]
-pub(super) enum LogMetadata {
-    /// `{f}` format specifier.
-    ///
-    /// For a file "src/foo/bar.rs", this option prints "bar.rs".
-    FileName,
-
-    /// `{F}` format specifier.
-    ///
-    /// For a file "src/foo/bar.rs", this option prints "src/foo/bar.rs".
-    FilePath,
-
-    /// `{l}` format specifier.
-    ///
-    /// Prints the line number where the log is coming from.
-    LineNumber,
-
-    /// `{s}` format specifier.
-    ///
-    /// Prints the actual log contents.
-    /// For `defmt::info!("hello")`, this prints "hello".
-    Log,
-
-    /// `{L}` format specifier.
-    ///
-    /// Prints the log level.
-    /// For `defmt::info!("hello")`, this prints "INFO".
-    LogLevel,
-
-    /// `{m}` format specifier.
-    ///
-    /// Prints the module path of the function where the log is coming from.
-    /// For the following log:
-    ///
-    /// ```ignore
-    /// // crate: my_crate
-    /// mod foo {
-    ///     fn bar() {
-    ///         defmt::info!("hello");
-    ///     }
-    /// }
-    /// ```
-    /// this prints "my_crate::foo::bar".
-    ModulePath,
-
-    /// Represents the parts of the formatting string that is not specifiers.
-    String(String),
-
-    /// `{t}` format specifier.
-    ///
-    /// Prints the timestamp at which something was logged.
-    /// For a log printed with a timestamp 123456 ms, this prints "123456".
-    Timestamp,
-
-    /// Represents formats specified within nested curly brackets in the formatting string.
-    NestedLogSegments(Vec<LogSegment>),
-}
-
-impl LogMetadata {
-    /// Checks whether this `LogMetadata` came from a specifier such as
-    /// {t}, {f}, etc.
-    fn is_metadata_specifier(&self) -> bool {
-        !matches!(
-            self,
-            LogMetadata::String(_) | LogMetadata::NestedLogSegments(_)
-        )
-    }
-}
-
-/// Coloring options for [LogSegment]s.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub(super) enum LogColor {
-    /// User-defined color.
-    ///
-    /// Use a string that can be parsed by the FromStr implementation
-    /// of [colored::Color].
-    Color(colored::Color),
-
-    /// Color matching the default color for the log level.
-    /// Use `"severity"` as a format parameter to use this option.
-    SeverityLevel,
-
-    /// Color matching the default color for the log level,
-    /// but only if the log level is WARN or ERROR.
-    ///
-    /// Use `"werror"` as a format parameter to use this option.
-    WarnError,
-}
-
-/// Alignment options for [LogSegment]s.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub(super) enum Alignment {
-    Center,
-    Left,
-    Right,
-}
-
-/// Representation of a segment of the formatting string.
-#[derive(Debug, PartialEq, Clone)]
-pub(super) struct LogSegment {
-    pub(super) metadata: LogMetadata,
-    pub(super) format: LogFormat,
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub(super) struct LogFormat {
-    pub(super) width: Option<usize>,
-    pub(super) color: Option<LogColor>,
-    pub(super) style: Option<Vec<colored::Styles>>,
-    pub(super) alignment: Option<Alignment>,
-}
-
 #[derive(Debug, PartialEq, Clone)]
 enum IntermediateOutput {
     Metadata(LogMetadata),
@@ -249,46 +137,6 @@ enum IntermediateOutput {
     Color(LogColor),
     Style(colored::Styles),
     NestedLogSegment(LogSegment),
-}
-
-impl LogSegment {
-    pub(super) const fn new(metadata: LogMetadata) -> Self {
-        Self {
-            metadata,
-            format: LogFormat {
-                color: None,
-                style: None,
-                width: None,
-                alignment: None,
-            },
-        }
-    }
-
-    #[cfg(test)]
-    const fn with_color(mut self, color: LogColor) -> Self {
-        self.format.color = Some(color);
-        self
-    }
-
-    #[cfg(test)]
-    fn with_style(mut self, style: colored::Styles) -> Self {
-        let mut styles = self.format.style.unwrap_or_default();
-        styles.push(style);
-        self.format.style = Some(styles);
-        self
-    }
-
-    #[cfg(test)]
-    const fn with_width(mut self, width: usize) -> Self {
-        self.format.width = Some(width);
-        self
-    }
-
-    #[cfg(test)]
-    const fn with_alignment(mut self, alignment: Alignment) -> Self {
-        self.format.alignment = Some(alignment);
-        self
-    }
 }
 
 /// This function is taken as-is from the parse-hyperlinks crate

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -4,7 +4,7 @@ use time::OffsetDateTime;
 
 use std::io::{self, Write};
 
-use super::{DefmtLoggerInfo, DefmtRecord, StdoutLogger};
+use super::{DefmtLoggerConfig, DefmtLoggerInfo, DefmtRecord, StdoutLogger};
 
 pub(crate) struct JsonLogger {
     should_log: Box<dyn Fn(&Metadata) -> bool + Sync + Send>,
@@ -42,13 +42,12 @@ impl Log for JsonLogger {
 
 impl JsonLogger {
     pub fn new(
-        log_format: Option<&str>,
-        host_log_format: Option<&str>,
+        config: DefmtLoggerConfig,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Box<Self> {
         Box::new(Self {
             should_log: Box::new(should_log),
-            host_logger: StdoutLogger::new_unboxed(log_format, host_log_format, |_| true),
+            host_logger: StdoutLogger::new_unboxed(config, |_| true),
         })
     }
 

--- a/decoder/src/log/json_logger.rs
+++ b/decoder/src/log/json_logger.rs
@@ -5,7 +5,7 @@ use time::OffsetDateTime;
 use std::io::{self, Write};
 
 use super::{
-    format::{DefmtFormatter, HostFormatter},
+    format::{Formatter, HostFormatter},
     DefmtRecord, StdoutLogger,
 };
 
@@ -45,7 +45,7 @@ impl Log for JsonLogger {
 
 impl JsonLogger {
     pub fn new(
-        formatter: DefmtFormatter,
+        formatter: Formatter,
         host_formatter: HostFormatter,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Box<Self> {

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -16,7 +16,7 @@ use log::{Level, LevelFilter, Log, Metadata, Record as LogRecord};
 use serde::{Deserialize, Serialize};
 
 use self::{
-    format::{DefmtFormatter, HostFormatter},
+    format::{Formatter, HostFormatter},
     json_logger::JsonLogger,
     stdout_logger::StdoutLogger,
 };
@@ -69,7 +69,7 @@ pub enum DefmtLoggerType {
 }
 
 pub struct DefmtLoggerConfig {
-    pub formatter: DefmtFormatter,
+    pub formatter: Formatter,
     pub host_formatter: HostFormatter,
     pub logger_type: DefmtLoggerType,
 }
@@ -125,7 +125,7 @@ impl<'a> DefmtRecord<'a> {
 /// The caller has to provide a `should_log` closure that determines whether a log record should be
 /// printed.
 pub fn init_logger(
-    formatter: DefmtFormatter,
+    formatter: Formatter,
     host_formatter: HostFormatter,
     logger_type: DefmtLoggerType,
     should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -6,19 +6,19 @@
 //! [`log`]: https://crates.io/crates/log
 //! [`defmt`]: https://crates.io/crates/defmt
 
-mod format;
+pub mod format;
 mod json_logger;
 mod stdout_logger;
 
 use std::fmt;
 
-use log::{Level, LevelFilter, Log, Metadata, Record};
+use log::{Level, LevelFilter, Log, Metadata, Record as LogRecord};
 use serde::{Deserialize, Serialize};
 
 use self::{
-    format::{LogMetadata, LogSegment},
+    format::{DefmtFormatter, HostFormatter},
     json_logger::JsonLogger,
-    stdout_logger::{Printer, StdoutLogger},
+    stdout_logger::StdoutLogger,
 };
 use crate::Frame;
 
@@ -40,7 +40,7 @@ pub fn log_defmt(
     );
 
     log::logger().log(
-        &Record::builder()
+        &LogRecord::builder()
             .args(format_args!("{}", frame.display_message()))
             // .level(level) // no need to set the level, since it is transferred via payload
             .target(&target)
@@ -58,7 +58,7 @@ pub fn is_defmt_frame(metadata: &Metadata) -> bool {
 
 /// A `log` record representing a defmt log frame.
 struct DefmtRecord<'a> {
-    log_record: &'a Record<'a>,
+    log_record: &'a LogRecord<'a>,
     payload: Payload,
 }
 
@@ -68,11 +68,9 @@ pub enum DefmtLoggerType {
     Json,
 }
 
-pub struct DefmtLoggerConfig<'a> {
-    pub log_format: Option<&'a str>,
-    pub host_log_format: Option<&'a str>,
-    pub is_timestamp_available: bool,
-    pub use_verbose_defaults: bool,
+pub struct DefmtLoggerConfig {
+    pub formatter: DefmtFormatter,
+    pub host_formatter: HostFormatter,
     pub logger_type: DefmtLoggerType,
 }
 
@@ -84,7 +82,7 @@ struct Payload {
 
 impl<'a> DefmtRecord<'a> {
     /// If `record` was produced by [`log_defmt`], returns the corresponding `DefmtRecord`.
-    pub fn new(log_record: &'a Record<'a>) -> Option<Self> {
+    pub fn new(log_record: &'a LogRecord<'a>) -> Option<Self> {
         let target = log_record.metadata().target();
         target
             .strip_prefix(DEFMT_TARGET_MARKER)
@@ -126,115 +124,21 @@ impl<'a> DefmtRecord<'a> {
 ///
 /// The caller has to provide a `should_log` closure that determines whether a log record should be
 /// printed.
-///
-/// An optional `log_format` string can be provided to format the way
-/// logs are printed. A format string could look as follows:
-/// "{t} [{L}] Location<{f}:{l}> {s}"
-///
-/// The arguments between curly braces are placeholders for log metadata.
-/// The following arguments are supported:
-/// - {f} : file name (e.g. "main.rs")
-/// - {F} : file path (e.g. "src/bin/main.rs")
-/// - {l} : line number
-/// - {L} : log level (e.g. "INFO", "DEBUG", etc)
-/// - {m} : module path (e.g. "foo::bar::some_function")
-/// - {s} : the actual log
-/// - {t} : log timestamp
-///
-/// For example, with the log format shown above, a log would look like this:
-/// "23124 [INFO] Location<main.rs:23> Hello, world!"
 pub fn init_logger(
-    config: DefmtLoggerConfig,
+    formatter: DefmtFormatter,
+    host_formatter: HostFormatter,
+    logger_type: DefmtLoggerType,
     should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
-) -> DefmtLoggerInfo {
-    let (logger, info): (Box<dyn Log>, DefmtLoggerInfo) = match config.logger_type {
-        DefmtLoggerType::Stdout => {
-            let logger = StdoutLogger::new(config, should_log);
-            let info = logger.info();
-            (logger, info)
-        }
+) {
+    let logger: Box<dyn Log> = match logger_type {
+        DefmtLoggerType::Stdout => StdoutLogger::new(formatter, host_formatter, should_log),
         DefmtLoggerType::Json => {
             JsonLogger::print_schema_version();
-            let logger = JsonLogger::new(config, should_log);
-            let info = logger.info();
-            (logger, info)
+            JsonLogger::new(formatter, host_formatter, should_log)
         }
     };
     log::set_boxed_logger(logger).unwrap();
     log::set_max_level(LevelFilter::Trace);
-    info
-}
-
-#[derive(Clone, Copy)]
-pub struct DefmtLoggerInfo {
-    has_timestamp: bool,
-}
-
-impl DefmtLoggerInfo {
-    pub fn has_timestamp(&self) -> bool {
-        self.has_timestamp
-    }
-}
-
-/// Format [`Frame`]s according to a `log_format`.
-///
-/// The `log_format` makes it possible to customize the defmt output.
-///
-/// The `log_format` is specified here: TODO
-// TODO:
-// - use two Formatter in StdoutLogger instead of the log format
-// - add fn format_to_sink
-// - specify log format
-// - clarify relationship between Formatter and Printer (https://github.com/knurling-rs/defmt/pull/781#discussion_r1343000073)
-#[derive(Debug)]
-pub struct Formatter {
-    format: Vec<LogSegment>,
-}
-
-impl Formatter {
-    pub fn new(log_format: &str) -> Self {
-        let format = format::parse(log_format)
-            .unwrap_or_else(|_| panic!("log format is invalid '{log_format}'"));
-        Self { format }
-    }
-
-    pub fn format_to_string(
-        &self,
-        frame: Frame<'_>,
-        file: Option<&str>,
-        line: Option<u32>,
-        module_path: Option<&str>,
-    ) -> String {
-        let (timestamp, level) = timestamp_and_level_from_frame(&frame);
-
-        // HACK: use match instead of let, because otherwise compilation fails
-        #[allow(clippy::match_single_binding)]
-        match format_args!("{}", frame.display_message()) {
-            args => {
-                let log_record = &Record::builder()
-                    .args(args)
-                    .module_path(module_path)
-                    .file(file)
-                    .line(line)
-                    .build();
-
-                let record = DefmtRecord {
-                    log_record,
-                    payload: Payload { level, timestamp },
-                };
-
-                match level {
-                    Some(_) => Printer::new_defmt(&record, &self.format),
-                    None => {
-                        // handle defmt::println separately
-                        const RAW_FORMAT: &[LogSegment] = &[LogSegment::new(LogMetadata::Log)];
-                        Printer::new_defmt(&record, RAW_FORMAT)
-                    }
-                }
-                .format_frame()
-            }
-        }
-    }
 }
 
 fn timestamp_and_level_from_frame(frame: &Frame<'_>) -> (String, Option<Level>) {

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -2,12 +2,12 @@ use log::{Log, Metadata, Record as LogRecord};
 use std::io::{self, StderrLock, StdoutLock, Write};
 
 use super::{
-    format::{DefmtFormatter, HostFormatter},
+    format::{Formatter, HostFormatter},
     DefmtRecord,
 };
 
 pub(crate) struct StdoutLogger {
-    formatter: DefmtFormatter,
+    formatter: Formatter,
     host_formatter: HostFormatter,
     should_log: Box<dyn Fn(&Metadata) -> bool + Sync + Send>,
 }
@@ -45,7 +45,7 @@ impl Log for StdoutLogger {
 
 impl StdoutLogger {
     pub fn new(
-        formatter: DefmtFormatter,
+        formatter: Formatter,
         host_formatter: HostFormatter,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Box<Self> {
@@ -53,7 +53,7 @@ impl StdoutLogger {
     }
 
     pub fn new_unboxed(
-        formatter: DefmtFormatter,
+        formatter: Formatter,
         host_formatter: HostFormatter,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Self {

--- a/decoder/src/log/stdout_logger.rs
+++ b/decoder/src/log/stdout_logger.rs
@@ -1,31 +1,15 @@
-use colored::{Color, ColoredString, Colorize, Styles};
-use dissimilar::Chunk;
-use log::{Level, Log, Metadata, Record as LogRecord};
-
-use std::{
-    fmt::Write as _,
-    io::{self, StderrLock, StdoutLock},
-    path::Path,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use log::{Log, Metadata, Record as LogRecord};
+use std::io::{self, StderrLock, StdoutLock, Write};
 
 use super::{
-    format::{self, Alignment, LogColor, LogFormat, LogMetadata, LogSegment},
-    DefmtLoggerConfig, DefmtLoggerInfo, DefmtRecord,
+    format::{DefmtFormatter, HostFormatter},
+    DefmtRecord,
 };
 
-enum Record<'a> {
-    Defmt(&'a DefmtRecord<'a>),
-    Host(&'a LogRecord<'a>),
-}
-
 pub(crate) struct StdoutLogger {
-    log_format: Vec<LogSegment>,
-    host_log_format: Vec<LogSegment>,
+    formatter: DefmtFormatter,
+    host_formatter: HostFormatter,
     should_log: Box<dyn Fn(&Metadata) -> bool + Sync + Send>,
-    /// Number of characters used by the timestamp.
-    /// This may increase over time and is used to align messages.
-    timing_align: AtomicUsize,
 }
 
 impl Log for StdoutLogger {
@@ -61,79 +45,28 @@ impl Log for StdoutLogger {
 
 impl StdoutLogger {
     pub fn new(
-        config: DefmtLoggerConfig,
+        formatter: DefmtFormatter,
+        host_formatter: HostFormatter,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Box<Self> {
-        Box::new(Self::new_unboxed(config, should_log))
+        Box::new(Self::new_unboxed(formatter, host_formatter, should_log))
     }
 
     pub fn new_unboxed(
-        config: DefmtLoggerConfig,
+        formatter: DefmtFormatter,
+        host_formatter: HostFormatter,
         should_log: impl Fn(&Metadata) -> bool + Sync + Send + 'static,
     ) -> Self {
-        const DEFAULT_LOG_FORMAT_WITH_TIMESTAMP: &str = "{t} {L} {s}\n└─ {m} @ {F}:{l}";
-        const DEFAULT_LOG_FORMAT_WITHOUT_TIMESTAMP: &str = "{L} {s}\n└─ {m} @ {F}:{l}";
-        const DEFAULT_HOST_LOG_FORMAT: &str = "(HOST) {L} {s}";
-        const DEFAULT_VERBOSE_HOST_LOG_FORMAT: &str = "(HOST) {L} {s}\n└─ {m} @ {F}:{l}";
-
-        let log_format = config
-            .log_format
-            .unwrap_or(if config.is_timestamp_available {
-                DEFAULT_LOG_FORMAT_WITH_TIMESTAMP
-            } else {
-                DEFAULT_LOG_FORMAT_WITHOUT_TIMESTAMP
-            });
-
-        let host_log_format = config
-            .host_log_format
-            .unwrap_or(if config.use_verbose_defaults {
-                DEFAULT_VERBOSE_HOST_LOG_FORMAT
-            } else {
-                DEFAULT_HOST_LOG_FORMAT
-            });
-
-        let log_format = format::parse(log_format).expect("log format is invalid '{log_format}'");
-
-        let host_log_format =
-            format::parse(host_log_format).expect("host log format is invalid '{host_log_format}'");
-
-        let format_has_timestamp = format_has_timestamp(&log_format);
-        if format_has_timestamp && !config.is_timestamp_available {
-            log::warn!(
-                "logger format contains timestamp but no timestamp implementation \
-                was provided; consider removing the timestamp (`{{t}}` or `{{T}}`) from the \
-                logger format or provide a `defmt::timestamp!` implementation"
-            );
-        } else if !format_has_timestamp && config.is_timestamp_available {
-            log::warn!(
-                "`defmt::timestamp!` implementation was found, but timestamp is not \
-                part of the log format; consider adding the timestamp (`{{t}}` or `{{T}}`) \
-                argument to the log format"
-            );
-        }
-
         Self {
-            log_format,
-            host_log_format,
+            formatter,
+            host_formatter,
             should_log: Box::new(should_log),
-            timing_align: AtomicUsize::new(0),
         }
-    }
-
-    pub fn info(&self) -> DefmtLoggerInfo {
-        let has_timestamp = format_has_timestamp(&self.log_format);
-        DefmtLoggerInfo { has_timestamp }
     }
 
     fn print_defmt_record(&self, record: DefmtRecord, mut sink: StdoutLock) {
-        let len = record.timestamp().len();
-        self.timing_align.fetch_max(len, Ordering::Relaxed);
-        let min_timestamp_width = self.timing_align.load(Ordering::Relaxed);
-
-        Printer::new(Record::Defmt(&record), &self.log_format)
-            .min_timestamp_width(min_timestamp_width)
-            .print_frame(&mut sink)
-            .ok();
+        let s = self.formatter.format(&record);
+        writeln!(sink, "{s}").ok();
     }
 
     pub(super) fn print_defmt_record_without_format(
@@ -141,363 +74,12 @@ impl StdoutLogger {
         record: DefmtRecord,
         mut sink: StdoutLock,
     ) {
-        const RAW_FORMAT: &[LogSegment] = &[LogSegment::new(LogMetadata::Log)];
-        Printer::new(Record::Defmt(&record), RAW_FORMAT)
-            .print_frame(&mut sink)
-            .ok();
+        let s = record.args().to_string();
+        writeln!(sink, "{s}").ok();
     }
 
     pub(super) fn print_host_record(&self, record: &LogRecord, mut sink: StderrLock) {
-        let min_timestamp_width = self.timing_align.load(Ordering::Relaxed);
-        Printer::new(Record::Host(record), &self.host_log_format)
-            .min_timestamp_width(min_timestamp_width)
-            .print_frame(&mut sink)
-            .ok();
+        let s = self.host_formatter.format(record);
+        writeln!(sink, "{s}").ok();
     }
-}
-
-fn format_has_timestamp(segments: &[LogSegment]) -> bool {
-    for segment in segments {
-        match &segment.metadata {
-            LogMetadata::Timestamp => return true,
-            LogMetadata::NestedLogSegments(s) => {
-                if format_has_timestamp(s) {
-                    return true;
-                }
-            }
-            _ => continue,
-        }
-    }
-    false
-}
-
-/// Printer for `DefmtRecord`s.
-pub(super) struct Printer<'a> {
-    record: Record<'a>,
-    format: &'a [LogSegment],
-    min_timestamp_width: usize,
-}
-
-impl<'a> Printer<'a> {
-    fn new(record: Record<'a>, format: &'a [LogSegment]) -> Self {
-        Self {
-            record,
-            format,
-            min_timestamp_width: 0,
-        }
-    }
-
-    pub fn new_defmt(record: &'a DefmtRecord<'a>, format: &'a [LogSegment]) -> Self {
-        Self::new(Record::Defmt(record), format)
-    }
-
-    /// Pads the defmt timestamp to take up at least the given number of characters.
-    /// TODO: Remove this, shouldn't be needed now that we have width field support
-    fn min_timestamp_width(&mut self, min_timestamp_width: usize) -> &mut Self {
-        self.min_timestamp_width = min_timestamp_width;
-        self
-    }
-
-    /// Prints the formatted log frame to `sink`.
-    pub fn print_frame<W: io::Write>(&self, sink: &mut W) -> io::Result<()> {
-        for segment in self.format {
-            let s = self.build_segment(segment);
-            write!(sink, "{s}")?;
-        }
-        writeln!(sink)
-    }
-
-    pub(super) fn format_frame(&self) -> String {
-        let mut buf = String::new();
-        for segment in self.format {
-            let s = self.build_segment(segment);
-            write!(buf, "{s}").expect("writing to String cannot fail");
-        }
-        buf
-    }
-
-    fn build_segment(&self, segment: &LogSegment) -> String {
-        match &segment.metadata {
-            LogMetadata::String(s) => s.to_string(),
-            LogMetadata::Timestamp => self.build_timestamp(&segment.format),
-            LogMetadata::FileName => self.build_file_name(&segment.format),
-            LogMetadata::FilePath => self.build_file_path(&segment.format),
-            LogMetadata::ModulePath => self.build_module_path(&segment.format),
-            LogMetadata::LineNumber => self.build_line_number(&segment.format),
-            LogMetadata::LogLevel => self.build_log_level(&segment.format),
-            LogMetadata::Log => self.build_log(&segment.format),
-            LogMetadata::NestedLogSegments(segments) => {
-                self.build_nested(segments, &segment.format)
-            }
-        }
-    }
-
-    fn build_nested(&self, segments: &[LogSegment], format: &LogFormat) -> String {
-        let mut result = String::new();
-        for segment in segments {
-            let s = match &segment.metadata {
-                LogMetadata::String(s) => s.to_string(),
-                LogMetadata::Timestamp => self.build_timestamp(&segment.format),
-                LogMetadata::FileName => self.build_file_name(&segment.format),
-                LogMetadata::FilePath => self.build_file_path(&segment.format),
-                LogMetadata::ModulePath => self.build_module_path(&segment.format),
-                LogMetadata::LineNumber => self.build_line_number(&segment.format),
-                LogMetadata::LogLevel => self.build_log_level(&segment.format),
-                LogMetadata::Log => self.build_log(&segment.format),
-                LogMetadata::NestedLogSegments(segments) => {
-                    self.build_nested(segments, &segment.format)
-                }
-            };
-            result.push_str(&s);
-        }
-
-        build_formatted_string(&result, format, 0, self.record_log_level(), format.color)
-    }
-
-    fn build_timestamp(&self, format: &LogFormat) -> String {
-        let s = match self.record {
-            Record::Defmt(record) if !record.timestamp().is_empty() => record.timestamp(),
-            _ => "<time>",
-        }
-        .to_string();
-
-        build_formatted_string(
-            s.as_str(),
-            format,
-            self.min_timestamp_width,
-            self.record_log_level(),
-            format.color,
-        )
-    }
-
-    fn build_log_level(&self, format: &LogFormat) -> String {
-        let s = match self.record_log_level() {
-            Some(level) => level.to_string(),
-            None => "<lvl>".to_string(),
-        };
-
-        let color = format.color.unwrap_or(LogColor::SeverityLevel);
-
-        build_formatted_string(s.as_str(), format, 5, self.record_log_level(), Some(color))
-    }
-
-    fn build_file_path(&self, format: &LogFormat) -> String {
-        let file_path = match self.record {
-            Record::Defmt(record) => record.file(),
-            Record::Host(record) => record.file(),
-        }
-        .unwrap_or("<file>");
-
-        build_formatted_string(file_path, format, 0, self.record_log_level(), format.color)
-    }
-
-    fn build_file_name(&self, format: &LogFormat) -> String {
-        let file = match self.record {
-            Record::Defmt(record) => record.file(),
-            Record::Host(record) => record.file(),
-        };
-
-        let s = if let Some(file) = file {
-            let file_name = Path::new(file).file_name();
-            if let Some(file_name) = file_name {
-                file_name.to_str().unwrap_or("<file>")
-            } else {
-                "<file>"
-            }
-        } else {
-            "<file>"
-        };
-
-        build_formatted_string(s, format, 0, self.record_log_level(), format.color)
-    }
-
-    fn build_module_path(&self, format: &LogFormat) -> String {
-        let s = match self.record {
-            Record::Defmt(record) => record.module_path(),
-            Record::Host(record) => record.module_path(),
-        }
-        .unwrap_or("<mod path>");
-
-        build_formatted_string(s, format, 0, self.record_log_level(), format.color)
-    }
-
-    fn build_line_number(&self, format: &LogFormat) -> String {
-        let s = match self.record {
-            Record::Defmt(record) => record.line(),
-            Record::Host(record) => record.line(),
-        }
-        .unwrap_or(0)
-        .to_string();
-
-        build_formatted_string(s.as_str(), format, 4, self.record_log_level(), format.color)
-    }
-
-    fn build_log(&self, format: &LogFormat) -> String {
-        match self.record {
-            Record::Defmt(record) => match color_diff(record.args().to_string()) {
-                Ok(s) => s.to_string(),
-                Err(s) => build_formatted_string(
-                    s.as_str(),
-                    format,
-                    0,
-                    self.record_log_level(),
-                    format.color,
-                ),
-            },
-            Record::Host(record) => record.args().to_string(),
-        }
-    }
-
-    fn record_log_level(&self) -> Option<Level> {
-        match self.record {
-            Record::Defmt(record) => record.level(),
-            Record::Host(record) => Some(record.level()),
-        }
-    }
-}
-
-// color the output of `defmt::assert_eq`
-// HACK we should not re-parse formatted output but instead directly format into a color diff
-// template; that may require specially tagging log messages that come from `defmt::assert_eq`
-fn color_diff(text: String) -> Result<String, String> {
-    let lines = text.lines().collect::<Vec<_>>();
-    let nlines = lines.len();
-    if nlines > 2 {
-        let left = lines[nlines - 2];
-        let right = lines[nlines - 1];
-
-        const LEFT_START: &str = " left: `";
-        const RIGHT_START: &str = "right: `";
-        const END: &str = "`";
-        if left.starts_with(LEFT_START)
-            && left.ends_with(END)
-            && right.starts_with(RIGHT_START)
-            && right.ends_with(END)
-        {
-            // `defmt::assert_eq!` output
-            let left = &left[LEFT_START.len()..left.len() - END.len()];
-            let right = &right[RIGHT_START.len()..right.len() - END.len()];
-
-            let mut buf = lines[..nlines - 2].join("\n").bold().to_string();
-            buf.push('\n');
-
-            let diffs = dissimilar::diff(left, right);
-
-            writeln!(
-                buf,
-                "{} {} / {}",
-                "diff".bold(),
-                "< left".red(),
-                "right >".green()
-            )
-            .ok();
-            write!(buf, "{}", "<".red()).ok();
-            for diff in &diffs {
-                match diff {
-                    Chunk::Equal(s) => {
-                        write!(buf, "{}", s.red()).ok();
-                    }
-                    Chunk::Insert(_) => continue,
-                    Chunk::Delete(s) => {
-                        write!(buf, "{}", s.red().bold()).ok();
-                    }
-                }
-            }
-            buf.push('\n');
-
-            write!(buf, "{}", ">".green()).ok();
-            for diff in &diffs {
-                match diff {
-                    Chunk::Equal(s) => {
-                        write!(buf, "{}", s.green()).ok();
-                    }
-                    Chunk::Delete(_) => continue,
-                    Chunk::Insert(s) => {
-                        write!(buf, "{}", s.green().bold()).ok();
-                    }
-                }
-            }
-            return Ok(buf);
-        }
-    }
-
-    Err(text)
-}
-
-fn color_for_log_level(level: Level) -> Color {
-    match level {
-        Level::Error => Color::Red,
-        Level::Warn => Color::Yellow,
-        Level::Info => Color::Green,
-        Level::Debug => Color::BrightWhite,
-        Level::Trace => Color::BrightBlack,
-    }
-}
-
-fn apply_color(
-    s: ColoredString,
-    log_color: Option<LogColor>,
-    level: Option<Level>,
-) -> ColoredString {
-    match log_color {
-        Some(color) => match color {
-            LogColor::Color(c) => s.color(c),
-            LogColor::SeverityLevel => match level {
-                Some(level) => s.color(color_for_log_level(level)),
-                None => s,
-            },
-            LogColor::WarnError => match level {
-                Some(level @ (Level::Warn | Level::Error)) => s.color(color_for_log_level(level)),
-                _ => s,
-            },
-        },
-        None => s,
-    }
-}
-
-fn apply_styles(s: ColoredString, log_style: Option<&Vec<Styles>>) -> ColoredString {
-    let Some(log_styles) = log_style else {
-        return s;
-    };
-
-    let mut stylized_string = s;
-    for style in log_styles {
-        stylized_string = match style {
-            Styles::Bold => stylized_string.bold(),
-            Styles::Italic => stylized_string.italic(),
-            Styles::Underline => stylized_string.underline(),
-            Styles::Strikethrough => stylized_string.strikethrough(),
-            Styles::Dimmed => stylized_string.dimmed(),
-            Styles::Clear => stylized_string.clear(),
-            Styles::Reversed => stylized_string.reversed(),
-            Styles::Blink => stylized_string.blink(),
-            Styles::Hidden => stylized_string.hidden(),
-        };
-    }
-
-    stylized_string
-}
-
-fn build_formatted_string(
-    s: &str,
-    format: &LogFormat,
-    default_width: usize,
-    level: Option<Level>,
-    log_color: Option<LogColor>,
-) -> String {
-    let s = ColoredString::from(s);
-    let s = apply_color(s, log_color, level);
-    let colored_str = apply_styles(s, format.style.as_ref());
-
-    let alignment = format.alignment.unwrap_or(Alignment::Left);
-    let width = format.width.unwrap_or(default_width);
-
-    let mut result = String::new();
-    match alignment {
-        Alignment::Left => write!(&mut result, "{colored_str:<0$}", width),
-        Alignment::Center => write!(&mut result, "{colored_str:^0$}", width),
-        Alignment::Right => write!(&mut result, "{colored_str:>0$}", width),
-    }
-    .expect("Failed to format string: \"{colored_str}\"");
-    result
 }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use defmt_decoder::{
     log::{
-        format::{DefmtFormatter, FormatterConfig, FormatterFormat, HostFormatter},
+        format::{Formatter, FormatterConfig, FormatterFormat, HostFormatter},
         DefmtLoggerType,
     },
     DecodeError, Frame, Locations, Table, DEFMT_VERSIONS,
@@ -155,7 +155,7 @@ fn main() -> anyhow::Result<()> {
         is_timestamp_available: table.has_timestamp(),
     };
 
-    let formatter = DefmtFormatter::new(defmt_config);
+    let formatter = Formatter::new(defmt_config);
     let host_formatter = HostFormatter::new(host_config);
 
     defmt_decoder::log::init_logger(formatter, host_formatter, logger_type, move |metadata| {


### PR DESCRIPTION
Besides refactoring the log formatting code, this PR introduces a few new features:

#### `{c}` metadata specifier
Now it's possible to add `{c}` to the log format in order to print the crate name. I'm currently parsing this out of the module path, there may be better ways to do this.

#### More detailed `{f}` metadata specifiers
I found the `{f}` specifier to be not very useful in most cases, mainly because a lot of files are called `mod.rs`. Now it's possible to increase how detailed to print the path to the file by adding `{ff}`, `{fff}`, etc... to the log format. With `{ff}` the Formatter would print `format/mod.rs` instead of just `mod.rs`, which I think is much more useful.

#### Zero-padding support
I added the zero-padding functionality from #780 to this PR. Now it's possible to zero-pad metadata specifiers, such as the timestamp or the line number.


