### PR TITLE
Introduce feature to disable blocking mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -650,6 +650,7 @@ Initial release
 
 * [#902] Use `core::ptr::addr_of_mut!` instead of `&mut` on mutable statics. No observable change.
 * [#901] `defmt-rtt`: Update to critical-section 1.2
+* [#915] Introduced `disable-blocking-mode` feature
 
 ### [defmt-rtt-v0.4.1] (2024-05-13)
 

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 version = "0.4.1"
 
+[features]
+disable-blocking-mode = []
+
 [dependencies]
 defmt = { version = "0.3", path = "../../defmt" }
 critical-section = "1.2"

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -27,6 +27,7 @@ impl Channel {
         // the host-connection-status is only modified after RAM initialization while the device is
         // halted, so we only need to check it once before the write-loop
         let write = match self.host_is_connected() {
+            _ if cfg!(feature = "disable-blocking-mode") => Self::nonblocking_write,
             true => Self::blocking_write,
             false => Self::nonblocking_write,
         };

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -18,6 +18,9 @@
 //!
 //! `defmt::flush` would also block forever in that case.
 //!
+//! If losing data is not an concern you can disable blocking mode by enabling the feature
+//! `disable-blocking-mode`
+//!
 //! # Critical section implementation
 //!
 //! This crate uses [`critical-section`](https://github.com/rust-embedded/critical-section) to ensure only one thread


### PR DESCRIPTION
Hi,

I've added the feature `disable-blocking-mode` which prevents the host from putting rtt into blocking mode, by which I've got bitten a couple of times because I tend to just unplug my devices. However with blocking mode they will just hang once the buffer is full. Since I do not log too much blocking is not of great benefit to me whereas not having the mcu hang is.