### PR TITLE
Release `defmt v0.3.7`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.7] - 2024-05-13
+
 - [#831]: Fix CI
 - [#830]: `book`: Add section about feature-gated derive Format
 - [#828]: `defmt-decoder`: Update to `gimli 0.29`
@@ -624,7 +626,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.6...main
+[Unreleased]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.7...main
+[v0.3.7]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.6...defmt-v0.3.7
 [v0.3.6]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.5...defmt-v0.3.6
 [v0.3.5]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.4...defmt-v0.3.5
 [v0.3.4]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.3...defmt-v0.3.4

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -35,7 +35,7 @@ gimli = { version = "0.29", default-features = false, features = [
     "read",
     "std",
 ] }
-object = { version = "0.32", default-features = false, features = [
+object = { version = "0.35", default-features = false, features = [
     "read_core",
     "elf",
     "std",

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.10"
+version = "0.3.11"
 
 [dependencies]
 byteorder = "1"

--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -13,9 +13,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{BitflagsKey, StringEntry, Table, TableEntry, Tag, DEFMT_VERSIONS};
 use anyhow::{anyhow, bail, ensure};
 use object::{Object, ObjectSection, ObjectSymbol};
+
+use crate::{BitflagsKey, StringEntry, Table, TableEntry, Tag, DEFMT_VERSIONS};
 
 pub fn parse_impl(elf: &[u8], check_version: bool) -> Result<Option<Table>, anyhow::Error> {
     let elf = object::File::parse(elf)?;

--- a/decoder/src/elf2table/symbol.rs
+++ b/decoder/src/elf2table/symbol.rs
@@ -1,8 +1,9 @@
-use crate::Tag;
 use serde::Deserialize;
 
+use crate::Tag;
+
 #[derive(Deserialize, PartialEq, Eq, Hash)]
-pub struct Symbol {
+pub(super) struct Symbol {
     /// Name of the Cargo package in which the symbol is being instantiated. Used for avoiding
     /// symbol name collisions.
     package: String,
@@ -27,12 +28,12 @@ pub struct Symbol {
     crate_name: Option<String>,
 }
 
-pub enum SymbolTag<'a> {
+pub(super) enum SymbolTag {
     /// `defmt_*` tag that we can interpret.
     Defmt(Tag),
 
     /// Non-`defmt_*` tag for custom tooling.
-    Custom(&'a str),
+    Custom(()),
 }
 
 impl Symbol {
@@ -41,7 +42,7 @@ impl Symbol {
             .map_err(|j| anyhow::anyhow!("failed to demangle defmt symbol `{}`: {}", raw, j))
     }
 
-    pub fn tag(&self) -> SymbolTag<'_> {
+    pub fn tag(&self) -> SymbolTag {
         match &*self.tag {
             "defmt_prim" => SymbolTag::Defmt(Tag::Prim),
             "defmt_derived" => SymbolTag::Defmt(Tag::Derived),
@@ -56,7 +57,7 @@ impl Symbol {
             "defmt_info" => SymbolTag::Defmt(Tag::Info),
             "defmt_warn" => SymbolTag::Defmt(Tag::Warn),
             "defmt_error" => SymbolTag::Defmt(Tag::Error),
-            _ => SymbolTag::Custom(&self.tag),
+            _ => SymbolTag::Custom(()),
         }
     }
 

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "0.3.6"
+version = "0.3.7"
 
 [features]
 alloc = []

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 defmt = { version = "0.3", path = "../../defmt" }

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "panic-probe"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 cortex-m = "0.7"

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.3.2"
 [dependencies]
 cortex-m = "0.7"
 defmt = { version = "0.3", path = "../../defmt", optional = true }
-rtt-target = { version = "0.4", optional = true }
+rtt-target = { version = "0.5", optional = true }
 
 
 [features]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -26,4 +26,4 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 [dev-dependencies]
 maplit = "1"
 pretty_assertions = "1"
-rstest = { version = "0.17", default-features = false }
+rstest = { version = "0.19", default-features = false }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "../README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.7"
+version = "0.3.8"
 
 [lib]
 proc-macro = true

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.3.4"
 thiserror = "1.0"
 
 [dev-dependencies]
-rstest = { version = "0.17", default-features = false }
+rstest = { version = "0.19", default-features = false }
 
 [features]
 unstable = []

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.11"
+version = "0.3.12"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.3.12"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=0.3.10", path = "../decoder", features = [
+defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
     "unstable",
 ] }
 log = "0.4"

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,6 +8,6 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { version = "=0.3.10", path = "../decoder", features = [
+defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
     "unstable",
 ] }


### PR DESCRIPTION
Release
- defmt v0.3.7
- defmt-macros 0.3.8
- defmt-decoder 0.3.11
- defmt-print 0.3.12
- defmt-rtt 0.4.1
- panic-probe 0.3.2