### PR TITLE
Adding defmt-1.0

### DIFF
--- a/.github/workflows/cargo-semver-check.yml
+++ b/.github/workflows/cargo-semver-check.yml
@@ -23,11 +23,6 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features
-          manifest-path: defmt-03
-      - name: Semver check host crates
-        uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          feature-group: default-features
           manifest-path: decoder
       - name: Semver check host crates
         uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/cargo-semver-check.yml
+++ b/.github/workflows/cargo-semver-check.yml
@@ -34,7 +34,10 @@ jobs:
         with:
           feature-group: default-features
           manifest-path: parser
+      # FIXME: Un-exclude and enable the rust-target once https://github.com/obi1kenobi/cargo-semver-checks-action/issues/98 is fixed
       - name: Semver check firmware crates
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           manifest-path: firmware/
+          exclude: defmt-semihosting
+          # rust-target: thumbv7em-none-eabihf

--- a/.github/workflows/cargo-semver-check.yml
+++ b/.github/workflows/cargo-semver-check.yml
@@ -14,22 +14,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Semver check host crates
+      - name: Semver check defmt
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features
           manifest-path: defmt
-      - name: Semver check host crates
+      - name: Semver check decoder
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features
           manifest-path: decoder
-      - name: Semver check host crates
+      - name: Semver check decoder/defmt-json-schema
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features
           manifest-path: decoder/defmt-json-schema
-      - name: Semver check host crates
+      - name: Semver check parser
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features

--- a/.github/workflows/cargo-semver-check.yml
+++ b/.github/workflows/cargo-semver-check.yml
@@ -18,6 +18,27 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features
+          manifest-path: defmt
+      - name: Semver check host crates
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: default-features
+          manifest-path: defmt-03
+      - name: Semver check host crates
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: default-features
+          manifest-path: decoder
+      - name: Semver check host crates
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: default-features
+          manifest-path: decoder/defmt-json-schema
+      - name: Semver check host crates
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: default-features
+          manifest-path: parser
       - name: Semver check firmware crates
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 * No changes
 
