### PR TITLE
Add a feature to stop linking the default panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [#821]: Cleanup
 - [#813]: doc: add note for the alloc feature flag
+- [#812]: `defmt`: Add a feature to stop linking a default panic handler
 - [#811]: `book`: Add some examples for byte slice/array hints as well
 - [#800]: `defmt-macros`: Fix generic trait bounds in Format derive macro
 
 [#821]: https://github.com/knurling-rs/defmt/pull/821
 [#813]: https://github.com/knurling-rs/defmt/pull/813
+[#812]: https://github.com/knurling-rs/defmt/pull/812
 [#811]: https://github.com/knurling-rs/defmt/pull/811
 [#800]: https://github.com/knurling-rs/defmt/pull/800
 

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.3.6"
 [features]
 alloc = []
 ip_in_core = []
+avoid-default-panic = []
 
 # Encoding feature flags. These should only be set by end-user crates, not by library crates.
 #

--- a/defmt/build.rs
+++ b/defmt/build.rs
@@ -1,10 +1,21 @@
 use std::{env, error::Error, fs, path::PathBuf};
 
+fn sub(linker_script: String) -> String {
+    #[cfg(not(feature = "avoid-default-panic"))]
+    {
+        linker_script
+    }
+    #[cfg(feature = "avoid-default-panic")]
+    {
+        linker_script.replacen("PROVIDE(_defmt_panic = __defmt_default_panic);", "", 1)
+    }
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var("OUT_DIR")?);
     let linker_script = fs::read_to_string("defmt.x.in")?;
-    fs::write(out.join("defmt.x"), linker_script)?;
+    fs::write(out.join("defmt.x"), sub(linker_script))?;
     println!("cargo:rustc-link-search={}", out.display());
     let target = env::var("TARGET")?;
 


### PR DESCRIPTION
When end-user crates provide a panic handler, this symbol is not needed ... but the linker isn't smart enough to optimize it away, even though the PROVIDE line isn't used (the symbol is provided by the rust function tagged with #[panic_handler]).  Those crates can enable this feature to remove the PROVIDE line from the linker script, to stop linking this default panic handler.

See #588 for some info.