### PR TITLE
Adds a watch flag to watch the elf file and reloads the file if it changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#843]: `defmt`: Sort IDs of log msgs by severity to allow runtime filtering by severity
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
 - [#855]: `defmt-print`: Now uses tokio to make tcp and stdin reads async (in preparation for a `watch elf` flag)
-- [#807]: `defmt-print`: Add watch_elf flag to allow elf reload without restarting `defmt-print`
+- [#807]: `defmt-print`: Add `watch_elf` flag to allow ELF file reload without restarting `defmt-print`
 
 [#852]: https://github.com/knurling-rs/defmt/pull/852
 [#847]: https://github.com/knurling-rs/defmt/pull/847

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#843]: `defmt`: Sort IDs of log msgs by severity to allow runtime filtering by severity
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
 - [#855]: `defmt-print`: Now uses tokio to make tcp and stdin reads async (in preparation for a `watch elf` flag)
+- [#807]: `defmt-print`: Add watch_elf flag to allow elf reload without restarting `defmt-print`
 
 [#852]: https://github.com/knurling-rs/defmt/pull/852
 [#847]: https://github.com/knurling-rs/defmt/pull/847
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#843]: https://github.com/knurling-rs/defmt/pull/843
 [#822]: https://github.com/knurling-rs/defmt/pull/822
 [#855]: https://github.com/knurling-rs/defmt/pull/855
+[#807]: https://github.com/knurling-rs/defmt/pull/807
 
 ## [v0.3.8] - 2024-05-17
 

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -43,7 +43,7 @@ object = { version = "0.35", default-features = false, features = [
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 regex = "1"
-alterable_logger = "1.0.0"
+alterable_logger = "1"
 
 [features]
 # WARNING: API and wire format subject to change.

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -43,6 +43,7 @@ object = { version = "0.35", default-features = false, features = [
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 regex = "1"
+alterable_logger = "1.0.0"
 
 [features]
 # WARNING: API and wire format subject to change.

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -137,8 +137,8 @@ pub fn init_logger(
             JsonLogger::new(formatter, host_formatter, should_log)
         }
     };
-    log::set_boxed_logger(logger).unwrap();
-    log::set_max_level(LevelFilter::Trace);
+    alterable_logger::set_boxed_logger(logger);
+    alterable_logger::set_max_level(LevelFilter::Trace);
 }
 
 fn timestamp_and_level_from_frame(frame: &Frame<'_>) -> (String, Option<Level>) {

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -18,7 +18,6 @@ clap = { version = "4.0", features = ["derive", "env"] }
 defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
     "unstable",
 ] }
-futures = "0.3"
 log = "0.4"
 notify = "6.1"
 tokio = { version = "1.38", features = ["full"] }

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -20,3 +20,5 @@ defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
 ] }
 log = "0.4"
 tokio = { version = "1.38", features = ["full"] }
+notify = "6.1.1"
+futures = "0.3"

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.0", features = ["derive", "env"] }
 defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
     "unstable",
 ] }
-log = "0.4"
-tokio = { version = "1.38", features = ["full"] }
-notify = "6.1.1"
 futures = "0.3"
+log = "0.4"
+notify = "6.1"
+tokio = { version = "1.38", features = ["full"] }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -134,7 +134,7 @@ async fn has_file_changed(rx: &mut Receiver<Result<Event, notify::Error>>, path:
     true
 }
 
-async fn run_and_watch(opts: Opts, mut source: &mut Source) -> anyhow::Result<()> {
+async fn run_and_watch(opts: Opts, source: &mut Source) -> anyhow::Result<()> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
     let mut watcher = RecommendedWatcher::new(
@@ -151,7 +151,7 @@ async fn run_and_watch(opts: Opts, mut source: &mut Source) -> anyhow::Result<()
 
     loop {
         select! {
-            r = run(opts.clone(), &mut source) => r?,
+            r = run(opts.clone(), source) => r?,
             _ = has_file_changed(&mut rx, &path) => ()
         }
     }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -47,7 +47,7 @@ struct Opts {
     #[arg(short = 'V', long)]
     version: bool,
 
-    #[arg[short, long]]
+    #[arg(short, long)]
     watch_elf: bool,
 
     #[command(subcommand)]

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -165,9 +165,7 @@ async fn run(opts: Opts, source: &mut Source) -> anyhow::Result<()> {
         host_log_format,
         show_skipped_frames,
         verbose,
-        version: _,
-        watch_elf: _,
-        command: _,
+        ..
     } = opts;
 
     // read and parse elf file


### PR DESCRIPTION
This PR adds a --watch_elf/-w flag that watches the elf file for changes and reloads defmt-print on file modify or create.

To make this work I had to add tokio as dependency, since `stdin.read` otherwise blocked until some more serial data is received at which point it is too late to make the reload (if you do you end up with broken frames for the first few messages).

I also had to add `alterable_logger` to defmt-decoder to allow for the global logger to be overwritten after it was already set.

I'm open to making the flag and/or the logger changes depending on a feature.

This PR would fix issue #794

In verbose mode the logger also catches some logs from the notify crate used for the file watcher. This can probably be worked around if need be