### PR TITLE
Deprecate ip_in_core feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          # - nightly # some tests use unstable features
+          - nightly # some tests use unstable features
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#813]: doc: add note for the alloc feature flag
 - [#812]: `defmt`: Add a feature to stop linking a default panic handler
 - [#811]: `book`: Add some examples for byte slice/array hints as well
+- [#805]: `defmt`: Drop ip_in_core feature and re-enable nightly snapshot tests
 - [#800]: `defmt-macros`: Fix generic trait bounds in Format derive macro
 
 [#831]: https://github.com/knurling-rs/defmt/pull/831
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#813]: https://github.com/knurling-rs/defmt/pull/813
 [#812]: https://github.com/knurling-rs/defmt/pull/812
 [#811]: https://github.com/knurling-rs/defmt/pull/811
+[#805]: https://github.com/knurling-rs/defmt/pull/805
 [#800]: https://github.com/knurling-rs/defmt/pull/800
 
 ## [v0.3.6] - 2024-02-05

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.3.6"
 [features]
 alloc = []
 avoid-default-panic = []
+ip_in_core = [] # no-op feature, should be removed at next breaking release
 
 # Encoding feature flags. These should only be set by end-user crates, not by library crates.
 #

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.3.6"
 
 [features]
 alloc = []
-ip_in_core = []
 avoid-default-panic = []
 
 # Encoding feature flags. These should only be set by end-user crates, not by library crates.

--- a/defmt/build.rs
+++ b/defmt/build.rs
@@ -28,6 +28,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         _ => {}
     }
+
+    // allow #[cfg(cfg_name)]
+    for cfg_name in ["c_variadic", "no_cas"] {
+        println!("cargo::rustc-check-cfg=cfg({cfg_name})");
+    }
+
     Ok(())
 }
 

--- a/defmt/src/impls/core_/mod.rs
+++ b/defmt/src/impls/core_/mod.rs
@@ -8,7 +8,6 @@
 mod alloc_;
 mod array;
 mod cell;
-#[cfg(feature = "ip_in_core")]
 mod net;
 mod num;
 mod ops;

--- a/defmt/src/lib.rs
+++ b/defmt/src/lib.rs
@@ -14,7 +14,6 @@
 // NOTE if you change this URL you'll also need to update all other crates in this repo
 #![doc(html_logo_url = "https://knurling.ferrous-systems.com/knurling_logo_light_text.svg")]
 #![warn(missing_docs)]
-#![cfg_attr(feature = "ip_in_core", feature(ip_in_core))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -22,12 +22,7 @@ linked_list_allocator = { version = "0.10.2", optional = true }
 
 [features]
 alloc = ["defmt/alloc", "alloc-cortex-m", "linked_list_allocator/const_mut_refs"]
-ip_in_core = ["defmt/ip_in_core"]
 
 [[bin]]
 name = "alloc"
 required-features = ["alloc"]
-
-[[bin]]
-name = "net"
-required-features = ["ip_in_core"]

--- a/firmware/qemu/build.rs
+++ b/firmware/qemu/build.rs
@@ -14,4 +14,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=memory.x");
+
+    // allow #[cfg(never)]
+    println!("cargo::rustc-check-cfg=cfg(never)");
 }

--- a/firmware/qemu/src/bin/net.rs
+++ b/firmware/qemu/src/bin/net.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(ip_in_core)]
 
 use core::net::{
     AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6,

--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -35,7 +35,10 @@ use anyhow::anyhow;
 use colored::Colorize as _;
 use tempfile::TempDir;
 
-use crate::{ALL_ERRORS, ALL_SNAPSHOT_TESTS, SNAPSHOT_TESTS_DIRECTORY};
+use crate::{
+    snapshot::{SNAPSHOT_TESTS_DIRECTORY, STABLE_SNAPSHOT_TESTS},
+    ALL_ERRORS,
+};
 
 const DISABLED: bool = false;
 
@@ -68,7 +71,7 @@ pub fn test() {
         }
     };
 
-    for snapshot_test in ALL_SNAPSHOT_TESTS {
+    for snapshot_test in STABLE_SNAPSHOT_TESTS {
         super::do_test(
             || qemu_run.run_snapshot(snapshot_test),
             "backcompat (see xtask/src/backcompat.rs for FIXME instructions)",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 
 use crate::{
-    snapshot::{test_snapshot, Snapshot, ALL_SNAPSHOT_TESTS, SNAPSHOT_TESTS_DIRECTORY},
+    snapshot::{test_snapshot, Snapshot},
     utils::{run_capturing_stdout, run_command},
 };
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 
 use crate::{
     snapshot::{test_snapshot, Snapshot, ALL_SNAPSHOT_TESTS, SNAPSHOT_TESTS_DIRECTORY},
-    utils::{run_capturing_stdout, run_command, rustc_is_nightly},
+    utils::{run_capturing_stdout, run_command},
 };
 
 static ALL_ERRORS: Mutex<Vec<String>> = Mutex::new(Vec::new());
@@ -152,28 +152,6 @@ fn test_cross(deny_warnings: bool) {
             },
             "cross",
         );
-
-        if rustc_is_nightly() {
-            do_test(
-                || {
-                    run_command(
-                        "cargo",
-                        &[
-                            "check",
-                            "--target",
-                            target,
-                            "-p",
-                            "defmt",
-                            "--features",
-                            "ip_in_core",
-                        ],
-                        None,
-                        &env,
-                    )
-                },
-                "cross",
-            );
-        }
     }
 
     do_test(
@@ -209,41 +187,19 @@ fn test_cross(deny_warnings: bool) {
         "cross",
     );
 
-    do_test(
-        || {
-            run_command(
-                "cargo",
-                &[
-                    "check",
-                    "--target",
-                    "thumbv6m-none-eabi",
-                    "--features",
-                    "print-defmt",
-                ],
-                Some("firmware/panic-probe"),
-                &env,
-            )
-        },
-        "cross",
-    );
-
-    do_test(
-        || {
-            run_command(
-                "cargo",
-                &[
-                    "check",
-                    "--target",
-                    "thumbv6m-none-eabi",
-                    "--features",
-                    "print-rtt",
-                ],
-                Some("firmware/panic-probe"),
-                &env,
-            )
-        },
-        "cross",
-    );
+    for feature in ["print-defmt", "print-rtt"] {
+        do_test(
+            || {
+                run_command(
+                    "cargo",
+                    &["check", "--target", "thumbv6m-none-eabi", "--features", feature],
+                    Some("firmware/panic-probe"),
+                    &env,
+                )
+            },
+            "cross",
+        );
+    }
 
     do_test(
         || {
@@ -256,13 +212,6 @@ fn test_cross(deny_warnings: bool) {
         },
         "lint",
     );
-
-    if rustc_is_nightly() {
-        do_test(
-            || run_command("cargo", &["check", "--features", "ip_in_core"], None, &env),
-            "cross",
-        );
-    }
 }
 
 fn test_book() {

--- a/xtask/src/snapshot.rs
+++ b/xtask/src/snapshot.rs
@@ -73,7 +73,6 @@ fn test_all_snapshots(overwrite: bool) {
     for test in tests {
         let features = match test {
             "alloc" => "alloc",
-            "net" => "ip_in_core",
             _ => "",
         };
 

--- a/xtask/src/snapshot.rs
+++ b/xtask/src/snapshot.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 pub const SNAPSHOT_TESTS_DIRECTORY: &str = "firmware/qemu";
-pub const ALL_SNAPSHOT_TESTS: [&str; 12] = [
+pub const STABLE_SNAPSHOT_TESTS: &[&str] = &[
     "log",
     "bitflags",
     "timestamp",
@@ -23,7 +23,9 @@ pub const ALL_SNAPSHOT_TESTS: [&str; 12] = [
     "hints",
     "hints_inner",
     "dbg",
+    "net",
 ];
+const NIGHTLY_SNAPSHOT_TESTS: &[&str] = &["alloc"];
 
 #[derive(Clone, Debug)]
 pub struct Snapshot(String);
@@ -38,12 +40,12 @@ impl FromStr for Snapshot {
     type Err = String;
 
     fn from_str(test: &str) -> Result<Self, Self::Err> {
-        if ALL_SNAPSHOT_TESTS.contains(&test) {
+        if STABLE_SNAPSHOT_TESTS.contains(&test) || NIGHTLY_SNAPSHOT_TESTS.contains(&test) {
             Ok(Self(String::from(test)))
         } else {
             Err(format!(
                 "Specified test '{}' does not exist, available tests are: {:?}",
-                test, ALL_SNAPSHOT_TESTS
+                test, STABLE_SNAPSHOT_TESTS
             ))
         }
     }
@@ -64,10 +66,10 @@ pub fn test_snapshot(overwrite: bool, snapshot: Option<Snapshot>) {
 }
 
 fn test_all_snapshots(overwrite: bool) {
-    let mut tests = ALL_SNAPSHOT_TESTS.to_vec();
+    let mut tests = STABLE_SNAPSHOT_TESTS.to_vec();
 
     if rustc_is_nightly() {
-        tests.extend(["alloc", "net"]);
+        tests.extend(NIGHTLY_SNAPSHOT_TESTS);
     }
 
     for test in tests {


### PR DESCRIPTION
This PR removed the ip_in_core feature from `defmt` and re-enables nightly shapshot tests. See #803 for details.