### PR TITLE
decoder: improve default format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - [#xxx]: `CI`: Update mdbook to v0.4.40
+- [#848]: `decoder`: improve default format
 - [#847]: `decoder`: Fix log format width specifier not working as expected
 - [#845]: `decoder`: fix println!() records being printed with formatting
 - [#843]: `defmt`: Sort IDs of log msgs by severity to allow runtime filtering by severity
 
 [#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
+[#848]: https://github.com/knurling-rs/defmt/pull/848
 [#847]: https://github.com/knurling-rs/defmt/pull/847
 [#845]: https://github.com/knurling-rs/defmt/pull/845
 [#843]: https://github.com/knurling-rs/defmt/pull/843

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#857]: Add an octal display hint (`:o`)
 - [#855]: `defmt-print`: Now uses tokio to make tcp and stdin reads async (in preparation for a `watch elf` flag)
 - [#852]: `CI`: Update mdbook to v0.4.40
-- [#848]: `decoder`: improve default format
+- [#848]: `decoder`: add optional one-line format
 - [#847]: `decoder`: Fix log format width specifier not working as expected
 - [#845]: `decoder`: fix println!() records being printed with formatting
 - [#843]: `defmt`: Sort IDs of log msgs by severity to allow runtime filtering by severity

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -1,9 +1,6 @@
 //! Decodes [`defmt`](https://github.com/knurling-rs/defmt) log frames
 //!
 //! NOTE: The decoder always runs on the host!
-//!
-//! This is an implementation detail of [`probe-run`](https://github.com/knurling-rs/probe-run) and
-//! not meant to be consumed by other tools at the moment so all the API is unstable.
 
 #![cfg(feature = "unstable")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -124,10 +121,13 @@ struct BitflagsKey {
     crate_name: Option<String>,
 }
 
+/// How a defmt frame is encoded
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Encoding {
+    /// raw data, that is no encoding.
     Raw,
+    /// [Reverse Zero-compressing COBS encoding](https://github.com/Dirbaio/rzcobs)
     Rzcobs,
 }
 
@@ -144,6 +144,7 @@ impl FromStr for Encoding {
 }
 
 impl Encoding {
+    /// Can this encoding recover from missed bytes?
     pub const fn can_recover(&self) -> bool {
         match self {
             Encoding::Raw => false,
@@ -322,11 +323,12 @@ struct FormatSliceElement<'t> {
     args: Vec<Arg<'t>>,
 }
 
+/// Ways in which decoding a defmt frame can fail.
 #[derive(Debug, Eq, PartialEq)]
 pub enum DecodeError {
     /// More data is needed to decode the next frame.
     UnexpectedEof,
-
+    /// The frame was not in the expected format.
     Malformed,
 }
 

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -316,11 +316,11 @@ impl<'a> FormatterConfig<'a> {
 
 impl InternalFormatter {
     fn new(config: FormatterConfig, source: Source) -> Self {
-        const FORMAT: &str = "{{[{L}]%bold} {s}%werror}";
-        const FORMAT_WITH_LOCATION: &str = "{{[{L}]%bold} {{c:bold}/{ff}:{l}%45} {s}%werror}";
-        const FORMAT_WITH_TIMESTAMP: &str = "{{t:>8} {[{L}]%bold} {s}%werror}";
+        const FORMAT: &str = "{[{L}]%bold} {s}";
+        const FORMAT_WITH_LOCATION: &str = "{[{L}]%bold} {s} {({c:bold}:{ff}:{l:1})%dimmed}";
+        const FORMAT_WITH_TIMESTAMP: &str = "{t} {[{L}]%bold} {s}";
         const FORMAT_WITH_TIMESTAMP_AND_LOCATION: &str =
-            "{{t:>8} {[{L}]%bold} {{c:bold}/{ff}:{l}%45} {s}%werror}";
+            "{t} {[{L}]%bold} {s} {({c:bold}:{ff}:{l:1})%dimmed}";
 
         const LEGACY_FORMAT: &str = "{L} {s}";
         const LEGACY_FORMAT_WITH_LOCATION: &str = "{L} {s}\n└─ {m} @ {F}:{l}";

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -317,7 +317,8 @@ impl InternalFormatter {
         const FORMAT: &str = "{{[{L}]%bold} {s}%werror}";
         const FORMAT_WITH_LOCATION: &str = "{{[{L}]%bold} {{c:bold}/{ff}:{l}%45} {s}%werror}";
         const FORMAT_WITH_TIMESTAMP: &str = "{{t:>8} {[{L}]%bold} {s}%werror}";
-        const FORMAT_WITH_TIMESTAMP_AND_LOCATION: &str = "{{t:>8} {[{L}]%bold} {{c:bold}/{ff}:{l}%45} {s}%werror}";
+        const FORMAT_WITH_TIMESTAMP_AND_LOCATION: &str =
+            "{{t:>8} {[{L}]%bold} {{c:bold}/{ff}:{l}%45} {s}%werror}";
 
         let format = match config.format {
             FormatterFormat::Default { with_location } => {

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -321,7 +321,7 @@ impl FormatterFormat<'static> {
 
 impl Default for FormatterFormat<'_> {
     fn default() -> Self {
-        FormatterFormat::OneLine {
+        FormatterFormat::Default {
             with_location: false,
         }
     }

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -314,10 +314,10 @@ impl<'a> FormatterConfig<'a> {
 
 impl InternalFormatter {
     fn new(config: FormatterConfig, source: Source) -> Self {
-        const FORMAT: &str = "{L} {s}";
-        const FORMAT_WITH_LOCATION: &str = "{L} {s}\n└─ {m} @ {F}:{l}";
-        const FORMAT_WITH_TIMESTAMP: &str = "{t} {L} {s}";
-        const FORMAT_WITH_TIMESTAMP_AND_LOCATION: &str = "{t} {L} {s}\n└─ {m} @ {F}:{l}";
+        const FORMAT: &str = "{{[{L}]%bold} {s}%werror}";
+        const FORMAT_WITH_LOCATION: &str = "{{[{L}]%bold} {{c:bold}/{ff}:{l}%45} {s}%werror}";
+        const FORMAT_WITH_TIMESTAMP: &str = "{{t:>8} {[{L}]%bold} {s}%werror}";
+        const FORMAT_WITH_TIMESTAMP_AND_LOCATION: &str = "{{t:>8} {[{L}]%bold} {{c:bold}/{ff}:{l}%45} {s}%werror}";
 
         let format = match config.format {
             FormatterFormat::Default { with_location } => {

--- a/decoder/src/log/format/mod.rs
+++ b/decoder/src/log/format/mod.rs
@@ -371,7 +371,7 @@ pub struct FormatterConfig<'a> {
     /// The format to use
     pub format: FormatterFormat<'a>,
     /// If `true`, then the logs should include a timestamp.
-    /// 
+    ///
     /// Not all targets can supply a timestamp, and if not, it should be
     /// omitted.
     pub is_timestamp_available: bool,
@@ -379,7 +379,7 @@ pub struct FormatterConfig<'a> {
 
 impl<'a> FormatterConfig<'a> {
     /// Create a new custom formatter config.
-    /// 
+    ///
     /// This allows the user to supply a custom log-format string. See the
     /// "Custom Log Output" section of the defmt book for details of the format.
     pub fn custom(format: &'a str) -> Self {
@@ -398,7 +398,7 @@ impl<'a> FormatterConfig<'a> {
 
     /// Modify a formatter configuration, setting the 'with_location' flag
     /// to true.
-    /// 
+    ///
     /// Do not use this with a custom log formatter.
     pub fn with_location(mut self) -> Self {
         // TODO: Should we warn the user that trying to set a location

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -1,4 +1,6 @@
-//! This module provides interoperability utilities between [`defmt`] and the [`log`] crate.
+//! Handles the conversion of defmt frames to log messages (as strings).
+//! 
+//! Also provides interoperability utilities between [`defmt`] and the [`log`] crate.
 //!
 //! If you are implementing a custom defmt decoding tool, this module can make it easier to
 //! integrate it with logs produced with the [`log`] crate.

--- a/decoder/src/log/mod.rs
+++ b/decoder/src/log/mod.rs
@@ -1,5 +1,5 @@
 //! Handles the conversion of defmt frames to log messages (as strings).
-//! 
+//!
 //! Also provides interoperability utilities between [`defmt`] and the [`log`] crate.
 //!
 //! If you are implementing a custom defmt decoding tool, this module can make it easier to


### PR DESCRIPTION
I have updated the default log format to something I consider more sensible. Whether this proposal is the best default or not is of course a very subjective matter.

The main and biggest problem with the current format is the two-line log on the "with location" variant. It introduces a lot of visual noise and it makes it pretty hard to read the logs IMO. It also introduces issues when the user wants to print a multi-line log for whatever reason. In the screenshots below I added an extra line just to emphasize an error, for example. The current version without location is not too bad actually.

The proposed format in this PR introduces the following improvements to the logging experience:
- Single line logs with decent alignment
- Replaces the full path of the log location to just the crate name and the two lowest levels of the file + line number
  - I chose to display the two lowest levels only to keep the location short
  - I feel like two levels is enough to find out where the log comes from
  - Just the filename is useless due to multiple files being called `mod.rs` in a single crate
- Show the crate name in bold for better visibility and contrast
- Color the entire log for warning and error logs for better visibility
- Got rid of the function name in the location
  - a lot of times this ends up being something not so useful due to async or closures, e.g. `my_app::____embassy_main_task::{async_fn#0}`

#### Logs with location before this PR
<img width="1009" alt="Screenshot 2024-06-02 at 0 35 57" src="https://github.com/knurling-rs/defmt/assets/8990961/fa0049a5-2264-4ab9-9fb3-89a9933eb9b1">

#### Logs with location after this PR
<img width="1098" alt="Screenshot 2024-06-02 at 0 33 24" src="https://github.com/knurling-rs/defmt/assets/8990961/6c142aef-68cd-44fd-a614-06b9ce53ce91">

#### Logs without location before this PR
<img width="685" alt="Screenshot 2024-06-02 at 0 36 48" src="https://github.com/knurling-rs/defmt/assets/8990961/bfbb7a54-38df-4713-8440-de8bf1824b72">

#### Logs without location after this PR
<img width="706" alt="Screenshot 2024-06-02 at 0 37 33" src="https://github.com/knurling-rs/defmt/assets/8990961/badc20a7-95ef-459e-97eb-0a6ff51dbe28">


I hope the proposed format is reasonable. I have no idea why nobody has made an attempt to improve the current one yet, maybe it's not as annoying to others as it is for me. This not only an issue for my own codebases, but generally the default ends up being used as reference material, on blog posts, etc, for example [this post on URLO](https://users.rust-lang.org/t/problem-getting-eth-client-rs-to-work/109187/2).

Note that the log format continues to be customizable, so if anyone wants to change anything, the option is still there.

Another idea I had was to introduce a new location option that prints just the crate name instead of crate + file name + line number:

<img width="843" alt="Screenshot 2024-06-02 at 1 40 24" src="https://github.com/knurling-rs/defmt/assets/8990961/1385754b-4414-43e3-8b3f-e13a79463b84">

I think an option like that would probably be useful for some people as well.