### PR TITLE
Use the more naive crate name to support renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#835]: Fix some `defmt` crate name usage
+
 ## [v0.3.7] - 2024-05-13
 
 - [#831]: Fix CI

--- a/macros/src/derives/format/codegen/fields.rs
+++ b/macros/src/derives/format/codegen/fields.rs
@@ -50,18 +50,18 @@ pub(crate) fn codegen(
             .unwrap_or_else(|| format_ident!("arg{}", index));
         // Find the required trait bounds for the field and add the formatting statement depending on the field type and the formatting options
         let bound: Option<syn::Path> = if let Some(FormatOption::Debug2Format) = format_opt {
-            stmts.push(quote!(::defmt::export::fmt(&defmt::Debug2Format(&#ident))));
+            stmts.push(quote!(defmt::export::fmt(&defmt::Debug2Format(&#ident))));
             field_ty.map(|_| parse_quote!(::core::fmt::Debug))
         } else if let Some(FormatOption::Display2Format) = format_opt {
-            stmts.push(quote!(::defmt::export::fmt(&defmt::Display2Format(&#ident))));
+            stmts.push(quote!(defmt::export::fmt(&defmt::Display2Format(&#ident))));
             field_ty.map(|_| parse_quote!(::core::fmt::Display))
         } else if ty == consts::TYPE_FORMAT {
-            stmts.push(quote!(::defmt::export::fmt(#ident)));
-            field_ty.map(|_| parse_quote!(::defmt::Format))
+            stmts.push(quote!(defmt::export::fmt(#ident)));
+            field_ty.map(|_| parse_quote!(defmt::Format))
         } else {
             let method = format_ident!("{}", ty);
-            stmts.push(quote!(::defmt::export::#method(#ident)));
-            field_ty.map(|_| parse_quote!(::defmt::Format))
+            stmts.push(quote!(defmt::export::#method(#ident)));
+            field_ty.map(|_| parse_quote!(defmt::Format))
         };
         if let Some(bound) = bound {
             where_predicates.push(parse_quote!(#field_ty: #bound));

--- a/macros/src/items/timestamp.rs
+++ b/macros/src/items/timestamp.rs
@@ -35,7 +35,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
         const _: () = {
             #[export_name = "_defmt_timestamp"]
             #[inline(never)]
-            fn defmt_timestamp(fmt: ::defmt::Formatter<'_>) {
+            fn defmt_timestamp(fmt: defmt::Formatter<'_>) {
                 match (#(&(#formatting_exprs)),*) {
                     (#(#patterns),*) => {
                     // NOTE: No format string index, and no finalize call.


### PR DESCRIPTION
Fixes #834 

`::defmt` points to the crate called `defmt`. This is nice to use because it avoids bad renames. One example I saw was `use mini_serde as serde`.

However, people have started renaming the crate in their own crates. Notably, embedded-hal does this which renames it `defmt-03`.
With the inclusion of defmt in these kinds of foundational crates, they will want to be able to support multiple defmt versions at the same time and they kinda need the renaming. (I don't see another way to do it)

Previously before #800 this all worked, but this PR changed it from `defmt` to `::defmt` which breaks code. (And defmt released this as a minor update, so everyone who does `cargo update` will get this).

This PR simply reverts that.
Also note that `::defmt` isn't even used everywhere. It was a mix. With this PR it's all the same (as far as I can see).