### PR TITLE
Implement "passthrough" Debug and Display instances for wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#858]: `defmt`: Implement "passthrough" trait impls for *2Format wrappers
 - [#852]: `CI`: Update mdbook to v0.4.40
 - [#847]: `decoder`: Fix log format width specifier not working as expected
 - [#845]: `decoder`: fix println!() records being printed with formatting

--- a/defmt/src/impls/adapter.rs
+++ b/defmt/src/impls/adapter.rs
@@ -24,6 +24,12 @@ use crate::{export, Format, Formatter, Str};
 /// because this always uses `{:?}` to format the contained value.
 pub struct Debug2Format<'a, T: fmt::Debug + ?Sized>(pub &'a T);
 
+impl<T: fmt::Debug + ?Sized> fmt::Debug for Debug2Format<'_, T> {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        self.0.fmt(fmt)
+    }
+}
+
 impl<T: fmt::Debug + ?Sized> Format for Debug2Format<'_, T> {
     default_format!();
 
@@ -61,6 +67,12 @@ impl<T: fmt::Debug + ?Sized> Format for Debug2Format<'_, T> {
 /// Note that any provided defmt display hints will be ignored
 /// because this always uses `{}` to format the contained value.
 pub struct Display2Format<'a, T: fmt::Display + ?Sized>(pub &'a T);
+
+impl<T: fmt::Display + ?Sized> fmt::Display for Display2Format<'_, T> {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
+        self.0.fmt(fmt)
+    }
+}
 
 impl<T: fmt::Display + ?Sized> Format for Display2Format<'_, T> {
     default_format!();


### PR DESCRIPTION
Useful for if you're writing code that switches between defmt::whatever and log::whatever or core::whatever using macros