### PR TITLE
Sort IDs of log msgs by severity to allow runtime filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [#847]: `decoder`: Fix log format width specifier not working as expected
 - [#845]: `decoder`: fix println!() records being printed with formatting
+- [#843]: `defmt`: Sort IDs of log msgs by severity to allow runtime filtering by severity
 
 [#847]: https://github.com/knurling-rs/defmt/pull/847
 [#845]: https://github.com/knurling-rs/defmt/pull/845
+[#843]: https://github.com/knurling-rs/defmt/pull/843
 
 ## [v0.3.8] - 2024-05-17
 

--- a/defmt/defmt.x.in
+++ b/defmt/defmt.x.in
@@ -19,6 +19,23 @@ SECTIONS
     /* Format implementations for primitives like u8 */
     *(.defmt.prim.*);
 
+    /* We order the ids of the log messages by severity and put markers in between, so that we can filter logs at runtime by severity */
+    __DEFMT_MARKER_TRACE_START = .;
+    *(.defmt.trace.*);
+    __DEFMT_MARKER_TRACE_END = .;
+    __DEFMT_MARKER_DEBUG_START = .;
+    *(.defmt.debug.*);
+    __DEFMT_MARKER_DEBUG_END = .;
+    __DEFMT_MARKER_INFO_START = .;
+    *(.defmt.info.*);
+    __DEFMT_MARKER_INFO_END = .;
+    __DEFMT_MARKER_WARN_START = .;
+    *(.defmt.warn.*);
+    __DEFMT_MARKER_WARN_END = .;
+    __DEFMT_MARKER_ERROR_START = .;
+    *(.defmt.error.*);
+    __DEFMT_MARKER_ERROR_END = .;
+
     /* Everything user-defined */
     *(.defmt.*);
 

--- a/defmt/src/lib.rs
+++ b/defmt/src/lib.rs
@@ -401,3 +401,49 @@ pub fn flush() {
         }
     }
 }
+
+#[cfg(not(feature = "unstable-test"))]
+#[doc(hidden)]
+pub struct IdRanges {
+    pub trace: core::ops::Range<u16>,
+    pub debug: core::ops::Range<u16>,
+    pub info: core::ops::Range<u16>,
+    pub warn: core::ops::Range<u16>,
+    pub error: core::ops::Range<u16>,
+}
+
+#[cfg(not(feature = "unstable-test"))]
+impl IdRanges {
+    pub fn get() -> Self {
+        extern "C" {
+            static __DEFMT_MARKER_TRACE_START: u8;
+            static __DEFMT_MARKER_TRACE_END: u8;
+            static __DEFMT_MARKER_DEBUG_START: u8;
+            static __DEFMT_MARKER_DEBUG_END: u8;
+            static __DEFMT_MARKER_INFO_START: u8;
+            static __DEFMT_MARKER_INFO_END: u8;
+            static __DEFMT_MARKER_WARN_START: u8;
+            static __DEFMT_MARKER_WARN_END: u8;
+            static __DEFMT_MARKER_ERROR_START: u8;
+            static __DEFMT_MARKER_ERROR_END: u8;
+        }
+
+        let trace_start = unsafe { &__DEFMT_MARKER_TRACE_START as *const u8 as u16 };
+        let trace_end = unsafe { &__DEFMT_MARKER_TRACE_END as *const u8 as u16 };
+        let debug_start = unsafe { &__DEFMT_MARKER_DEBUG_START as *const u8 as u16 };
+        let debug_end = unsafe { &__DEFMT_MARKER_DEBUG_END as *const u8 as u16 };
+        let info_start = unsafe { &__DEFMT_MARKER_INFO_START as *const u8 as u16 };
+        let info_end = unsafe { &__DEFMT_MARKER_INFO_END as *const u8 as u16 };
+        let warn_start = unsafe { &__DEFMT_MARKER_WARN_START as *const u8 as u16 };
+        let warn_end = unsafe { &__DEFMT_MARKER_WARN_END as *const u8 as u16 };
+        let error_start = unsafe { &__DEFMT_MARKER_ERROR_START as *const u8 as u16 };
+        let error_end = unsafe { &__DEFMT_MARKER_ERROR_END as *const u8 as u16 };
+        Self {
+            trace: trace_start..trace_end,
+            debug: debug_start..debug_end,
+            info: info_start..info_end,
+            warn: warn_start..warn_end,
+            error: error_start..error_end,
+        }
+    }
+}

--- a/macros/src/derives/format/codegen.rs
+++ b/macros/src/derives/format/codegen.rs
@@ -29,7 +29,7 @@ pub(crate) fn encode_struct_data(ident: &Ident, data: &DataStruct) -> syn::Resul
         }
     }));
 
