### PR TITLE
Fix address of logo on docs.rs

### DIFF
--- a/defmt/src/lib.rs
+++ b/defmt/src/lib.rs
@@ -12,7 +12,7 @@
 
 #![cfg_attr(not(feature = "unstable-test"), no_std)]
 // NOTE if you change this URL you'll also need to update all other crates in this repo
-#![doc(html_logo_url = "https://knurling.ferrous-systems.com/knurling_logo_light_text.svg")]
+#![doc(html_logo_url = "https://defmt.ferrous-systems.com/assets/knurling_logo_light_text.svg")]
 #![warn(missing_docs)]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
The logo is not available at the previous address anymore, since we deprecated the knurling website some time ago. This PR changes the address to the logo from the defmt book.

`cargo doc` now shows the logo again, but this will only solve it for new releases. The old releases will keep the old address. If we want to fix them we have to host the logo at the previous address again.

Fix #904.