### PR TITLE
Fix the READMEs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,7 @@ Initial release
 > Parsing library for defmt format strings
 
 [defmt-parser-next]: https://github.com/knurling-rs/defmt/compare/defmt-parser-v0.4.0...main
+[defmt-parser-v0.4.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.4.1
 [defmt-parser-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.4.0
 [defmt-parser-v0.3.4]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.3.4
 [defmt-parser-v0.3.3]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.3.3
@@ -592,6 +593,10 @@ Initial release
 [defmt-parser-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.1.0
 
 ### [defmt-parser-next]
+
+### [defmt-parser-v0.4.1] (2024-11-27)
+
+* [#897] Added its own README
 
 ### [defmt-parser-v0.4.0] (2024-11-27)
 
@@ -812,6 +817,7 @@ Initial release
 
 ---
 
+[#897]: https://github.com/knurling-rs/defmt/pull/897
 [#889]: https://github.com/knurling-rs/defmt/pull/889
 [#887]: https://github.com/knurling-rs/defmt/pull/887
 [#884]: https://github.com/knurling-rs/defmt/pull/884

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 keywords = ["knurling", "defmt"]
 license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 version = "0.4.0"
 
 [dependencies]
 byteorder = "1"
 colored = "2"
-defmt-parser = { version = "=0.4.0", path = "../parser" }
+defmt-parser = { version = "=0.4.1", path = "../parser" }
 ryu = "1"
 nom = "7"
 

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -1,0 +1,44 @@
+# `defmt-decoder`
+
+`defmt` ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.
+
+For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
+
+The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
+
+This library is for decoding [`defmt`](https://crates.io/crates/defmt) frames
+into formatted strings. It is used by
+[`defmt-print`](https://crates.io/crates/defmt-print) and other tools.
+
+## MSRV
+
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+
+## Support
+
+`defmt` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com/
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/decoder/defmt-json-schema/Cargo.toml
+++ b/decoder/defmt-json-schema/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 keywords = ["knurling", "defmt"]
 license = "MIT OR Apache-2.0"
 name = "defmt-json-schema"
-readme = "../../README.md"
+readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 version = "0.1.0"
 

--- a/decoder/defmt-json-schema/README.md
+++ b/decoder/defmt-json-schema/README.md
@@ -1,0 +1,43 @@
+# `defmt-json-schema`
+
+`defmt` ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.
+
+For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
+
+The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
+
+This library describes the JSON output from
+[`defmt-decoder`](https://crates.io/crates/defmt-decoder).
+
+## MSRV
+
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+
+## Support
+
+`defmt` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com/
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/firmware/defmt-test/macros/Cargo.toml
+++ b/firmware/defmt-test/macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 keywords = ["knurling", "defmt", "testing"]
 license = "MIT OR Apache-2.0"
 name = "defmt-test-macros"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 version = "0.3.1"
 

--- a/firmware/defmt-test/macros/README.md
+++ b/firmware/defmt-test/macros/README.md
@@ -1,0 +1,43 @@
+# `defmt-test-macros`
+
+`defmt` ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.
+
+For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
+
+The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
+
+This library contains the proc macros used by
+[`defmt-test`](https://crates.io/crates/defmt-test).
+
+## MSRV
+
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+
+## Support
+
+`defmt` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com/
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 keywords = ["knurling", "defmt"]
 license = "MIT OR Apache-2.0"
 name = "defmt-macros"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 version = "0.3.10"
 
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { version = "=0.4.0", path = "../parser" }
+defmt-parser = { version = "=0.4.1", path = "../parser" }
 proc-macro-error2 = "2"
 proc-macro2 = "1"
 quote = "1"

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,0 +1,43 @@
+# `defmt-macros`
+
+`defmt` ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.
+
+For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
+
+The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
+
+This library contains the proc macros used by
+[`defmt`](https://crates.io/crates/defmt).
+
+## MSRV
+
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+
+## Support
+
+`defmt` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com/
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 keywords = ["knurling", "defmt"]
 license = "MIT OR Apache-2.0"
 name = "defmt-parser"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 thiserror = "2"

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,44 @@
+# `defmt-parser`
+
+`defmt` ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.
+
+For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
+
+The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
+
+This library decodes `defmt` frames into Rust structures. It is mainly used by
+[`defmt-decoder`](https://crates.io/crates/defmt-decoder), and you should prefer
+using that crate to this one.
+
+## MSRV
+
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+
+## Support
+
+`defmt` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com/
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs


### PR DESCRIPTION
Now every package has its own, instead of linking to the top-level README.