### PR TITLE
Set MSRV to 1.76

### DIFF
--- a/.github/actions/update-rust/action.yml
+++ b/.github/actions/update-rust/action.yml
@@ -12,3 +12,5 @@ runs:
       shell: bash
     - run: rustup default ${{ inputs.toolchain }}
       shell: bash
+    - run: rustup component add clippy rustfmt
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,17 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        toolchain:
+          - "stable"
+          - "1.77" # MSRV
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - name: Use the latest stable release
+      - name: Set Rust version
         uses: ./.github/actions/update-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Install C libraries for tooling on ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
@@ -34,40 +39,68 @@ jobs:
         run: cargo xtask -d test-host
 
   cross:
+    strategy:
+      matrix:
+        toolchain:
+          - "stable"
+          - "1.77" # MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use the latest stable release
+      - name: Set Rust version
         uses: ./.github/actions/update-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Install Rust targets, build defmt crates for no_std targets, build defmt dependent crates for cortex-m targets, build panic-probe with different features
         run: cargo xtask test-cross
 
   lint:
+    strategy:
+      matrix:
+        toolchain:
+          - "stable"
+          - "1.77" # MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Use the latest stable release
+      - name: Set Rust version
         uses: ./.github/actions/update-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Run rustfmt & clippy
         run: cargo xtask test-lint
 
   ui:
+    strategy:
+      matrix:
+        toolchain:
+          - "stable"
+          - "1.77" # MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use the latest stable release
+      - name: Set Rust version
         uses: ./.github/actions/update-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Install Rust stable, run all UI tests on the host
         run: cargo xtask test-ui
 
   mdbook:
+    strategy:
+      matrix:
+        toolchain:
+          - "stable"
+          - "1.77" # MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Use the latest stable release
+      - name: Set Rust version
         uses: ./.github/actions/update-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
@@ -80,6 +113,7 @@ jobs:
       matrix:
         toolchain:
           - stable
+          - "1.77" # MSRV
           - nightly # some tests use unstable features
     runs-on: ubuntu-latest
     steps:
@@ -96,13 +130,20 @@ jobs:
         run: cargo xtask test-snapshot
 
   backcompat:
