### PR TITLE
Make defmt-print async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#845]: `decoder`: fix println!() records being printed with formatting
 - [#843]: `defmt`: Sort IDs of log msgs by severity to allow runtime filtering by severity
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
+- [#855]: `defmt-print`: Now uses tokio to make tcp and stdin reads async (in preparation for a `watch elf` flag)
 
 [#852]: https://github.com/knurling-rs/defmt/pull/852
 [#847]: https://github.com/knurling-rs/defmt/pull/847
 [#845]: https://github.com/knurling-rs/defmt/pull/845
 [#843]: https://github.com/knurling-rs/defmt/pull/843
 [#822]: https://github.com/knurling-rs/defmt/pull/822
+[#855]: https://github.com/knurling-rs/defmt/pull/855
 
 ## [v0.3.8] - 2024-05-17
 

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -19,4 +19,4 @@ defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
     "unstable",
 ] }
 log = "0.4"
-tokio = { version = "1.38.0", features = ["net", "macros", "time", "rt", "io-util", "fs", "io-std", "sync", "rt-multi-thread"] }
+tokio = { version = "1.38", features = ["full"] }

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -19,3 +19,4 @@ defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
     "unstable",
 ] }
 log = "0.4"
+tokio = { version = "1.38.0", features = ["net", "macros", "time", "rt", "io-util", "fs", "io-std", "sync", "rt-multi-thread"] }

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
-    path::{Path, PathBuf},
     env,
+    path::{Path, PathBuf},
 };
 
 use anyhow::anyhow;

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -13,10 +13,9 @@ use defmt_decoder::{
     DecodeError, Frame, Locations, Table, DEFMT_VERSIONS,
 };
 
-use tokio::io::{self, AsyncReadExt};
 use tokio::{
-    fs::{self},
-    io::Stdin,
+    fs,
+    io::{self, AsyncReadExt, Stdin},
     net::TcpStream,
 };
 

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -1,8 +1,6 @@
 use std::{
-    env, fs,
-    io::{self, Read, StdinLock},
-    net::TcpStream,
     path::{Path, PathBuf},
+    env,
 };
 
 use anyhow::anyhow;
@@ -13,6 +11,13 @@ use defmt_decoder::{
         DefmtLoggerType,
     },
     DecodeError, Frame, Locations, Table, DEFMT_VERSIONS,
+};
+
+use tokio::io::{self, AsyncReadExt};
+use tokio::{
+    fs::{self},
+    io::Stdin,
+    net::TcpStream,
 };
 
 /// Prints defmt-encoded logs to stdout
@@ -59,36 +64,37 @@ enum Command {
 }
 
 enum Source {
-    Stdin(StdinLock<'static>),
+    Stdin(Stdin),
     Tcp(TcpStream),
 }
 
 impl Source {
     fn stdin() -> Self {
-        Source::Stdin(io::stdin().lock())
+        Source::Stdin(io::stdin())
     }
 
-    fn tcp(host: String, port: u16) -> anyhow::Result<Self> {
-        match TcpStream::connect((host, port)) {
+    async fn tcp(host: String, port: u16) -> anyhow::Result<Self> {
+        match TcpStream::connect((host, port)).await {
             Ok(stream) => Ok(Source::Tcp(stream)),
             Err(e) => Err(anyhow!(e)),
         }
     }
 
-    fn read(&mut self, buf: &mut [u8]) -> anyhow::Result<(usize, bool)> {
+    async fn read(&mut self, buf: &mut [u8]) -> anyhow::Result<(usize, bool)> {
         match self {
             Source::Stdin(stdin) => {
-                let n = stdin.read(buf)?;
+                let n = stdin.read(buf).await?;
                 Ok((n, n == 0))
             }
-            Source::Tcp(tcpstream) => Ok((tcpstream.read(buf)?, false)),
+            Source::Tcp(tcpstream) => Ok((tcpstream.read(buf).await?, false)),
         }
     }
 }
 
 const READ_BUFFER_SIZE: usize = 1024;
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let Opts {
         elf,
         json,
@@ -105,7 +111,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // read and parse elf file
-    let bytes = fs::read(elf.unwrap())?;
+    let bytes = fs::read(elf.unwrap()).await?;
     let table = Table::parse(&bytes)?.ok_or_else(|| anyhow!(".defmt data not found"))?;
     let locs = table.get_locations(&bytes)?;
 
@@ -159,12 +165,12 @@ fn main() -> anyhow::Result<()> {
 
     let mut source = match command {
         None | Some(Command::Stdin) => Source::stdin(),
-        Some(Command::Tcp { host, port }) => Source::tcp(host, port)?,
+        Some(Command::Tcp { host, port }) => Source::tcp(host, port).await?,
     };
 
     loop {
         // read from stdin or tcpstream and push it to the decoder
-        let (n, eof) = source.read(&mut buf)?;
+        let (n, eof) = source.read(&mut buf).await?;
 
         // if 0 bytes where read, we reached EOF, so quit
         if eof {


### PR DESCRIPTION
As discussed in #807 I've split out the work to make defmt-print async into a separate PR.
It changes very little, but please do test it to see if everything still works.
As for the tokio features, I've added all of the features needed instead of using `full` but afaik it wouldn't have made much of a difference as most features were needed anyway.