### PR TITLE
Prepare `defmt-decoder v0.3.9` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## defmt-decoder v0.3.9, defmt-print v0.3.10 - 2023-10-04
 
+- [#784]: `defmt-decoder`: Prepare `defmt-decoder v0.3.9` release
 - [#781]: `defmt-decoder`: Add `pub struct Formatter` to `defmt_decoder::log`
 - [#778]: `defmt-decoder`: Add support for nested log formatting
 - [#777]: `defmt-decoder`: Simplify StdoutLogger
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#771]: `defmt-macros`: Ignore empty items in DEFMT_LOG
 - [#769]: `defmt-decoder`: Add support for color, style, width and alignment to format
 
+[#784]: https://github.com/knurling-rs/defmt/pull/784
 [#781]: https://github.com/knurling-rs/defmt/pull/781
 [#778]: https://github.com/knurling-rs/defmt/pull/778
 [#777]: https://github.com/knurling-rs/defmt/pull/777

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## defmt-decoder v0.3.9, defmt-print v0.3.10 - 2023-10-04
+
 - [#781]: `defmt-decoder`: Add `pub struct Formatter` to `defmt_decoder::log`
 - [#778]: `defmt-decoder`: Add support for nested log formatting
 - [#777]: `defmt-decoder`: Simplify StdoutLogger

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.8"
+version = "0.3.9"
 
 [dependencies]
 byteorder = "1"
@@ -31,11 +31,11 @@ defmt-json-schema = { version = "0.1", path = "./defmt-json-schema" }
 
 # elf2table
 anyhow = "1.0.65"
-gimli = { version = "0.27", default-features = false, features = [
+gimli = { version = "0.28", default-features = false, features = [
     "read",
     "std",
 ] }
-object = { version = "0.31", default-features = false, features = [
+object = { version = "0.32", default-features = false, features = [
     "read_core",
     "elf",
     "std",

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,14 +8,14 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.9"
+version = "0.3.10"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=0.3.8", path = "../decoder", features = [
+defmt-decoder = { version = "=0.3.9", path = "../decoder", features = [
     "unstable",
 ] }
 log = "0.4"

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,6 +8,6 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { version = "=0.3.8", path = "../decoder", features = [
+defmt-decoder = { version = "=0.3.9", path = "../decoder", features = [
     "unstable",
 ] }


### PR DESCRIPTION
Release
- `defmt-decoder v0.3.9`
- `defmt-print v0.3.10` (no changes just uses new decoder version)