-    let format_tag = construct::interned_string(&format_string, "derived", false);
+    let format_tag = construct::interned_string(&format_string, "derived", false, None);
     Ok(EncodeData {
         format_tag,
         stmts,

--- a/macros/src/derives/format/codegen/enum_data.rs
+++ b/macros/src/derives/format/codegen/enum_data.rs
@@ -11,7 +11,7 @@ pub(crate) fn encode(ident: &Ident, data: &DataEnum) -> syn::Result<EncodeData> 
     if data.variants.is_empty() {
         return Ok(EncodeData {
             stmts: vec![quote!(match *self {})],
-            format_tag: construct::interned_string("!", "derived", false),
+            format_tag: construct::interned_string("!", "derived", false, None),
             where_predicates: vec![],
         });
     }
@@ -49,7 +49,7 @@ pub(crate) fn encode(ident: &Ident, data: &DataEnum) -> syn::Result<EncodeData> 
         ))
     }
 
-    let format_tag = construct::interned_string(&format_string, "derived", false);
+    let format_tag = construct::interned_string(&format_string, "derived", false, None);
     let stmts = vec![quote!(match self {
         #(#match_arms)*
     })];

--- a/macros/src/function_like/intern.rs
+++ b/macros/src/function_like/intern.rs
@@ -5,5 +5,5 @@ use crate::construct;
 
 pub(crate) fn expand(args: TokenStream) -> TokenStream {
     let literal = parse_macro_input!(args as LitStr);
-    construct::interned_string(&literal.value(), "str", false).into()
+    construct::interned_string(&literal.value(), "str", false, None).into()
 }

--- a/macros/src/function_like/log.rs
+++ b/macros/src/function_like/log.rs
@@ -36,7 +36,8 @@ pub(crate) fn expand_parsed(level: Level, args: Args) -> TokenStream2 {
         args.format_string.span(),
     );
 
-    let header = construct::interned_string(&format_string, level.as_str(), true);
+    let header =
+        construct::interned_string(&format_string, level.as_str(), true, Some(level.as_str()));
     let env_filter = EnvFilter::from_env_var();
 
     if let Some(filter_check) = env_filter.path_check(level) {

--- a/macros/src/function_like/println.rs
+++ b/macros/src/function_like/println.rs
@@ -34,7 +34,7 @@ pub(crate) fn expand_parsed(args: Args) -> TokenStream2 {
         args.format_string.span(),
     );
 
-    let header = construct::interned_string(&format_string, "println", true);
+    let header = construct::interned_string(&format_string, "println", true, None);
     quote!({
         match (#(&(#formatting_exprs)),*) {
             (#(#patterns),*) => {

--- a/macros/src/function_like/write.rs
+++ b/macros/src/function_like/write.rs
@@ -34,7 +34,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
         log_args.format_string.span(),
     );
 
-    let format_tag = construct::interned_string(&format_string, "write", false);
+    let format_tag = construct::interned_string(&format_string, "write", false, None);
     quote!({
         let _typecheck_formatter: defmt::Formatter<'_> = #formatter;
         match (#(&(#formatting_exprs)),*) {

--- a/macros/src/items/bitflags.rs
+++ b/macros/src/items/bitflags.rs
@@ -23,7 +23,7 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
         construct::crate_local_disambiguator(),
         cargo::crate_name(),
     );
-    let format_tag = construct::interned_string(&format_string, "bitflags", false);
+    let format_tag = construct::interned_string(&format_string, "bitflags", false, None);
 
     let ident = input.ident();
     let ty = input.ty();

--- a/macros/src/items/timestamp.rs
+++ b/macros/src/items/timestamp.rs
@@ -29,7 +29,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
     );
 
     let var_name = format_ident!("S");
-    let var_item = construct::static_variable(&var_name, &format_string, "timestamp");
+    let var_item = construct::static_variable(&var_name, &format_string, "timestamp", None);
 
     quote!(
         const _: () = {


### PR DESCRIPTION
I want to be able to filter log messages at runtime by their log level. For this, the id's must be ordered by level and we need some markers to query the id ranges of the individual levels.

This PR implements a hacked-together version of what I need. AFAIK it is not a breaking change and `defmt-print` etc will continue to work. Would something like this be mergable?

Our usecase:
We develop an embedded iot product where we use defmt to store the logs into the flash of the device. When we have a defective device, the customer sends it back, and we can extract the logs from the flash. Now, it would be nice, to also be able to request the logs from the device over the air, but for that we need to be able to reduce the number of logs to transmit by filtering them. We can already filter the messages by timestamp today, but not by severity. In order to filter the logs by severity we need the changes implemented by this PR. I'll probably open-source the tooling we've built around this entire use-case, as soon as it is mature enough.

Related: https://github.com/knurling-rs/defmt/issues/793 -> Filtering by module

(Note: This PR is not related to embedded-test in any way)