+    strategy:
+      matrix:
+        toolchain:
+          - "stable"
+          - "1.77" # MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Use the latest stable release
+      - name: Set Rust version
         uses: ./.github/actions/update-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Install QEMU_TARGET
         run: rustup target add ${{ env.QEMU_TARGET }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - windows-latest
         toolchain:
           - "stable"
-          - "1.77" # MSRV
+          - "1.76" # MSRV
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
@@ -43,7 +43,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.77" # MSRV
+          - "1.76" # MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.77" # MSRV
+          - "1.76" # MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -76,7 +76,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.77" # MSRV
+          - "1.76" # MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.77" # MSRV
+          - "1.76" # MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -113,7 +113,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.77" # MSRV
+          - "1.76" # MSRV
           - nightly # some tests use unstable features
     runs-on: ubuntu-latest
     steps:
@@ -134,7 +134,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.77" # MSRV
+          - "1.76" # MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [#xxx]: Set MSRV to Rust 1.77
+- [#871]: Set MSRV to Rust 1.76
 - [#865]: `defmt`: Replace proc-macro-error with proc-macro-error2
 - [#859]: `defmt`: Satisfy clippy
 - [#858]: `defmt`: Implement "passthrough" trait impls for *2Format wrappers
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
 - [#807]: `defmt-print`: Add `watch_elf` flag to allow ELF file reload without restarting `defmt-print`
 
-[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
+[#871]: https://github.com/knurling-rs/defmt/pull/871
 [#859]: https://github.com/knurling-rs/defmt/pull/859
 [#858]: https://github.com/knurling-rs/defmt/pull/858
 [#857]: https://github.com/knurling-rs/defmt/pull/857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#xxx]: Set MSRV to Rust 1.77
 - [#865]: `defmt`: Replace proc-macro-error with proc-macro-error2
 - [#859]: `defmt`: Satisfy clippy
 - [#858]: `defmt`: Implement "passthrough" trait impls for *2Format wrappers
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
 - [#807]: `defmt-print`: Add `watch_elf` flag to allow ELF file reload without restarting `defmt-print`
 
+[#xxx]: https://github.com/knurling-rs/defmt/pull/xxx
 [#859]: https://github.com/knurling-rs/defmt/pull/859
 [#858]: https://github.com/knurling-rs/defmt/pull/858
 [#857]: https://github.com/knurling-rs/defmt/pull/857

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To include `defmt` in your existing project, follow our [Application Setup guide
 
 ## MSRV
 
-The minimum supported Rust version is 1.76, which is Ferrocene 24.05.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## defmt ecosystem
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ To include `defmt` in your existing project, follow our [Application Setup guide
 [Application Setup guide]: https://defmt.ferrous-systems.com/setup.html
 
 ## MSRV
-`defmt` always compiles on the [latest `stable` rust release](https://github.com/rust-lang/rust/releases/latest). This is enforced by our CI building and testing against this version.
 
-It still might work on older rust versions, but this isn't ensured.
+The minum supported Rust version is 1.77.
 
 ## defmt ecosystem
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To include `defmt` in your existing project, follow our [Application Setup guide
 
 ## MSRV
 
-The minum supported Rust version is 1.77.
+The minimum supported Rust version is 1.76, which is Ferrocene 24.05.
 
 ## defmt ecosystem
 

--- a/firmware/defmt-semihosting/src/lib.rs
+++ b/firmware/defmt-semihosting/src/lib.rs
@@ -6,6 +6,9 @@
 //! log frames so don't use those APIs.
 
 #![no_std]
+// nightly warns about static_mut_refs, but 1.76 (our MSRV) does not know about
+// that lint yet, so we ignore it it but also ignore if it is unknown
+#![allow(unknown_lints, static_mut_refs)]
 
 use core::sync::atomic::{AtomicBool, Ordering};
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
+use utils::rustc_is_msrv;
 
 use crate::{
     snapshot::{test_snapshot, Snapshot},
@@ -136,8 +137,13 @@ fn test_cross(deny_warnings: bool) {
         false => vec![],
     };
 
+    let mut features = vec!["", "alloc"];
+    if !rustc_is_msrv() {
+        features.push("ip_in_core");
+    }
+
     for target in &targets {
-        for feature in ["", "alloc", "ip_in_core"] {
+        for feature in &features {
             do_test(
                 || {
                     run_command(
@@ -203,12 +209,21 @@ fn test_cross(deny_warnings: bool) {
         || {
             run_command(
                 "cargo",
-                &["clippy", "--target", "thumbv7m-none-eabi", "--", "-D", "warnings"],
+                &[
+                    "clippy",
+                    "--target",
+                    "thumbv7m-none-eabi",
+                    "--",
+                    "-D",
+                    "warnings",
+                    "-A",
+                    "unknown-lints",
+                ],
                 Some("firmware/"),
                 &env,
             )
         },
-        "lint",
+        "cross",
     );
 }
 

--- a/xtask/src/snapshot.rs
+++ b/xtask/src/snapshot.rs
@@ -6,7 +6,10 @@ use similar::{ChangeTag, TextDiff};
 
 use crate::{
     do_test,
-    utils::{load_expected_output, overwrite_expected_output, run_capturing_stdout, rustc_is_nightly},
+    utils::{
+        load_expected_output, overwrite_expected_output, run_capturing_stdout, rustc_is_msrv,
+        rustc_is_nightly,
+    },
 };
 
 pub const SNAPSHOT_TESTS_DIRECTORY: &str = "firmware/qemu";
@@ -25,15 +28,19 @@ pub(crate) fn all_snapshot_tests() -> Vec<&'static str> {
         "hints",
         "hints_inner",
         "dbg",
-        "net",
         "panic_info",
     ];
     const NIGHTLY_SNAPSHOT_TESTS: &[&str] = &["alloc"];
+    const POST_MSRV_SNAPSHOT_TESTS: &[&str] = &["net"];
 
     let mut tests = STABLE_SNAPSHOT_TESTS.to_vec();
     if rustc_is_nightly() {
         tests.extend(NIGHTLY_SNAPSHOT_TESTS);
     }
+    if !rustc_is_msrv() {
+        tests.extend(POST_MSRV_SNAPSHOT_TESTS);
+    }
+
     tests
 }
 

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -94,3 +94,9 @@ pub fn rustc_is_nightly() -> bool {
     let out = run_capturing_stdout(Command::new("rustc").args(["-V"])).unwrap();
     out.contains("nightly")
 }
+
+pub fn rustc_is_msrv() -> bool {
+    const MSRV: &str = "1.76";
+    let out = run_capturing_stdout(Command::new("rustc").args(["-V"])).unwrap();
+    out.contains(MSRV)
+}


### PR DESCRIPTION
This PR documents and tests Rust 1.76 as our MSRV. This is the version Ferrocene 24.05 is based on. Before we only guaranteed to support the latest stable.

I tried to store the MSRV in an env variable in the workflow file, but unfortunately env variables are not available in the strategy matrix, so it has to be repeated.