### PR TITLE
Fix __defmt_default_panic being garbage collected by linker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - [#874]: `defmt`: Fix doc test
+- [#873]: `defmt`: Fix __defmt_default_panic being garbage collected by linker
 - [#872]: `defmt`: Add `expect!` as alias for `unwrap!` for discoverability
 - [#871]: Set MSRV to Rust 1.76
 - [#865]: `defmt`: Replace proc-macro-error with proc-macro-error2
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#807]: `defmt-print`: Add `watch_elf` flag to allow ELF file reload without restarting `defmt-print`
 
 [#874]: https://github.com/knurling-rs/defmt/pull/874
+[#873]: https://github.com/knurling-rs/defmt/pull/873
 [#872]: https://github.com/knurling-rs/defmt/pull/872
 [#871]: https://github.com/knurling-rs/defmt/pull/871
 [#859]: https://github.com/knurling-rs/defmt/pull/859

--- a/defmt/defmt.x.in
+++ b/defmt/defmt.x.in
@@ -1,10 +1,15 @@
-/* exhaustively search for these symbols */
+/* Exhaustively search for these symbols */
 EXTERN(_defmt_acquire);
 EXTERN(_defmt_release);
-EXTERN(__defmt_default_timestamp);
 EXTERN(__DEFMT_MARKER_TIMESTAMP_WAS_DEFINED);
+
+/* Define timestamp and panic, unless the user defines them */
 PROVIDE(_defmt_timestamp = __defmt_default_timestamp);
 PROVIDE(_defmt_panic = __defmt_default_panic);
+
+/* Avoid default implementations to be garbage collected */
+EXTERN(__defmt_default_timestamp);
+EXTERN(__defmt_default_panic);
 
 SECTIONS
 {


### PR DESCRIPTION
This PR modifies the defmt linker script to stop LLD of garbage collecting the panic default implementation. ~~This PR targets main, after it gets merged the PR will be backported to a defmt-0.3.8 release branch and a release with just this change will be published.~~

~~Workaround for #862~~