### PR TITLE
Release defmt v0.3.6 (and others)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.6] - 2024-02-05
+
 - [#804]: `CI`: Remove mdbook strategy
 - [#803]: `CI`: Disable nightly qemu-snapshot tests
 - [#789]: `defmt`: Add support for new time-related display hints
@@ -603,7 +605,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.5...main
+[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.6...main
+[v0.3.6]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.5...defmt-v0.3.6
 [v0.3.5]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.4...defmt-v0.3.5
 [v0.3.4]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.3...defmt-v0.3.4
 [v0.3.3]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.2...defmt-v0.3.3

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.9"
+version = "0.3.10"
 
 [dependencies]
 byteorder = "1"
 colored = "2"
-defmt-parser = { version = "=0.3.3", path = "../parser", features = ["unstable"] }
+defmt-parser = { version = "=0.3.4", path = "../parser", features = ["unstable"] }
 ryu = "1"
 nom = "7"
 

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "0.3.5"
+version = "0.3.6"
 
 [features]
 alloc = []

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.6"
+version = "0.3.7"
 
 [lib]
 proc-macro = true
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { version = "=0.3.3", path = "../parser", features = ["unstable"] }
+defmt-parser = { version = "=0.3.4", path = "../parser", features = ["unstable"] }
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-parser"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.3"
+version = "0.3.4"
 
 [dependencies]
 thiserror = "1.0"

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,14 +8,14 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.10"
+version = "0.3.11"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=0.3.9", path = "../decoder", features = [
+defmt-decoder = { version = "=0.3.10", path = "../decoder", features = [
     "unstable",
 ] }
 log = "0.4"

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,6 +8,6 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { version = "=0.3.9", path = "../decoder", features = [
+defmt-decoder = { version = "=0.3.10", path = "../decoder", features = [
     "unstable",
 ] }


### PR DESCRIPTION
Release order:
- defmt-parser 0.3.4
- defmt-macros 0.3.7
- defmt 0.3.6
- defmt-decoder 0.3.10
- defmt-print 0.3.11