### PR TITLE
Bumped rtt-target dependency to version 0.5

### DIFF
--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.3.1"
 [dependencies]
 cortex-m = "0.7"
 defmt = { version = "0.3", path = "../../defmt", optional = true }
-rtt-target = { version = "0.4", optional = true }
+rtt-target = { version = "0.5", optional = true }
 
 
 [features]


### PR DESCRIPTION
When panic-probe depends on rtt-target 0.4 while the binary depends on version 0.5, the panics will fail to print. Hence the bump.