### PR TITLE
`defmt-test`: Exit with semihosting exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#786]: `defmt-test`: Exit with semihosting exit
+
+[#786]: https://github.com/knurling-rs/defmt/pull/786
+
 ## defmt-decoder v0.3.9, defmt-print v0.3.10 - 2023-10-04
 
 - [#784]: `defmt-decoder`: Prepare `defmt-decoder v0.3.9` release

--- a/decoder/src/log/format.rs
+++ b/decoder/src/log/format.rs
@@ -306,7 +306,7 @@ pub fn take_until_unbalanced(
             index += n;
             let mut it = i[index..].chars();
             match it.next().unwrap_or_default() {
-                c if c == '\\' => {
+                '\\' => {
                     // Skip the escape char `\`.
                     index += '\\'.len_utf8();
                     // Skip also the following char.

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.3.0"
 
 [dependencies]
-cortex-m = "0.7"
 cortex-m-rt = "0.7"
+cortex-m-semihosting = "0.5"
 defmt = { version = "0.3", path = "../../defmt" }
 defmt-test-macros = { version = "=0.3.0", path = "macros" }

--- a/firmware/defmt-test/src/export.rs
+++ b/firmware/defmt-test/src/export.rs
@@ -1,11 +1,14 @@
 use cortex_m_rt as _;
+use cortex_m_semihosting::debug;
 pub use defmt::info;
 
 use crate::TestOutcome;
 
+/// Terminates the application and makes a semihosting-capable debug tool exit
+/// with status code 0.
 pub fn exit() -> ! {
     loop {
-        cortex_m::asm::bkpt()
+        debug::exit(debug::EXIT_SUCCESS);
     }
 }
 

--- a/macros/src/function_like/log.rs
+++ b/macros/src/function_like/log.rs
@@ -27,8 +27,8 @@ pub(crate) fn expand_parsed(level: Level, args: Args) -> TokenStream2 {
 
     let formatting_exprs = args
         .formatting_args
-        .map(|punctuated| punctuated.into_iter().collect())
-        .unwrap_or_else(Vec::new);
+        .map(|punctuated| punctuated.into_iter().collect::<Vec<_>>())
+        .unwrap_or_default();
 
     let Codegen { patterns, exprs } = Codegen::new(
         &fragments,

--- a/macros/src/function_like/println.rs
+++ b/macros/src/function_like/println.rs
@@ -25,8 +25,8 @@ pub(crate) fn expand_parsed(args: Args) -> TokenStream2 {
 
     let formatting_exprs = args
         .formatting_args
-        .map(|punctuated| punctuated.into_iter().collect())
-        .unwrap_or_else(Vec::new);
+        .map(|punctuated| punctuated.into_iter().collect::<Vec<_>>())
+        .unwrap_or_default();
 
     let Codegen { patterns, exprs } = Codegen::new(
         &fragments,


### PR DESCRIPTION
This PR makes `probe-rs` detect exit as successfully. Basically the same as https://github.com/knurling-rs/app-template/pull/71.