### PR TITLE
Mark decoder and parser not as unstable anymore

### DIFF
--- a/.github/workflows/cargo-semver-check.yml
+++ b/.github/workflows/cargo-semver-check.yml
@@ -14,15 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Semver check crates without "unstable" feature
+      - name: Semver check host crates
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features
-      - name: Semver check crates with "unstable" feature
-        uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          exclude: defmt, defmt-json-schema
-          features: unstable
       - name: Semver check firmware crates
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#883]: Mark decoder and parser not as unstable anymore
 - [#880]: Merge function calls emitted by the macro to save space.
 - [#874]: `defmt`: Fix doc test
 - [#872]: `defmt`: Add `expect!` as alias for `unwrap!` for discoverability
@@ -26,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#822]: `CI`: Run `cargo semver-checks` on every PR
 - [#807]: `defmt-print`: Add `watch_elf` flag to allow ELF file reload without restarting `defmt-print`
 
+[#883]: https://github.com/knurling-rs/defmt/pull/883
+[#880]: https://github.com/knurling-rs/defmt/pull/880
 [#874]: https://github.com/knurling-rs/defmt/pull/874
 [#872]: https://github.com/knurling-rs/defmt/pull/872
 [#871]: https://github.com/knurling-rs/defmt/pull/871

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.3.11"
 [dependencies]
 byteorder = "1"
 colored = "2"
-defmt-parser = { version = "=0.3.4", path = "../parser", features = ["unstable"] }
+defmt-parser = { version = "=0.3.4", path = "../parser" }
 ryu = "1"
 nom = "7"
 
@@ -45,10 +45,5 @@ serde_json = { version = "1", features = ["arbitrary_precision"] }
 regex = "1"
 alterable_logger = "1"
 
-[features]
-# WARNING: API and wire format subject to change.
-unstable = []
-
 [package.metadata.docs.rs]
-features = ["unstable"]
 rustdoc-args = ["--cfg=docsrs"]

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -45,5 +45,9 @@ serde_json = { version = "1", features = ["arbitrary_precision"] }
 regex = "1"
 alterable_logger = "1"
 
+[features]
+# DEPRECATED: noop, will be removed in 1.0
+unstable = []
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg=docsrs"]

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -2,9 +2,7 @@
 //!
 //! NOTE: The decoder always runs on the host!
 
-#![cfg(feature = "unstable")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, doc(cfg(unstable)))]
 #![doc(html_logo_url = "https://knurling.ferrous-systems.com/knurling_logo_light_text.svg")]
 
 pub const DEFMT_VERSIONS: &[&str] = &["3", "4"];

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { version = "=0.3.4", path = "../parser", features = ["unstable"] }
+defmt-parser = { version = "=0.3.4", path = "../parser" }
 proc-macro-error2 = "2"
 proc-macro2 = "1"
 quote = "1"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,9 +15,5 @@ thiserror = "1.0"
 [dev-dependencies]
 rstest = { version = "0.19", default-features = false }
 
-[features]
-unstable = []
-
 [package.metadata.docs.rs]
-features = ["unstable"]
 rustdoc-args = [ "--cfg=docsrs" ]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,5 +15,9 @@ thiserror = "1.0"
 [dev-dependencies]
 rstest = { version = "0.19", default-features = false }
 
+[features]
+# DEPRECATED: noop, will be removed in 1.0
+unstable = []
+
 [package.metadata.docs.rs]
 rustdoc-args = [ "--cfg=docsrs" ]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -5,9 +5,7 @@
 //!
 //! [`defmt`]: https://github.com/knurling-rs/defmt
 
-#![cfg(feature = "unstable")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, doc(cfg(unstable)))]
 #![doc(html_logo_url = "https://knurling.ferrous-systems.com/knurling_logo_light_text.svg")]
 
 mod display_hint;

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -15,9 +15,7 @@ version = "0.3.12"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
-    "unstable",
-] }
+defmt-decoder = { version = "=0.3.11", path = "../decoder" }
 log = "0.4"
 notify = "6.1"
 tokio = { version = "1.38", features = ["full"] }

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,6 +8,4 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { version = "=0.3.11", path = "../decoder", features = [
-    "unstable",
-] }
+defmt-decoder = { version = "=0.3.11", path = "../decoder" }


### PR DESCRIPTION
This PR marks the `defmt-decoder` and `defmt-parser` as _not_ unstable anymore. We did uphold semver for years (except one accidental breakage), so making that explicit just makes sense.

Users now do not need to pass `unstable` anymore in order to use this crate. To be precise they are not allowed to pass it anymore, therefore this is a breaking change, as it requires users to update their `Cargo.toml`. It will be released together with two other breaking changes. For `probe-rs` we gonna change it in https://github.com/probe-rs/probe-rs/pull/2809.