-### [defmt-v1.0.0] (2025-01-01)
+### [defmt-v1.0.0] (2025-04-01)
 
 * [#909] First 1.0 stable release :tada:
 * [#940] `defmt-print`: Allow reading from a serial port
@@ -61,7 +61,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#935] Add note in book's setup chapter to clarify staticlib setup
 * [#914] Add cargo-deny as a CI action to check crate security and licensing
 
-### [defmt-v0.3.100] (2025-01-01)
+### [defmt-v0.3.100] (2025-04-01)
 
 * [#909] Re-exports defmt-1.0.0
 
@@ -417,8 +417,9 @@ Initial release
 
 ### [defmt-macros-next]
 
+* No changes
 
-### [defmt-macros-v1.0.0] (2025-01-01)
+### [defmt-macros-v1.0.0] (2025-04-01)
 
 * [#948] Add support for specifying the `defmt` crate path for the `Format` derive via a `#[defmt(crate = path )]` helper attribute
 * [#909] First 1.0 stable release :tada:
@@ -492,7 +493,9 @@ Initial release
 
 ### [defmt-print-next]
 
-### [defmt-print-v1.0.0] (2025-01-01)
+* No changes
+
+### [defmt-print-v1.0.0] (2025-04-01)
 
 * [#909] First 1.0 stable release :tada:
 
@@ -570,7 +573,9 @@ Initial release
 
 ### [defmt-decoder-next]
 
-### [defmt-decoder-v1.0.0] (2025-01-01)
+* No changes
+
+### [defmt-decoder-v1.0.0] (2025-04-01)
 
 * [#909] First 1.0 stable release :tada:
 * [#902] Minor change to `impl StreamDecoder` for `Raw` and `Rzcobs`, eliding a lifetime specifier to satisfy Clippy 1.83. No observable change.
@@ -641,7 +646,9 @@ Initial release
 
 ### [defmt-parser-next]
 
-### [defmt-parser-v1.0.0] (2025-01-01)
+* No changes
+
+### [defmt-parser-v1.0.0] (2025-04-01)
 
 * [#916] Mark `DisplayHint` as `non_exhaustive`. This is a breaking change.
 * [#916] Add display hint ":cbor", indicating RFC8949 encoded data to be displayed in diagnostic notation.
@@ -690,7 +697,9 @@ Initial release
 
 ### [defmt-rtt-next]
 
-### [defmt-rtt-v1.0.0] (2025-01-01)
+* No changes
+
+### [defmt-rtt-v1.0.0] (2025-04-01)
 
 * [#909] First 1.0 stable release :tada:
 
@@ -734,7 +743,9 @@ Initial release
 
 ### [defmt-itm-next]
 
-### [defmt-itm-v0.4.0] (2025-01-01)
+* No changes
+
+### [defmt-itm-v0.4.0] (2025-04-01)
 
 * [#909] Switch to using defmt-1.0
 * [#902] Switch to using critical-section, and copy implementation over from defmt-rtt.
@@ -749,11 +760,16 @@ Initial release
 
 > Transmit defmt log messages using semi-hosting breakpoints
 
-[defmt-semihosting-next]: https://github.com/knurling-rs/defmt/compare/defmt-semihosting-v0.2.0...main
+[defmt-semihosting-next]: https://github.com/knurling-rs/defmt/compare/defmt-semihosting-v0.3.0...main
+[defmt-semihosting-v0.3.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-semihosting-v0.3.0
 [defmt-semihosting-v0.2.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-semihosting-v0.2.0
 [defmt-semihosting-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-semihosting-v0.1.0
 
 ### [defmt-semihosting-next]
+
+* No changes
+
+### [defmt-semihosting-v0.3.0] (2025-04-01)
 
 * [#909] Switch to using defmt-1.0
 
@@ -781,7 +797,9 @@ Initial release
 
 ### [panic-probe-next]
 
-### [panic-probe-v1.0.0] (2025-01-01)
+* No changes
+
+### [panic-probe-v1.0.0] (2025-04-01)
 
 * [#909] Switch to using defmt-1.0
 
@@ -819,7 +837,9 @@ Initial release
 
 ### [defmt-test-next]
 
-### [defmt-test-v0.4.0] (2025-01-01)
+* No changes
+
+### [defmt-test-v0.4.0] (2025-04-01)
 
 * [#909] Switch to using defmt-1.0
 
@@ -857,6 +877,8 @@ Initial release
 
 ### [defmt-test-macros-next]
 
+* No changes
+
 ### [defmt-test-macros-v0.3.1] (2024-03-05)
 
 ### [defmt-test-macros-v0.3.0] (2021-11-26)
@@ -879,6 +901,8 @@ Initial release
 [defmt-json-schema-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-json-schema-v0.1.0
 
 ### [defmt-json-schema-next]
+
+* No changes
 
 ### [defmt-json-schema-v0.1.0] (2022-03-10)
 
@@ -911,6 +935,12 @@ Initial release
 [#950]: https://github.com/knurling-rs/defmt/pull/950
 [#949]: https://github.com/knurling-rs/defmt/pull/949
 [#948]: https://github.com/knurling-rs/defmt/pull/948
+[#945]: https://github.com/knurling-rs/defmt/pull/945
+[#943]: https://github.com/knurling-rs/defmt/pull/943
+[#940]: https://github.com/knurling-rs/defmt/pull/940
+[#938]: https://github.com/knurling-rs/defmt/pull/938
+[#935]: https://github.com/knurling-rs/defmt/pull/935
+[#916]: https://github.com/knurling-rs/defmt/pull/916
 [#915]: https://github.com/knurling-rs/defmt/pull/915
 [#914]: https://github.com/knurling-rs/defmt/pull/914
 [#909]: https://github.com/knurling-rs/defmt/pull/909
@@ -940,7 +970,9 @@ Initial release
 [#840]: https://github.com/knurling-rs/defmt/pull/840
 [#839]: https://github.com/knurling-rs/defmt/pull/839
 [#838]: https://github.com/knurling-rs/defmt/pull/838
+[#835]: https://github.com/knurling-rs/defmt/pull/835
 [#831]: https://github.com/knurling-rs/defmt/pull/831
+[#830]: https://github.com/knurling-rs/defmt/pull/830
 [#822]: https://github.com/knurling-rs/defmt/pull/822
 [#821]: https://github.com/knurling-rs/defmt/pull/821
 [#813]: https://github.com/knurling-rs/defmt/pull/813
@@ -973,6 +1005,7 @@ Initial release
 [#683]: https://github.com/knurling-rs/defmt/pull/683
 [#682]: https://github.com/knurling-rs/defmt/pull/682
 [#681]: https://github.com/knurling-rs/defmt/pull/681
+[#669]: https://github.com/knurling-rs/defmt/pull/669
 [#662]: https://github.com/knurling-rs/defmt/pull/662
 [#661]: https://github.com/knurling-rs/defmt/pull/661
 [#659]: https://github.com/knurling-rs/defmt/pull/659

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 > A highly efficient logging framework that targets resource-constrained devices, like microcontrollers
 
-[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v0.3.10...main
+[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v1.0.0...main
+[defmt-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.0.0
+[defmt-v0.3.100]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.3.100
 [defmt-v0.3.10]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.3.10
 [defmt-v0.3.9]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.3.9
 [defmt-v0.3.8]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.3.8
@@ -49,10 +51,19 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* No changes
+
+### [defmt-v1.0.0] (2025-01-01)
+
+* [#909] First 1.0 stable release :tada:
 * [#940] `defmt-print`: Allow reading from a serial port
 * [#938] Emit `option_env!("DEFMT_LOG")` so rustc depinfo can track it
 * [#935] Add note in book's setup chapter to clarify staticlib setup
 * [#914] Add cargo-deny as a CI action to check crate security and licensing
+
+### [defmt-v0.3.100] (2025-01-01)
+
+* [#909] Re-exports defmt-1.0.0
 
 ### [defmt-v0.3.10] (2024-11-29)
 
@@ -383,7 +394,8 @@ Initial release
 
 > Macros for [defmt](#defmt)
 
-[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v0.4.0...main
+[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v1.0.0...main
+[defmt-macros-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.0.0
 [defmt-macros-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.4.0
 [defmt-macros-v0.3.10]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.3.10
 [defmt-macros-v0.3.9]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.3.9
@@ -405,7 +417,11 @@ Initial release
 
 ### [defmt-macros-next]
 
+
+### [defmt-macros-v1.0.0] (2025-01-01)
+
 * [#948] Add support for specifying the `defmt` crate path for the `Format` derive via a `#[defmt(crate = path )]` helper attribute
+* [#909] First 1.0 stable release :tada:
 
 ### [defmt-macros-v0.4.0] (2024-11-29)
 
@@ -455,7 +471,8 @@ Initial release
 
 > A tool that decodes defmt logs and prints them to the console
 
-[defmt-print-next]: https://github.com/knurling-rs/defmt/compare/defmt-print-v0.3.13...main
+[defmt-print-next]: https://github.com/knurling-rs/defmt/compare/defmt-print-v1.0.0...main
+[defmt-print-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v1.0.0
 [defmt-print-v0.3.13]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v0.3.13
 [defmt-print-v0.3.12]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v0.3.12
 [defmt-print-v0.3.11]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v0.3.11
@@ -474,6 +491,10 @@ Initial release
 [defmt-print-v0.2.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v0.2.0
 
 ### [defmt-print-next]
+
+### [defmt-print-v1.0.0] (2025-01-01)
+
+* [#909] First 1.0 stable release :tada:
 
 ### [defmt-print-v0.3.13] (2024-11-27)
 
@@ -525,7 +546,8 @@ Initial release
 
 > Decodes defmt log frames
 
-[defmt-decoder-next]: https://github.com/knurling-rs/defmt/compare/defmt-decoder-v0.4.0...main
+[defmt-decoder-next]: https://github.com/knurling-rs/defmt/compare/defmt-decoder-v1.0.0...main
+[defmt-decoder-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v1.0.0
 [defmt-decoder-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v0.4.0
 [defmt-decoder-v0.3.11]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v0.3.11
 [defmt-decoder-v0.3.10]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v0.3.10
@@ -548,6 +570,9 @@ Initial release
 
 ### [defmt-decoder-next]
 
+### [defmt-decoder-v1.0.0] (2025-01-01)
+
+* [#909] First 1.0 stable release :tada:
 * [#902] Minor change to `impl StreamDecoder` for `Raw` and `Rzcobs`, eliding a lifetime specifier to satisfy Clippy 1.83. No observable change.
 * [#916] Support the ":cbor" display hint, adding new dependency `cbor-edn`.
 
@@ -600,7 +625,8 @@ Initial release
 
 > Parsing library for defmt format strings
 
-[defmt-parser-next]: https://github.com/knurling-rs/defmt/compare/defmt-parser-v0.4.0...main
+[defmt-parser-next]: https://github.com/knurling-rs/defmt/compare/defmt-parser-v1.0.0...main
+[defmt-parser-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v1.0.0
 [defmt-parser-v0.4.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.4.1
 [defmt-parser-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.4.0
 [defmt-parser-v0.3.4]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.3.4
@@ -615,8 +641,11 @@ Initial release
 
 ### [defmt-parser-next]
 
+### [defmt-parser-v1.0.0] (2025-01-01)
+
 * [#916] Mark `DisplayHint` as `non_exhaustive`. This is a breaking change.
 * [#916] Add display hint ":cbor", indicating RFC8949 encoded data to be displayed in diagnostic notation.
+* [#909] First 1.0 stable release :tada:
 
 ### [defmt-parser-v0.4.1] (2024-11-27)
 
@@ -648,7 +677,8 @@ Initial release
 
 > Transmit defmt log messages over the RTT (Real-Time Transfer) protocol
 
-[defmt-rtt-next]: https://github.com/knurling-rs/defmt/compare/defmt-rtt-v0.4.1...main
+[defmt-rtt-next]: https://github.com/knurling-rs/defmt/compare/defmt-rtt-v1.0.0...main
+[defmt-rtt-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.0.0
 [defmt-rtt-v0.4.2]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.4.2
 [defmt-rtt-v0.4.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.4.1
 [defmt-rtt-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.4.0
@@ -659,6 +689,10 @@ Initial release
 [defmt-rtt-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.1.0
 
 ### [defmt-rtt-next]
+
+### [defmt-rtt-v1.0.0] (2025-01-01)
+
+* [#909] First 1.0 stable release :tada:
 
 ### [defmt-rtt-v0.4.2] (2025-03-27)
 
@@ -693,12 +727,16 @@ Initial release
 
 > Transmit defmt log messages over the ITM (Instrumentation Trace Macrocell) stimulus port
 
-[defmt-itm-next]: https://github.com/knurling-rs/defmt/compare/defmt-itm-v0.3.0...main
+[defmt-itm-next]: https://github.com/knurling-rs/defmt/compare/defmt-itm-v0.4.0...main
+[defmt-itm-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-itm-v0.4.0
 [defmt-itm-v0.3.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-itm-v0.3.0
 [defmt-itm-v0.2.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-itm-v0.2.0
 
 ### [defmt-itm-next]
 
+### [defmt-itm-v0.4.0] (2025-01-01)
+
+* [#909] Switch to using defmt-1.0
 * [#902] Switch to using critical-section, and copy implementation over from defmt-rtt.
 
 ### [defmt-itm-v0.3.0] (2021-11-26)
@@ -717,6 +755,8 @@ Initial release
 
 ### [defmt-semihosting-next]
 
+* [#909] Switch to using defmt-1.0
+
 ### [defmt-semihosting-v0.2.0] (2025-03-27)
 
 * [#943] use critical_section for synchronization.
@@ -730,15 +770,20 @@ Initial release
 
 > Panic handler that exits `probe-run` with an error code
 
-[panic-probe-next]: https://github.com/knurling-rs/defmt/compare/panic-probe-v0.3.2...main
-[panic-probe-v0.3.2]: https://github.com/knurling-rs/defmt/compare/panic-probe-v0.3.1...panic-probe-v0.3.2
-[panic-probe-v0.3.1]: https://github.com/knurling-rs/defmt/compare/panic-probe-v0.3.0...panic-probe-v0.3.1
-[panic-probe-v0.3.0]: https://github.com/knurling-rs/defmt/compare/panic-probe-v0.2.1...panic-probe-v0.3.0
-[panic-probe-v0.2.1]: https://github.com/knurling-rs/defmt/compare/panic-probe-v0.2.0...panic-probe-v0.2.1
-[panic-probe-v0.2.0]: https://github.com/knurling-rs/defmt/compare/panic-probe-v0.1.0...panic-probe-v0.2.0
-[panic-probe-v0.1.0]: https://github.com/knurling-rs/defmt/compare/panic-probe-v0.0.0...panic-probe-v0.1.0
+[panic-probe-next]: https://github.com/knurling-rs/defmt/compare/panic-probe-v1.0.0...main
+[panic-probe-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/panic-probe-v1.0.0
+[panic-probe-v0.3.2]: https://github.com/knurling-rs/defmt/releases/tag/panic-probe-v0.3.1
+[panic-probe-v0.3.1]: https://github.com/knurling-rs/defmt/releases/tag/panic-probe-v0.3.0
+[panic-probe-v0.3.0]: https://github.com/knurling-rs/defmt/releases/tag/panic-probe-v0.2.1
+[panic-probe-v0.2.1]: https://github.com/knurling-rs/defmt/releases/tag/panic-probe-v0.2.0
+[panic-probe-v0.2.0]: https://github.com/knurling-rs/defmt/releases/tag/panic-probe-v0.1.0
+[panic-probe-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/panic-probe-v0.0.0
 
 ### [panic-probe-next]
+
+### [panic-probe-v1.0.0] (2025-01-01)
+
+* [#909] Switch to using defmt-1.0
 
 ### [panic-probe-v0.3.2] (2024-05-13)
 
@@ -760,7 +805,8 @@ Initial release
 
 > A test harness for embedded devices
 
-[defmt-test-next]:  https://github.com/knurling-rs/defmt/compare/defmt-test-v0.3.2...main
+[defmt-test-next]:  https://github.com/knurling-rs/defmt/compare/defmt-test-v0.4.0...main
+[defmt-test-v0.4.0]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.4.0
 [defmt-test-v0.3.2]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.3.2
 [defmt-test-v0.3.1]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.3.1
 [defmt-test-v0.3.0]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.3.0
@@ -772,6 +818,10 @@ Initial release
 [defmt-test-v0.1.0]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.1.0
 
 ### [defmt-test-next]
+
+### [defmt-test-v0.4.0] (2025-01-01)
+
+* [#909] Switch to using defmt-1.0
 
 ### [defmt-test-v0.3.2] (2024-03-05)
 
@@ -861,7 +911,9 @@ Initial release
 [#950]: https://github.com/knurling-rs/defmt/pull/950
 [#949]: https://github.com/knurling-rs/defmt/pull/949
 [#948]: https://github.com/knurling-rs/defmt/pull/948
+[#915]: https://github.com/knurling-rs/defmt/pull/915
 [#914]: https://github.com/knurling-rs/defmt/pull/914
+[#909]: https://github.com/knurling-rs/defmt/pull/909
 [#902]: https://github.com/knurling-rs/defmt/pull/902
 [#901]: https://github.com/knurling-rs/defmt/pull/901
 [#899]: https://github.com/knurling-rs/defmt/pull/899

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-exclude = ["firmware/*"]
+exclude = ["firmware/*", "defmt-03"]
 members = [
   "decoder",
   "decoder/defmt-json-schema",

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.0"
+version = "1.0.0-alpha"
 
 [dependencies]
 byteorder = "1"
 colored = "2"
-defmt-parser = { version = "=0.4.1", path = "../parser" }
+defmt-parser = { version = "=1.0.0-alpha", path = "../parser" }
 ryu = "1"
 nom = "7"
 

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 [dependencies]
 byteorder = "1"
 colored = "2"
-defmt-parser = { version = "=1.0.0-rc.1", path = "../parser" }
+defmt-parser = { version = "=1.0.0", path = "../parser" }
 ryu = "1"
 nom = "7"
 

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-alpha"
+version = "1.0.0-rc.1"
 
 [dependencies]
 byteorder = "1"
 colored = "2"
-defmt-parser = { version = "=1.0.0-alpha", path = "../parser" }
+defmt-parser = { version = "=1.0.0-rc.1", path = "../parser" }
 ryu = "1"
 nom = "7"
 

--- a/defmt-03/Cargo.toml
+++ b/defmt-03/Cargo.toml
@@ -10,17 +10,19 @@ description = "A highly efficient logging framework that targets resource-constr
 edition = "2021"
 keywords = [ "knurling", "logging", "logger", "formatting", "formatter" ]
 license = "MIT OR Apache-2.0"
-links = "defmt" # Prevent multiple versions of defmt being linked
 name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "1.0.0-alpha"
+version = "0.3.100"
+
+[dependencies]
+defmt10 = { package = "defmt", version = "1.0.0-alpha", path = "../defmt" }
 
 [features]
-alloc = []
-avoid-default-panic = []
-ip_in_core = []
+alloc = ["defmt10/alloc"]
+avoid-default-panic = ["defmt10/avoid-default-panic"]
+ip_in_core = ["defmt10/ip_in_core"]
 
 # Encoding feature flags. These should only be set by end-user crates, not by library crates.
 #
@@ -31,26 +33,16 @@ ip_in_core = []
 
 # Raw encoding: All log frames are concatenated and sent over the wire with no framing or compression.
 # This is the fastest CPU-wise, but may end up being slower if the limiting factor is wire speed.
-encoding-raw = []
+encoding-raw = ["defmt10/encoding-raw"]
 
 # rzCOBS encoding: Performs framing on the log frames using reverse-COBS, additionally applying a
 # light compression for data known to contain many zero bytes, like defmt streams.
 # The framing allows the decoder to recover from missing or corrupted data, and start decoding
 # in the middle of a stream, for example when attaching to an already-running device.
-encoding-rzcobs = []
+encoding-rzcobs = ["defmt10/encoding-rzcobs"]
 
 # WARNING: for internal use only, not covered by semver guarantees
-unstable-test = [ "defmt-macros/unstable-test" ]
-
-[dependencies]
-# There is exactly one version of defmt-macros supported in this version of
-# defmt. Although, multiple versions of defmt might use the *same* defmt-macros.
-defmt-macros = { path = "../macros", version = "=1.0.0-alpha" }
-bitflags = "1"
-
-[dev-dependencies]
-rustc_version = "0.4"
-trybuild = "1"
+unstable-test = [ "defmt10/unstable-test" ]
 
 [package.metadata.docs.rs]
 features = [ "alloc" ]

--- a/defmt-03/Cargo.toml
+++ b/defmt-03/Cargo.toml
@@ -14,10 +14,10 @@ name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "0.3.100"
+version = "0.3.100-rc.1"
 
 [dependencies]
-defmt10 = { package = "defmt", version = "1.0.0-alpha", path = "../defmt" }
+defmt10 = { package = "defmt", version = "1.0.0-rc.1", path = "../defmt" }
 
 [features]
 alloc = ["defmt10/alloc"]

--- a/defmt-03/Cargo.toml
+++ b/defmt-03/Cargo.toml
@@ -14,10 +14,10 @@ name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "0.3.100-rc.1"
+version = "0.3.100"
 
 [dependencies]
-defmt10 = { package = "defmt", version = "1.0.0-rc.1", path = "../defmt" }
+defmt10 = { package = "defmt", version = "1", path = "../defmt" }
 
 [features]
 alloc = ["defmt10/alloc"]

--- a/defmt-03/README.md
+++ b/defmt-03/README.md
@@ -1,0 +1,54 @@
+# `defmt`
+
+`defmt` ("de format", short for "deferred formatting") is a highly efficient logging framework that targets resource-constrained devices, like microcontrollers.
+
+For more details about the framework check the book at <https://defmt.ferrous-systems.com>.
+
+This release is a semver-trick compatibility shim that allows packages using `defmt = "0.3"` to inter-operate with packages using `defmt = "1.0"`.
+
+## Setup
+
+### New project
+
+The fastest way to get started with `defmt` is to use our [app-template] to set up a new Cortex-M embedded project.
+
+[app-template]: https://github.com/knurling-rs/app-template
+
+### Existing project
+
+To include `defmt` in your existing project, follow our [Application Setup guide].
+
+[Application Setup guide]: https://defmt.ferrous-systems.com/setup.html
+
+## MSRV
+
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+
+## Support
+
+`defmt` is part of the [Knurling] project, [Ferrous Systems]' effort at
+improving tooling used to develop for embedded systems.
+
+If you think that our work is useful, consider sponsoring it via [GitHub
+Sponsors].
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+[Knurling]: https://knurling.ferrous-systems.com/
+[Ferrous Systems]: https://ferrous-systems.com/
+[GitHub Sponsors]: https://github.com/sponsors/knurling-rs

--- a/defmt-03/src/lib.rs
+++ b/defmt-03/src/lib.rs
@@ -6,6 +6,10 @@
 //!
 //! # Compatibility
 //!
+//! This is a defmt-0.3 compatbility crate. It depends upon `defmt-1.0` and
+//! re-exports the items that were available in `defmt-0.3`. This allows you to
+//! mix defmt-0.3 and defmt-1.0 within the same compilation.
+//!
 //! The `defmt` wire format might change between minor versions. Attempting to
 //! read a defmt stream with an incompatible version will result in an error,
 //! and any tool used to process that stream should first check for a symbol
@@ -15,60 +19,7 @@
 //! Updating your version of defmt might mean you also have to update your
 //! version of `defmt-print` or `defmt-decoder`.
 
-#![cfg_attr(not(feature = "unstable-test"), no_std)]
-// NOTE if you change this URL you'll also need to update all other crates in this repo
-#![doc(html_logo_url = "https://knurling.ferrous-systems.com/knurling_logo_light_text.svg")]
-#![warn(missing_docs)]
-
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
-// This must be in the root lib.rs, otherwise it doesn't appear in the final binary.
-
-/// The defmt ABI and wire format version.
-///
-/// This number has to be updated every time there is a backwards-incompatible change to
-/// - the symbol naming scheme
-/// - the symbol and section layout
-/// - the data encoding / wire format
-#[used]
-#[cfg_attr(target_os = "macos", link_section = ".defmt,end.VERSION")]
-#[cfg_attr(not(target_os = "macos"), link_section = ".defmt.end")]
-#[export_name = "_defmt_version_ = 4"]
-static DEFMT_VERSION: u8 = 0;
-
-#[used]
-#[cfg_attr(target_os = "macos", link_section = ".defmt,end.ENCODING")]
-#[cfg_attr(not(target_os = "macos"), link_section = ".defmt.end")]
-#[cfg_attr(feature = "encoding-raw", export_name = "_defmt_encoding_ = raw")]
-#[cfg_attr(
-    not(feature = "encoding-raw"),
-    export_name = "_defmt_encoding_ = rzcobs"
-)]
-#[allow(missing_docs)]
-#[doc(hidden)]
-pub static DEFMT_ENCODING: u8 = 0;
-
-mod encoding;
-#[doc(hidden)]
-pub mod export;
-mod formatter;
-mod impls;
-#[cfg(all(test, feature = "unstable-test"))]
-mod tests;
-mod traits;
-
-pub use crate::{
-    encoding::Encoder,
-    formatter::{Formatter, Str},
-    impls::adapter::{Debug2Format, Display2Format},
-    traits::{Format, Logger},
-};
-
-#[cfg(all(test, not(feature = "unstable-test")))]
-compile_error!(
-    "to run unit tests enable the `unstable-test` feature, e.g. `cargo t --features unstable-test`"
-);
+#![no_std]
 
 /// Just like the [`core::assert!`] macro but `defmt` is used to log the panic message
 ///
@@ -77,7 +28,7 @@ compile_error!(
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::assert_ as assert;
+pub use defmt10::assert;
 
 /// Just like the [`core::assert_eq!`] macro but `defmt` is used to log the panic message
 ///
@@ -86,7 +37,7 @@ pub use defmt_macros::assert_ as assert;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::assert_eq_ as assert_eq;
+pub use defmt10::assert_eq;
 
 /// Just like the [`core::assert_ne!`] macro but `defmt` is used to log the panic message
 ///
@@ -95,7 +46,7 @@ pub use defmt_macros::assert_eq_ as assert_eq;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::assert_ne_ as assert_ne;
+pub use defmt10::assert_ne;
 
 /// Just like the [`core::debug_assert!`] macro but `defmt` is used to log the panic message
 ///
@@ -104,7 +55,7 @@ pub use defmt_macros::assert_ne_ as assert_ne;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::debug_assert_ as debug_assert;
+pub use defmt10::debug_assert;
 
 /// Just like the [`core::debug_assert_eq!`] macro but `defmt` is used to log the panic message
 ///
@@ -113,7 +64,7 @@ pub use defmt_macros::debug_assert_ as debug_assert;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::debug_assert_eq_ as debug_assert_eq;
+pub use defmt10::debug_assert_eq;
 
 /// Just like the [`core::debug_assert_ne!`] macro but `defmt` is used to log the panic message
 ///
@@ -122,7 +73,7 @@ pub use defmt_macros::debug_assert_eq_ as debug_assert_eq;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::debug_assert_ne_ as debug_assert_ne;
+pub use defmt10::debug_assert_ne;
 
 /// Just like the [`core::unreachable!`] macro but `defmt` is used to log the panic message
 ///
@@ -131,7 +82,7 @@ pub use defmt_macros::debug_assert_ne_ as debug_assert_ne;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::unreachable_ as unreachable;
+pub use defmt10::unreachable;
 
 /// Just like the [`core::todo!`] macro but `defmt` is used to log the panic message
 ///
@@ -140,7 +91,7 @@ pub use defmt_macros::unreachable_ as unreachable;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::todo_ as todo;
+pub use defmt10::todo;
 
 /// Just like the [`core::unimplemented!`] macro but `defmt` is used to log the panic message
 ///
@@ -149,7 +100,7 @@ pub use defmt_macros::todo_ as todo;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::todo_ as unimplemented;
+pub use defmt10::todo as unimplemented;
 
 /// Just like the [`core::panic!`] macro but `defmt` is used to log the panic message
 ///
@@ -158,7 +109,7 @@ pub use defmt_macros::todo_ as unimplemented;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::panic_ as panic;
+pub use defmt10::panic;
 
 /// Unwraps an `Option` or `Result`, panicking if it is `None` or `Err`.
 ///
@@ -192,7 +143,7 @@ pub use defmt_macros::panic_ as panic;
 /// If used, the format string must follow the defmt syntax (documented in [the manual])
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::unwrap;
+pub use defmt10::unwrap;
 
 /// This is an alias for defmt's [`unwrap`] macro which supports messages like std's except.
 /// ```
@@ -206,7 +157,7 @@ pub use defmt_macros::unwrap;
 ///
 /// For the complete documentation see that of defmt's *unwrap* macro.
 // note: Linking to unwrap is broken as of 2024-10-09, it links back to expect
-pub use defmt_macros::unwrap as expect;
+pub use defmt10::unwrap as expect;
 
 /// Overrides the panicking behavior of `defmt::panic!`
 ///
@@ -219,7 +170,7 @@ pub use defmt_macros::unwrap as expect;
 /// # Inter-operation with built-in attributes
 ///
 /// This attribute cannot be used together with the `export_name` or `no_mangle` attributes
-pub use defmt_macros::panic_handler;
+pub use defmt10::panic_handler;
 
 /// Creates an interned string ([`Str`]) from a string literal.
 ///
@@ -234,55 +185,55 @@ pub use defmt_macros::panic_handler;
 /// ```
 ///
 /// [`Str`]: struct.Str.html
-pub use defmt_macros::intern;
+pub use defmt10::intern;
 
 /// Always logs data irrespective of log level.
 ///
 /// Please refer to [the manual] for documentation on the syntax.
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::println;
+pub use defmt10::println;
 
 /// Logs data at *debug* level.
 ///
 /// Please refer to [the manual] for documentation on the syntax.
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::debug;
+pub use defmt10::debug;
 /// Logs data at *error* level.
 ///
 /// Please refer to [the manual] for documentation on the syntax.
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::error;
+pub use defmt10::error;
 /// Logs data at *info* level.
 ///
 /// Please refer to [the manual] for documentation on the syntax.
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::info;
+pub use defmt10::info;
 /// Logs data at *trace* level.
 ///
 /// Please refer to [the manual] for documentation on the syntax.
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::trace;
+pub use defmt10::trace;
 /// Logs data at *warn* level.
 ///
 /// Please refer to [the manual] for documentation on the syntax.
 ///
 /// [the manual]: https://defmt.ferrous-systems.com/macros.html
-pub use defmt_macros::warn;
+pub use defmt10::warn;
 
 /// Just like the [`std::dbg!`] macro but `defmt` is used to log the message at `TRACE` level.
 ///
 /// [`std::dbg!`]: https://doc.rust-lang.org/std/macro.dbg.html
-pub use defmt_macros::dbg;
+pub use defmt10::dbg;
 
 /// Writes formatted data to a [`Formatter`].
 ///
 /// [`Formatter`]: struct.Formatter.html
-pub use defmt_macros::write;
+pub use defmt10::write;
 
 /// Defines the global defmt logger.
 ///
@@ -318,7 +269,7 @@ pub use defmt_macros::write;
 /// ```
 ///
 /// [`Logger`]: trait.Logger.html
-pub use defmt_macros::global_logger;
+pub use defmt10::global_logger;
 
 /// Defines the global timestamp provider for defmt.
 ///
@@ -338,7 +289,7 @@ pub use defmt_macros::global_logger;
 /// static COUNT: AtomicU32 = AtomicU32::new(0);
 /// defmt::timestamp!("{=u32:us}", COUNT.fetch_add(1, Ordering::Relaxed));
 /// ```
-pub use defmt_macros::timestamp;
+pub use defmt10::timestamp;
 
 /// Generates a bitflags structure that can be formatted with defmt.
 ///
@@ -370,98 +321,16 @@ pub use defmt_macros::timestamp;
 /// defmt::info!("Flags::ABC: {}", Flags::ABC);
 /// defmt::info!("Flags::empty(): {}", Flags::empty());
 /// ```
-pub use defmt_macros::bitflags;
+pub use defmt10::bitflags;
 
-#[doc(hidden)] // documented as the `Format` trait instead
-pub use defmt_macros::Format;
+#[doc(inline)]
+pub use defmt10::{Debug2Format, Display2Format, Encoder, Formatter, Str};
 
-// There is no default timestamp format. Instead, the decoder looks for a matching ELF symbol. If
-// absent, timestamps are turned off.
-#[export_name = "__defmt_default_timestamp"]
-fn default_timestamp(_f: Formatter<'_>) {}
+#[doc(inline)]
+pub use defmt10::{Format, Logger};
 
-#[export_name = "__defmt_default_panic"]
-fn default_panic() -> ! {
-    core::panic!()
-}
-
-/// Block until host has read all pending data.
-///
-/// The flush operation will not fail, but might not succeed in flushing _all_ pending data. It is
-/// implemented as a "best effort" operation.
-///
-/// This calls the method `flush` of the used "global [`Logger`]". The logger is likely provided by
-/// [`defmt-rtt`](https://crates.io/crates/defmt-rtt) or [`defmt-itm`](https://crates.io/crates/defmt-itm).
-pub fn flush() {
-    match () {
-        #[cfg(feature = "unstable-test")]
-        () => {
-            // no-op when run on host
-        }
-
-        #[cfg(not(feature = "unstable-test"))]
-        () => {
-            extern "Rust" {
-                fn _defmt_acquire();
-                fn _defmt_flush();
-                fn _defmt_release();
-            }
-            // SAFETY:
-            // * we call these function in the correct order: first acquire the lock, then flush and
-            //   finally release the lock
-            // * these function should be provided by the macro `#[global_logger]` and therefore
-            //   trustworthy to call through FFI-bounds
-            unsafe {
-                _defmt_acquire();
-                _defmt_flush();
-                _defmt_release()
-            }
-        }
-    }
-}
-
-#[cfg(not(feature = "unstable-test"))]
 #[doc(hidden)]
-pub struct IdRanges {
-    pub trace: core::ops::Range<u16>,
-    pub debug: core::ops::Range<u16>,
-    pub info: core::ops::Range<u16>,
-    pub warn: core::ops::Range<u16>,
-    pub error: core::ops::Range<u16>,
-}
+pub use defmt10::export;
 
-#[cfg(not(feature = "unstable-test"))]
-impl IdRanges {
-    pub fn get() -> Self {
-        extern "C" {
-            static __DEFMT_MARKER_TRACE_START: u8;
-            static __DEFMT_MARKER_TRACE_END: u8;
-            static __DEFMT_MARKER_DEBUG_START: u8;
-            static __DEFMT_MARKER_DEBUG_END: u8;
-            static __DEFMT_MARKER_INFO_START: u8;
-            static __DEFMT_MARKER_INFO_END: u8;
-            static __DEFMT_MARKER_WARN_START: u8;
-            static __DEFMT_MARKER_WARN_END: u8;
-            static __DEFMT_MARKER_ERROR_START: u8;
-            static __DEFMT_MARKER_ERROR_END: u8;
-        }
-
-        let trace_start = unsafe { &__DEFMT_MARKER_TRACE_START as *const u8 as u16 };
-        let trace_end = unsafe { &__DEFMT_MARKER_TRACE_END as *const u8 as u16 };
-        let debug_start = unsafe { &__DEFMT_MARKER_DEBUG_START as *const u8 as u16 };
-        let debug_end = unsafe { &__DEFMT_MARKER_DEBUG_END as *const u8 as u16 };
-        let info_start = unsafe { &__DEFMT_MARKER_INFO_START as *const u8 as u16 };
-        let info_end = unsafe { &__DEFMT_MARKER_INFO_END as *const u8 as u16 };
-        let warn_start = unsafe { &__DEFMT_MARKER_WARN_START as *const u8 as u16 };
-        let warn_end = unsafe { &__DEFMT_MARKER_WARN_END as *const u8 as u16 };
-        let error_start = unsafe { &__DEFMT_MARKER_ERROR_START as *const u8 as u16 };
-        let error_end = unsafe { &__DEFMT_MARKER_ERROR_END as *const u8 as u16 };
-        Self {
-            trace: trace_start..trace_end,
-            debug: debug_start..debug_end,
-            info: info_start..info_end,
-            warn: warn_start..warn_end,
-            error: error_start..error_end,
-        }
-    }
-}
+#[doc(inline)]
+pub use defmt10::flush;

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "1.0.0-alpha"
+version = "1.0.0-rc.1"
 
 [features]
 alloc = []
@@ -45,7 +45,7 @@ unstable-test = [ "defmt-macros/unstable-test" ]
 [dependencies]
 # There is exactly one version of defmt-macros supported in this version of
 # defmt. Although, multiple versions of defmt might use the *same* defmt-macros.
-defmt-macros = { path = "../macros", version = "=1.0.0-alpha" }
+defmt-macros = { path = "../macros", version = "=1.0.0-rc.1" }
 bitflags = "1"
 
 [dev-dependencies]

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 [features]
 alloc = []
@@ -45,7 +45,7 @@ unstable-test = [ "defmt-macros/unstable-test" ]
 [dependencies]
 # There is exactly one version of defmt-macros supported in this version of
 # defmt. Although, multiple versions of defmt might use the *same* defmt-macros.
-defmt-macros = { path = "../macros", version = "=1.0.0-rc.1" }
+defmt-macros = { path = "../macros", version = "=1.0.0" }
 bitflags = "1"
 
 [dev-dependencies]

--- a/firmware/defmt-itm/Cargo.toml
+++ b/firmware/defmt-itm/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT OR Apache-2.0"
 name = "defmt-itm"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 cortex-m = "0.7"
 critical-section = "1.2.0"
-defmt = { version = "0.3", path = "../../defmt" }
+defmt = { version = "1.0.0-alpha", path = "../../defmt" }

--- a/firmware/defmt-itm/Cargo.toml
+++ b/firmware/defmt-itm/Cargo.toml
@@ -13,4 +13,4 @@ version = "0.4.0"
 [dependencies]
 cortex-m = "0.7"
 critical-section = "1.2.0"
-defmt = { version = "1.0.0-alpha", path = "../../defmt" }
+defmt = { version = "1.0.0-rc.1", path = "../../defmt" }

--- a/firmware/defmt-itm/Cargo.toml
+++ b/firmware/defmt-itm/Cargo.toml
@@ -13,4 +13,4 @@ version = "0.4.0"
 [dependencies]
 cortex-m = "0.7"
 critical-section = "1.2.0"
-defmt = { version = "1.0.0-rc.1", path = "../../defmt" }
+defmt = { version = "1", path = "../../defmt" }

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-alpha"
+version = "1.0.0-rc.1"
 
 [features]
 disable-blocking-mode = []
 
 [dependencies]
-defmt = { version = "1.0.0-alpha", path = "../../defmt" }
+defmt = { version = "1.0.0-rc.1", path = "../../defmt" }
 critical-section = "1.2"

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 [features]
 disable-blocking-mode = []
 
 [dependencies]
-defmt = { version = "1.0.0-rc.1", path = "../../defmt" }
+defmt = { version = "1", path = "../../defmt" }
 critical-section = "1.2"

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.2"
+version = "1.0.0-alpha"
 
 [features]
 disable-blocking-mode = []
 
 [dependencies]
-defmt = { version = "0.3", path = "../../defmt" }
+defmt = { version = "1.0.0-alpha", path = "../../defmt" }
 critical-section = "1.2"

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.2.0"
 [dependencies]
 cortex-m = "0.7"
 critical-section = "1.2"
-defmt = { version = "0.3", path = "../../defmt" }
+defmt = { version = "1.0.0-alpha", path = "../../defmt" }
 semihosting = { version = "0.1.19", features = ["stdio"] }
 
 [features]

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.2.0"
 [dependencies]
 cortex-m = "0.7"
 critical-section = "1.2"
-defmt = { version = "1.0.0-rc.1", path = "../../defmt" }
+defmt = { version = "1", path = "../../defmt" }
 semihosting = { version = "0.1.19", features = ["stdio"] }
 
 [features]

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-semihosting"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 cortex-m = "0.7"

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -18,3 +18,7 @@ semihosting = { version = "0.1.19", features = ["stdio"] }
 
 [features]
 critical-section-single-core = ["cortex-m/critical-section-single-core"]
+
+[package.metadata.docs.rs]
+rustdoc-args = [ "--cfg=docsrs" ]
+targets = [ "thumbv7em-none-eabihf" ]

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.2.0"
 [dependencies]
 cortex-m = "0.7"
 critical-section = "1.2"
-defmt = { version = "1.0.0-alpha", path = "../../defmt" }
+defmt = { version = "1.0.0-rc.1", path = "../../defmt" }
 semihosting = { version = "0.1.19", features = ["stdio"] }
 
 [features]

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -13,5 +13,5 @@ version = "0.4.0"
 [dependencies]
 cortex-m-rt = "0.7"
 cortex-m-semihosting = "0.5"
-defmt = { version = "1", path = "../../defmt" }
+defmt = { version = "1.0.0-rc.1", path = "../../defmt" }
 defmt-test-macros = { version = "=0.3.2", path = "macros" }

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -13,5 +13,5 @@ version = "0.4.0"
 [dependencies]
 cortex-m-rt = "0.7"
 cortex-m-semihosting = "0.5"
-defmt = { version = "1.0.0-rc.1", path = "../../defmt" }
+defmt = { version = "1", path = "../../defmt" }
 defmt-test-macros = { version = "=0.3.2", path = "macros" }

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT OR Apache-2.0"
 name = "defmt-test"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.3"
+version = "0.4.0"
 
 [dependencies]
 cortex-m-rt = "0.7"
 cortex-m-semihosting = "0.5"
-defmt = { version = "0.3", path = "../../defmt" }
+defmt = { version = "1", path = "../../defmt" }
 defmt-test-macros = { version = "=0.3.2", path = "macros" }

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 name = "panic-probe"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.2"
+version = "1.0.0-alpha"
 
 [dependencies]
 cortex-m = "0.7"
-defmt = { version = "0.3", path = "../../defmt", optional = true }
+defmt = { version = "1.0.0-alpha", path = "../../defmt", optional = true }
 rtt-target = { version = "0.5", optional = true }
 
 

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 name = "panic-probe"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 [dependencies]
 cortex-m = "0.7"
-defmt = { version = "1.0.0-rc.1", path = "../../defmt", optional = true }
+defmt = { version = "1", path = "../../defmt", optional = true }
 rtt-target = { version = "0.5", optional = true }
 
 

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 name = "panic-probe"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-alpha"
+version = "1.0.0-rc.1"
 
 [dependencies]
 cortex-m = "0.7"
-defmt = { version = "1.0.0-alpha", path = "../../defmt", optional = true }
+defmt = { version = "1.0.0-rc.1", path = "../../defmt", optional = true }
 rtt-target = { version = "0.5", optional = true }
 
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.0"
+version = "1.0.0-alpha"
 
 [lib]
 proc-macro = true
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { version = "=0.4.1", path = "../parser" }
+defmt-parser = { version = "=1.0.0-alpha", path = "../parser" }
 proc-macro-error2 = "2"
 proc-macro2 = "1"
 quote = "1"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-alpha"
+version = "1.0.0-rc.1"
 
 [lib]
 proc-macro = true
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { version = "=1.0.0-alpha", path = "../parser" }
+defmt-parser = { version = "=1.0.0-rc.1", path = "../parser" }
 proc-macro-error2 = "2"
 proc-macro2 = "1"
 quote = "1"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 [lib]
 proc-macro = true
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { version = "=1.0.0-rc.1", path = "../parser" }
+defmt-parser = { version = "=1.0.0", path = "../parser" }
 proc-macro-error2 = "2"
 proc-macro2 = "1"
 quote = "1"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-parser"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.1"
+version = "1.0.0-alpha"
 
 [dependencies]
 thiserror = "2"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-parser"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 [dependencies]
 thiserror = "2"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-parser"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-alpha"
+version = "1.0.0-rc.1"
 
 [dependencies]
 thiserror = "2"

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,14 +8,14 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.13"
+version = "1.0.0-alpha"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=0.4.0", path = "../decoder" }
+defmt-decoder = { version = "=1.0.0-alpha", path = "../decoder" }
 log = "0.4"
 notify = "7"
 tokio = { version = "1.38", features = ["full"] }

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,14 +8,14 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=1.0.0-rc.1", path = "../decoder" }
+defmt-decoder = { version = "=1.0.0", path = "../decoder" }
 log = "0.4"
 notify = "7"
 tokio = { version = "1.38", features = ["full"] }

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,14 +8,14 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0-alpha"
+version = "1.0.0-rc.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=1.0.0-alpha", path = "../decoder" }
+defmt-decoder = { version = "=1.0.0-rc.1", path = "../decoder" }
 log = "0.4"
 notify = "7"
 tokio = { version = "1.38", features = ["full"] }

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.0.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { version = "=0.4.0", path = "../decoder" }
+defmt-decoder = { version = "=1.0.0-alpha", path = "../decoder" }

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.0.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { version = "=1.0.0-alpha", path = "../decoder" }
+defmt-decoder = { version = "=1.0.0-rc.1", path = "../decoder" }

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.0.0"
 
 [dependencies]
 anyhow = "1"
-defmt-decoder = { version = "=1.0.0-rc.1", path = "../decoder" }
+defmt-decoder = { version = "=1.0.0", path = "../decoder" }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -162,6 +162,17 @@ fn test_cross(deny_warnings: bool) {
                 },
                 "cross",
             );
+            do_test(
+                || {
+                    run_command(
+                        "cargo",
+                        &["check", "--target", target, "--features", feature],
+                        Some("defmt-03"),
+                        &env,
+                    )
+                },
+                "cross-03",
+            );
         }
     }
 
@@ -293,7 +304,7 @@ fn test_lint() {
     println!("🧪 lint");
 
     // rustfmt
-    for cwd in [None, Some("firmware/")] {
+    for cwd in [None, Some("defmt-03/"), Some("firmware/")] {
         do_test(
             || run_command("cargo", &["fmt", "--", "--check"], cwd, &[]),
             "lint",


### PR DESCRIPTION
Adds a defmt 0.3 proxy, and bumps most crates to 1.0.0.

Tested by patching the radio-app from the exercises to use the `defmt-0.3` folder. That seems to work.

```diff
diff --git a/nrf52-code/radio-app/Cargo.toml b/nrf52-code/radio-app/Cargo.toml
index 78649ece..e959cfdd 100644
--- a/nrf52-code/radio-app/Cargo.toml
+++ b/nrf52-code/radio-app/Cargo.toml
@@ -33,3 +33,6 @@ incremental = false
 lto = "fat"
 opt-level = 3
 overflow-checks = false
+
+[patch.crates-io]
+defmt = { path = "/Users/jonathan/Documents/knurling-rs/defmt/defmt-03" }
diff --git a/nrf52-code/radio-app/src/bin/hello.rs b/nrf52-code/radio-app/src/bin/hello.rs
index 104bd832..60e6c3bd 100644
--- a/nrf52-code/radio-app/src/bin/hello.rs
+++ b/nrf52-code/radio-app/src/bin/hello.rs
@@ -8,6 +8,12 @@ use cortex_m_rt::entry;
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use radio_app as _;

+#[derive(defmt::Format)]
+struct Oblong {
+    width: u32,
+    height: u32
+}
+
 // the custom entry point
 // 👇🏾
 #[entry]
@@ -18,7 +24,8 @@ fn main() -> ! {
     // initializes the peripherals
     dk::init().unwrap();

-    defmt::println!("Hello, world!"); // 👋🏾
+    let ob = Oblong { width: 10, height: 20 };
+    defmt::println!("Hello, world! sq = {:?}", ob); // 👋🏾

     dk::exit();
 }
```

```console
$ cargo run --bin hello -- --probe 1366:1051:001050288864
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.14s
     Running `probe-rs run --chip nRF52840_xxAA --allow-erase-all target/thumbv7em-none-eabihf/debug/hello --probe '1366:1051:001050288864'`
      Erasing ✔ [00:00:00] [####################################################################################################################################################################################################] 8.00 KiB/8.00 KiB @ 29.09 KiB/s (eta 0s )
  Programming ✔ [00:00:00] [####################################################################################################################################################################################################] 8.00 KiB/8.00 KiB @ 24.74 KiB/s (eta 0s )    Finished in 0.628s
<lvl> Hello, world! sq = Oblong { width: 10, height: 20 }
└─ hello::__cortex_m_rt_main @ src/bin/hello.rs:28
<lvl> `dk::exit()` called; exiting ...
└─ dk::exit @ /Users/jonathan/Documents/ferrous-systems/rust-exercises/nrf52-code/boards/dk/src/lib.rs:415
```