### PR TITLE
Add missing type hints in fields codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#869]: `macros`: Add missing type hints
 - [#865]: `defmt`: Replace proc-macro-error with proc-macro-error2
 - [#859]: `defmt`: Satisfy clippy
 - [#858]: `defmt`: Implement "passthrough" trait impls for *2Format wrappers
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
 - [#807]: `defmt-print`: Add `watch_elf` flag to allow ELF file reload without restarting `defmt-print`
 
+[#869]: https://github.com/knurling-rs/defmt/pull/869
 [#859]: https://github.com/knurling-rs/defmt/pull/859
 [#858]: https://github.com/knurling-rs/defmt/pull/858
 [#857]: https://github.com/knurling-rs/defmt/pull/857

--- a/macros/src/derives/format/codegen/fields.rs
+++ b/macros/src/derives/format/codegen/fields.rs
@@ -157,8 +157,8 @@ fn as_native_type(ty: &Type) -> Option<String> {
             let ty_name = ident.to_string();
 
             match &*ty_name {
-                "u8" | "u16" | "u32" | "usize" | "i8" | "i16" | "i32" | "isize" | "f32" | "f64"
-                | "bool" | "str" => Some(ty_name),
+                "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64"
+                | "i128" | "isize" | "f32" | "f64" | "bool" | "str" => Some(ty_name),
                 _ => None,
             }
         }


### PR DESCRIPTION
I noticed that having
```rust
#[derive(defmt::Format)]
struct Foo {
  u16: u16,
  u32: u32,
  u64: u64,
  u128: u128,
}
```
`cargo expand` generates:
```rust
impl defmt::Format for Foo
where
    u64: defmt::Format,
    u128: defmt::Format,
{
    fn _format_tag() -> defmt::Str {
        {
            defmt::export::make_istr({
                #[link_section = ".defmt.{\"package\":\"examples\",\"tag\":\"defmt_derived\",\"data\":\"Foo {{ u16: {=u16:?}, u32: {=u32:?}, u64: {=?:?}, u128: {=?:?} }}\",\"disambiguator\":\"6889995364419830437\",\"crate_name\":\"stm32f411x_scsi_bbb\"}"]
                #[export_name = "{\"package\":\"examples\",\"tag\":\"defmt_derived\",\"data\":\"Foo {{ u16: {=u16:?}, u32: {=u32:?}, u64: {=?:?}, u128: {=?:?} }}\",\"disambiguator\":\"6889995364419830437\",\"crate_name\":\"stm32f411x_scsi_bbb\"}"]
                static S: u8 = 0;
                &S as *const u8 as u16
            })
        }
    }
    fn _format_data(&self) {
        match self {
            Self {
                u16,
                u32,
                u64,
                u128,
            } => {
                defmt::export::u16(u16);
                defmt::export::u32(u32);
                defmt::export::fmt(u64);
                defmt::export::fmt(u128);
            }
        }
    }
}
```
the important bit here is that there're missing type hints for `u64` and `u128`. Therefore
```rust
    let foo = Foo {
        u16: 0xCAFE,
        u32: 0xCAFE,
        u64: 0xCAFE,
        u128: 0xCAFE,
    };
    defmt::info!("{:#X}", foo);
```
outputs `INFO  Foo { u16: 0xCAFE, u32: 0xCAFE, u64: 51966, u128: 51966 }`.

This PR adds those missing hints, so the output is correct:
`INFO  Foo { u16: 0xCAFE, u32: 0xCAFE, u64: 0xCAFE, u128: 0xCAFE }`