### PR TITLE
Run `cargo-semver-checks` in CI

### DIFF
--- a/.github/workflows/cargo-semver-check.yml
+++ b/.github/workflows/cargo-semver-check.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
+
+name: Check semver breakage
+
+jobs:
+  cargo-semver-check:
+    runs-on: ubuntu-latest
+
+    # Skip if PR is labelled as breaking change
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'breaking change') }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Semver check crates without "unstable" feature
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: default-features
+      - name: Semver check crates with "unstable" feature
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          exclude: defmt, defmt-json-schema
+          features: unstable
+      - name: Semver check firmware crates
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          manifest-path: firmware/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [#831]: Fix CI
 - [#828]: `defmt-decoder`: Update to `gimli 0.29`
-- [#821]: Cleanup
+- [#822]: Run `cargo semver-checks` in CI
+- [#821]: Clean up
 - [#813]: doc: add note for the alloc feature flag
 - [#812]: `defmt`: Add a feature to stop linking a default panic handler
 - [#811]: `book`: Add some examples for byte slice/array hints as well
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [#831]: https://github.com/knurling-rs/defmt/pull/831
 [#828]: https://github.com/knurling-rs/defmt/pull/828
+[#822]: https://github.com/knurling-rs/defmt/pull/822
 [#821]: https://github.com/knurling-rs/defmt/pull/821
 [#813]: https://github.com/knurling-rs/defmt/pull/813
 [#812]: https://github.com/knurling-rs/defmt/pull/812


### PR DESCRIPTION
Run `cargo-semver-checks` in CI for every pull request. This is to ensure we do not accidentally break the API of our crates (again 😅).

When a PR does break the api it should be flagged with the "breaking change" label. If that is done, the check will be skipped. The next release after merging that PR needs to update the version accordingly.

Examples of the CI catching breakages:
- https://github.com/knurling-rs/defmt/actions/runs/8423214408/job/23064303225
- https://github.com/knurling-rs/defmt/actions/runs/8423250114/job/23064426046

Example of the job being skipped:
- https://github.com/knurling-rs/defmt/actions/runs/8423156779/job/23064112383