### PR TITLE
Merge function calls emitted by the macro to save space.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#880]: Merge function calls emitted by the macro to save space.
 - [#874]: `defmt`: Fix doc test
 - [#872]: `defmt`: Add `expect!` as alias for `unwrap!` for discoverability
 - [#871]: Set MSRV to Rust 1.76

--- a/defmt/src/export/mod.rs
+++ b/defmt/src/export/mod.rs
@@ -209,9 +209,20 @@ pub fn display(val: &dyn core::fmt::Display) {
 }
 
 #[inline(never)]
-pub fn header(s: &Str) {
+pub unsafe fn acquire_and_header(s: &Str) {
+    acquire();
     istr(s);
     timestamp(make_formatter());
+}
+
+#[inline(never)]
+pub fn acquire_header_and_release(s: &Str) {
+    // safety: will be released a few lines further down
+    unsafe { acquire() };
+    istr(s);
+    timestamp(make_formatter());
+    // safety: acquire() was called a few lines above
+    unsafe { release() };
 }
 
 struct FmtWrite;

--- a/macros/src/function_like/log.rs
+++ b/macros/src/function_like/log.rs
@@ -41,16 +41,25 @@ pub(crate) fn expand_parsed(level: Level, args: Args) -> TokenStream2 {
     let env_filter = EnvFilter::from_env_var();
 
     if let Some(filter_check) = env_filter.path_check(level) {
+        let content = if exprs.is_empty() {
+            quote!(
+                defmt::export::acquire_header_and_release(&#header);
+            )
+        } else {
+            quote!(
+                // safety: will be released a few lines further down
+                unsafe { defmt::export::acquire_and_header(&#header); };
+                #(#exprs;)*
+                // safety: acquire() was called a few lines above
+                unsafe { defmt::export::release() }
+            )
+        };
+
         quote!(
             match (#(&(#formatting_exprs)),*) {
                 (#(#patterns),*) => {
                     if #filter_check {
-                        // safety: will be released a few lines further down
-                        unsafe { defmt::export::acquire() };
-                        defmt::export::header(&#header);
-                        #(#exprs;)*
-                        // safety: acquire() was called a few lines above
-                        unsafe { defmt::export::release() }
+                        #content
                     }
                 }
             }


### PR DESCRIPTION
Save code space by merging functions.

- If the log line has no args, generated code has 1 call instead of 3.
- If the log line has args, generated code has n+2 calls instead of n+3.

```rust
#[inline(never)]
unsafe fn test1() {
    info!("boo");
}

#[inline(never)]
unsafe fn test2() {
    info!("boo {=u32}", 42);
}

============ BEFORE =============
000465c8 <_ZN11application5test117hcc5385f1594b37ddE>:
   465c8: b580         	push	{r7, lr}
   465ca: 466f         	mov	r7, sp
   465cc: f005 faf8    	bl	0x4bbc0 <_defmt_acquire> @ imm = #0x55f0
   465d0: 4803         	ldr	r0, [pc, #0xc]          @ 0x465e0 <_ZN11application5test117hcc5385f1594b37ddE+0x18>
   465d2: f00a f8bc    	bl	0x5074e <_ZN5defmt6export6header17hd841c3329e459a6fE> @ imm = #0xa178
   465d6: e8bd 4080    	pop.w	{r7, lr}
   465da: f005 baff    	b.w	0x4bbdc <_defmt_release> @ imm = #0x55fe
   465de: bf00         	nop
   465e0: 01 01 00 00  	.word	0x00000101

000465e4 <_ZN11application5test217h31c534e4d89d1917E>:
   465e4: b580         	push	{r7, lr}
   465e6: 466f         	mov	r7, sp
   465e8: f005 faea    	bl	0x4bbc0 <_defmt_acquire> @ imm = #0x55d4
   465ec: 4804         	ldr	r0, [pc, #0x10]         @ 0x46600 <_ZN11application5test217h31c534e4d89d1917E+0x1c>
   465ee: f00a f8ae    	bl	0x5074e <_ZN5defmt6export6header17hd841c3329e459a6fE> @ imm = #0xa15c
   465f2: 202a         	movs	r0, #0x2a
   465f4: f00a f8bc    	bl	0x50770 <_ZN5defmt6export8integers3u3217h8d5db4af4ec353d2E> @ imm = #0xa178
   465f8: e8bd 4080    	pop.w	{r7, lr}
   465fc: f005 baee    	b.w	0x4bbdc <_defmt_release> @ imm = #0x55dc
   46600: 02 01 00 00  	.word	0x00000102


============ AFTER =============
0004767c <_ZN11application5test117h23c58548f98ab538E>:
   4767c: 4801         	ldr	r0, [pc, #0x4]          @ 0x47684 <_ZN11application5test117h23c58548f98ab538E+0x8>
   4767e: f008 bcec    	b.w	0x5005a <_ZN5defmt6export26acquire_header_and_release17h4f68c6bdd10634b9E> @ imm = #0x89d8
   47682: bf00         	nop
   47684: 80 00 00 00  	.word	0x00000080

00047688 <_ZN11application5test217h6abec0c993cbeb6cE>:
   47688: b580         	push	{r7, lr}
   4768a: 466f         	mov	r7, sp
   4768c: 4804         	ldr	r0, [pc, #0x10]         @ 0x476a0 <_ZN11application5test217h6abec0c993cbeb6cE+0x18>
   4768e: f008 fcd8    	bl	0x50042 <_ZN5defmt6export18acquire_and_header17h3b663ca5e66ca628E> @ imm = #0x89b0
   47692: 202a         	movs	r0, #0x2a
   47694: f008 fcb4    	bl	0x50000 <_ZN5defmt6export8integers3u3217hc4c48e67bb670440E> @ imm = #0x8968
   47698: e8bd 4080    	pop.w	{r7, lr}
   4769c: f005 ba54    	b.w	0x4cb48 <_defmt_release> @ imm = #0x54a8
   476a0: 81 00 00 00  	.word	0x00000081
```
