### PR TITLE
Add an impl Format for PanicInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#845]: `decoder`: fix println!() records being printed with formatting
 - [#843]: `defmt`: Sort IDs of log msgs by severity to allow runtime filtering by severity
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
+- [#856]: `defmt`: Add a `Format` impl for `PanicInfo` and related types.
 
 [#859]: https://github.com/knurling-rs/defmt/pull/859
 [#858]: https://github.com/knurling-rs/defmt/pull/858
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#845]: https://github.com/knurling-rs/defmt/pull/845
 [#843]: https://github.com/knurling-rs/defmt/pull/843
 [#822]: https://github.com/knurling-rs/defmt/pull/822
+[#856]: https://github.com/knurling-rs/defmt/pull/856
 
 ## [v0.3.8] - 2024-05-17
 

--- a/defmt/src/impls/core_/mod.rs
+++ b/defmt/src/impls/core_/mod.rs
@@ -12,6 +12,7 @@ mod cell;
 mod net;
 mod num;
 mod ops;
+mod panic;
 mod ptr;
 mod slice;
 

--- a/defmt/src/impls/core_/panic.rs
+++ b/defmt/src/impls/core_/panic.rs
@@ -4,14 +4,9 @@ use super::*;
 
 impl<'a> Format for panic::PanicInfo<'a> {
     fn format(&self, f: Formatter) {
-        crate::write!(f, "panicked at {}:", self.location());
+        crate::write!(f, "panicked at {}", self.location());
         // TODO: consider supporting self.message() once stabilized, or add a crate feature for
         // conditional support
-
-        #[allow(deprecated)] // Deprecated on nightly
-        if let Some(msg) = self.payload().downcast_ref::<&'static str>() {
-            crate::write!(f, "\n{=str}", msg);
-        }
     }
 }
 

--- a/defmt/src/impls/core_/panic.rs
+++ b/defmt/src/impls/core_/panic.rs
@@ -1,0 +1,28 @@
+use core::panic;
+
+use super::*;
+
+impl<'a> Format for panic::PanicInfo<'a> {
+    fn format(&self, f: Formatter) {
+        crate::write!(f, "panicked at {}:", self.location());
+        // TODO: consider supporting self.message() once stabilized, or add a crate feature for
+        // conditional support
+
+        #[allow(deprecated)] // Deprecated on nightly
+        if let Some(msg) = self.payload().downcast_ref::<&'static str>() {
+            crate::write!(f, "\n{=str}", msg);
+        }
+    }
+}
+
+impl<'a> Format for panic::Location<'a> {
+    fn format(&self, f: Formatter) {
+        crate::write!(
+            f,
+            "{=str}:{=u32}:{=u32}",
+            self.file(),
+            self.line(),
+            self.column()
+        );
+    }
+}

--- a/defmt/src/impls/core_/panic.rs
+++ b/defmt/src/impls/core_/panic.rs
@@ -4,7 +4,11 @@ use super::*;
 
 impl<'a> Format for panic::PanicInfo<'a> {
     fn format(&self, f: Formatter) {
-        crate::write!(f, "panicked at {}", self.location());
+        if let Some(location) = self.location() {
+            crate::write!(f, "panicked at {}", location);
+        } else {
+            crate::write!(f, "panicked");
+        }
         // TODO: consider supporting self.message() once stabilized, or add a crate feature for
         // conditional support
     }

--- a/firmware/qemu/src/bin/panic_info.out
+++ b/firmware/qemu/src/bin/panic_info.out
@@ -1,0 +1,1 @@
+INFO PanicInfo: panicked at qemu/src/bin/panic_info.rs:14:5

--- a/firmware/qemu/src/bin/panic_info.rs
+++ b/firmware/qemu/src/bin/panic_info.rs
@@ -1,0 +1,23 @@
+#![no_std]
+#![no_main]
+
+use core::panic;
+use cortex_m_semihosting::debug;
+
+use defmt_semihosting as _; // global logger
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    // Note: this test is a bit brittle in that the line/column number of the following panic is
+    // included in the test snapshot.  Hence, be mindful to update the snapshot if you want to
+    // add any additional code to this file above the following line!
+    panic!("aaah!")
+}
+
+#[panic_handler]
+fn panic(panic_info: &panic::PanicInfo) -> ! {
+    defmt::info!("PanicInfo: {=?}", panic_info);
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}

--- a/xtask/src/snapshot.rs
+++ b/xtask/src/snapshot.rs
@@ -26,6 +26,7 @@ pub(crate) fn all_snapshot_tests() -> Vec<&'static str> {
         "hints_inner",
         "dbg",
         "net",
+        "panic_info",
     ];
     const NIGHTLY_SNAPSHOT_TESTS: &[&str] = &["alloc"];
 


### PR DESCRIPTION
This impl is useful for panic handlers that use `defmt` to report panics, for example, `panic_probe` with the `defmt` feature.

The default `core::fmt` implementation for `PanicInfo` pulls in number formatting, padding support, `dyn Debug/Display` dependencies, etc. which can cause a lot of unnecessary code to be pulled in just to format `PanicInfo`.