### PR TITLE
Fix build on Rust 1.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#902] Minor change to Format impl for `core::panic::PanicInfo`, eliding a lifetime specifier to satisfy Clippy 1.83.
+
 ### [defmt-v0.3.9] - 2024-11-27
 
 * [#889] Add script for book hosting
@@ -530,6 +532,8 @@ Initial release
 
 ### [defmt-decoder-next]
 
+* [#902] Minor change to `impl StreamDecoder` for `Raw` and `Rzcobs`, eliding a lifetime specifier to satisfy Clippy 1.83. No observable change.
+
 ### [defmt-decoder-v0.4.0] (2024-11-27)
 
 ### [defmt-decoder-v0.3.11] (2024-05-13)
@@ -635,6 +639,8 @@ Initial release
 
 ### [defmt-rtt-next]
 
+* [#902] Use `core::ptr::addr_of_mut!` instead of `&mut` on mutable statics. No observable change.
+
 ### [defmt-rtt-v0.4.1] (2024-05-13)
 
 ### [defmt-rtt-v0.4.0] (2022-10-07)
@@ -665,6 +671,8 @@ Initial release
 [defmt-itm-v0.2.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-itm-v0.2.0
 
 ### [defmt-itm-next]
+
+* [#902] Switch to using critical-section, and copy implementation over from defmt-rtt.
 
 ### [defmt-itm-v0.3.0] (2021-11-26)
 
@@ -817,6 +825,7 @@ Initial release
 
 ---
 
+[#902]: https://github.com/knurling-rs/defmt/pull/902
 [#897]: https://github.com/knurling-rs/defmt/pull/897
 [#889]: https://github.com/knurling-rs/defmt/pull/889
 [#887]: https://github.com/knurling-rs/defmt/pull/887

--- a/decoder/src/stream/raw.rs
+++ b/decoder/src/stream/raw.rs
@@ -15,7 +15,7 @@ impl<'a> Raw<'a> {
     }
 }
 
-impl<'a> StreamDecoder for Raw<'a> {
+impl StreamDecoder for Raw<'_> {
     fn received(&mut self, data: &[u8]) {
         self.data.extend_from_slice(data);
     }

--- a/decoder/src/stream/rzcobs.rs
+++ b/decoder/src/stream/rzcobs.rs
@@ -53,7 +53,7 @@ impl<'a> Rzcobs<'a> {
     }
 }
 
-impl<'a> StreamDecoder for Rzcobs<'a> {
+impl StreamDecoder for Rzcobs<'_> {
     fn received(&mut self, mut data: &[u8]) {
         // Trim zeros from the left, start storing at first non-zero byte.
         if self.raw.is_empty() {

--- a/defmt/src/impls/core_/panic.rs
+++ b/defmt/src/impls/core_/panic.rs
@@ -2,7 +2,7 @@ use core::panic;
 
 use super::*;
 
-impl<'a> Format for panic::PanicInfo<'a> {
+impl Format for panic::PanicInfo<'_> {
     fn format(&self, f: Formatter) {
         if let Some(location) = self.location() {
             crate::write!(f, "panicked at {}", location);
@@ -14,7 +14,7 @@ impl<'a> Format for panic::PanicInfo<'a> {
     }
 }
 
-impl<'a> Format for panic::Location<'a> {
+impl Format for panic::Location<'_> {
     fn format(&self, f: Formatter) {
         crate::write!(
             f,

--- a/firmware/defmt-itm/Cargo.toml
+++ b/firmware/defmt-itm/Cargo.toml
@@ -12,4 +12,5 @@ version = "0.3.0"
 
 [dependencies]
 cortex-m = "0.7"
+critical-section = "1.2.0"
 defmt = { version = "0.3", path = "../../defmt" }

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -53,19 +53,22 @@ unsafe impl defmt::Logger for Logger {
         // safety: Must be paired with corresponding call to release(), see below
         let restore = unsafe { critical_section::acquire() };
 
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
         if TAKEN.load(Ordering::Relaxed) {
             panic!("defmt logger taken reentrantly")
         }
 
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
         TAKEN.store(true, Ordering::Relaxed);
 
         // safety: accessing the `static mut` is OK because we have acquired a critical section.
         unsafe { CS_RESTORE = restore };
 
         // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        unsafe { ENCODER.start_frame(do_write) }
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
+            encoder.start_frame(do_write)
+        }
     }
 
     unsafe fn flush() {
@@ -75,21 +78,29 @@ unsafe impl defmt::Logger for Logger {
 
     unsafe fn release() {
         // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        ENCODER.end_frame(do_write);
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
+            encoder.end_frame(do_write);
+        }
 
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
         TAKEN.store(false, Ordering::Relaxed);
 
         // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        let restore = CS_RESTORE;
+        let restore = unsafe { CS_RESTORE };
 
         // safety: Must be paired with corresponding call to acquire(), see above
-        critical_section::release(restore);
+        unsafe {
+            critical_section::release(restore);
+        }
     }
 
     unsafe fn write(bytes: &[u8]) {
         // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        ENCODER.write(bytes, do_write);
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
+            encoder.write(bytes, do_write);
+        }
     }
 }
 
@@ -128,7 +139,7 @@ unsafe fn handle() -> &'static Channel {
         up_channel: Channel {
             name: &NAME as *const _ as *const u8,
             #[allow(static_mut_refs)]
-            buffer: unsafe { &mut BUFFER as *mut _ as *mut u8 },
+            buffer: unsafe { BUFFER.as_mut_ptr() },
             size: BUF_SIZE,
             write: AtomicUsize::new(0),
             read: AtomicUsize::new(0),
@@ -145,5 +156,5 @@ unsafe fn handle() -> &'static Channel {
     #[link_section = ".data"]
     static NAME: [u8; 6] = *b"defmt\0";
 
-    &_SEGGER_RTT.up_channel
+    unsafe { &*core::ptr::addr_of!(_SEGGER_RTT.up_channel) }
 }


### PR DESCRIPTION
Rust 1.83 came out yesterday and adds some new warnings. As we build in CI with `-D warnings`, this broke our CI builds.

They should now work again.
