### PR TITLE
Remove mentions of the git version of the defmt book.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
 
-The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
-
 ## Components
 
 This repository contains the following packages:

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -4,8 +4,6 @@
 
 For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
 
-The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
-
 This library is for decoding [`defmt`](https://crates.io/crates/defmt) frames
 into formatted strings. It is used by
 [`defmt-print`](https://crates.io/crates/defmt-print) and other tools.

--- a/decoder/defmt-json-schema/README.md
+++ b/decoder/defmt-json-schema/README.md
@@ -4,8 +4,6 @@
 
 For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
 
-The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
-
 This library describes the JSON output from
 [`defmt-decoder`](https://crates.io/crates/defmt-decoder).
 

--- a/defmt/README.md
+++ b/defmt/README.md
@@ -4,8 +4,6 @@
 
 For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
 
-The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
-
 ## Setup
 
 ### New project

--- a/firmware/defmt-test/macros/README.md
+++ b/firmware/defmt-test/macros/README.md
@@ -4,8 +4,6 @@
 
 For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
 
-The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
-
 This library contains the proc macros used by
 [`defmt-test`](https://crates.io/crates/defmt-test).
 

--- a/macros/README.md
+++ b/macros/README.md
@@ -4,8 +4,6 @@
 
 For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
 
-The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
-
 This library contains the proc macros used by
 [`defmt`](https://crates.io/crates/defmt).
 

--- a/parser/README.md
+++ b/parser/README.md
@@ -4,8 +4,6 @@
 
 For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
 
-The git version of the defmt book can be viewed at <https://defmt-next.ferrous-systems.com/>.
-
 This library decodes `defmt` frames into Rust structures. It is mainly used by
 [`defmt-decoder`](https://crates.io/crates/defmt-decoder), and you should prefer
 using that crate to this one.


### PR DESCRIPTION
When we move to cloudflare, defmt.ferrous-systems.com will always just be the contents of main.