### PR TITLE
Disable nightly tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - nightly # some tests use unstable features
+          # - nightly # some tests use unstable features
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#xxx]: `CI`: Disable nightly qemu-snapshot tests
 - [#789]: `defmt`: Add support for new time-related display hints
 - [#783]: `defmt-decoder`: Move formatting logic to `Formatter`
 
+[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
 [#789]: https://github.com/knurling-rs/defmt/pull/789
 [#783]: https://github.com/knurling-rs/defmt/pull/783
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [#xxx]: `CI`: Disable nightly qemu-snapshot tests
+- [#803]: `CI`: Disable nightly qemu-snapshot tests
 - [#789]: `defmt`: Add support for new time-related display hints
 - [#783]: `defmt-decoder`: Move formatting logic to `Formatter`
 
-[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
+[#803]: https://github.com/knurling-rs/defmt/pull/803
 [#789]: https://github.com/knurling-rs/defmt/pull/789
 [#783]: https://github.com/knurling-rs/defmt/pull/783
 


### PR DESCRIPTION
Since `rustc 1.77.0-nightly` the qemu-snapshot tests fail because the `ip_in_core` feature got stabilized.

```
error: the feature `ip_in_core` has been stable since 1.77.0-nightly and no longer requires an attribute to enable
  --> /home/runner/work/defmt/defmt/defmt/src/lib.rs:17:45
⏳ uninstalling targets
   |
17 | #![cfg_attr(feature = "ip_in_core", feature(ip_in_core))]
   |                                             ^^^^^^^^^^
   |
   = note: `-D stable-features` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(stable_features)]`

error: could not compile `defmt` (lib) due to 1 previous error
```

The proper solution is to remove the feature at our end (or make it a no-op for backcompat reasons). But at the moment the stable tests (rustc 1.75) require the feature attribute, but the nightly tests do not. Therefore we are disabling the nightly tests until rustc 1.77 is stable and are going to remove the feature attribute then and re-enable the nightly tests.