### PR TITLE
Add ':cbor' hint for CBOR Diagnostic Notation (EDN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,7 @@ Initial release
 ### [defmt-decoder-next]
 
 * [#902] Minor change to `impl StreamDecoder` for `Raw` and `Rzcobs`, eliding a lifetime specifier to satisfy Clippy 1.83. No observable change.
+* [#916] Support the ":cbor" display hint, adding new dependency `cbor-edn`.
 
 ### [defmt-decoder-v0.4.0] (2024-11-27)
 
@@ -608,6 +609,9 @@ Initial release
 [defmt-parser-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-parser-v0.1.0
 
 ### [defmt-parser-next]
+
+* [#916] Mark `DisplayHint` as `non_exhaustive`. This is a breaking change.
+* [#916] Add display hint ":cbor", indicating RFC8949 encoded data to be displayed in diagnostic notation.
 
 ### [defmt-parser-v0.4.1] (2024-11-27)
 

--- a/book/src/hints.md
+++ b/book/src/hints.md
@@ -8,19 +8,20 @@ The hint follows the syntax `:Display` and must come after the type within the b
 
 The following display hints are currently supported:
 
-| hint   | name                                                     |
-| :----- | :------------------------------------------------------- |
-| `:x`   | lowercase hexadecimal                                    |
-| `:X`   | uppercase hexadecimal                                    |
-| `:?`   | `core::fmt::Debug`-like                                  |
-| `:b`   | binary                                                   |
-| `:o`   | octal                                                    |
-| `:a`   | ASCII                                                    |
-| `:ms`  | timestamp in seconds (input in milliseconds)             |
-| `:us`  | timestamp in seconds (input in microseconds)             |
-| `:ts`  | timestamp in human-readable time (input in seconds)      |
-| `:tms` | timestamp in human-readable time (input in milliseconds) |
-| `:tus` | timestamp in human-readable time (input in microseconds) |
+| hint    | name                                                     |
+| :------ | :------------------------------------------------------- |
+| `:x`    | lowercase hexadecimal                                    |
+| `:X`    | uppercase hexadecimal                                    |
+| `:?`    | `core::fmt::Debug`-like                                  |
+| `:b`    | binary                                                   |
+| `:o`    | octal                                                    |
+| `:a`    | ASCII                                                    |
+| `:ms`   | timestamp in seconds (input in milliseconds)             |
+| `:us`   | timestamp in seconds (input in microseconds)             |
+| `:ts`   | timestamp in human-readable time (input in seconds)      |
+| `:tms`  | timestamp in human-readable time (input in milliseconds) |
+| `:tus`  | timestamp in human-readable time (input in microseconds) |
+| `:cbor` | CBOR encoded items rendered in Diagnostic Notation (EDN) |
 
 The first 4 display hints resemble what's supported in `core::fmt`, for example:
 
@@ -42,6 +43,22 @@ The ASCII display hint formats byte slices (and arrays) using Rust's byte string
 let bytes = [104, 101, 255, 108, 108, 111];
 
 defmt::info!("{=[u8]:a}", bytes); // -> INFO b"he\xffllo"
+```
+
+The CBOR display hint is useful when CBOR data is in memory, especially before further processing:
+
+``` rust
+# extern crate defmt;
+# fn parse(slice: &[u8]) -> Result<(), ()> {
+#     Ok(())
+# }
+# fn main() -> Result<(), ()> {
+let id_cred = &[0xa1, 0x04, 0x44, 0x6b, 0x69, 0x64, 0x31];
+
+defmt::info!("Peer ID: {=[u8]:cbor}", id_cred); // -> INFO Peer ID: {4: 'kid1'}
+let parsed = parse(id_cred)?;
+# Ok(())
+# }
 ```
 
 ## Alternate printing

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -44,6 +44,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 regex = "1"
 alterable_logger = "1"
+cbor-edn = { version = "0.0.6", default-features = false }
 
 [features]
 # DEPRECATED: noop, will be removed in 1.0

--- a/decoder/src/frame.rs
+++ b/decoder/src/frame.rs
@@ -399,6 +399,16 @@ impl<'t> Frame<'t> {
                 }
                 buf.push(']');
             }
+            Some(DisplayHint::Cbor) => {
+                use core::fmt::Write;
+                let parsed = cbor_edn::Sequence::from_cbor(bytes);
+                match parsed {
+                    Ok(parsed) => buf.write_str(&parsed.serialize())?,
+                    Err(err) => {
+                        write!(buf, "invalid CBOR (error: {}, bytes: {:02x?})", err, bytes)?
+                    }
+                }
+            }
             _ => write!(buf, "{bytes:?}")?,
         }
         Ok(())

--- a/parser/src/display_hint.rs
+++ b/parser/src/display_hint.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 /// All display hints
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DisplayHint {
     NoHint {
         zero_pad: usize,

--- a/parser/src/display_hint.rs
+++ b/parser/src/display_hint.rs
@@ -40,6 +40,17 @@ pub enum DisplayHint {
         disambiguator: String,
         crate_name: Option<String>,
     },
+    /// `:cbor`: There is CBOR data encoded in those bytes, to be shown in diagnostic notation.
+    ///
+    /// Technically, the byte string interpreted as a CBOR sequence, and shown in the diagnostic
+    /// notation of a sequence. That is identical to processing a single CBOR item if there is just
+    /// one present, but also allows reporting multiple items from consecutive memory; diagnostic
+    /// notation turns those into comma separated items.
+    // Should we have a flag to say "do a more display style stringification" (like, if you
+    // recognize `54([64,h'20010db8'])`, don't show "IP'2001:db8::/64'" but just "2001:db8::64")?
+    // Should we allow additional params that give a CDDL that further guides processing (like,
+    // when data is not tagged but the shape is known for processing anyway)?
+    Cbor,
     /// Display hints currently not supported / understood
     Unknown(String),
 }
@@ -108,6 +119,7 @@ impl DisplayHint {
             },
             "iso8601ms" => DisplayHint::ISO8601(TimePrecision::Millis),
             "iso8601s" => DisplayHint::ISO8601(TimePrecision::Seconds),
+            "cbor" => DisplayHint::Cbor,
             "?" => DisplayHint::Debug,
             _ => return None,
         })


### PR DESCRIPTION
I often find myself sending CBOR (a format for standardized data interchange with embedded devices; binary, using a superset of JSON's data model) through defmt. CBOR comes with a human-readable format (that is a superset of JSON's serialization), which is designed with human usability and not embedded devices in mind. The diagnostic notation is exactly capable of round-tripping binary data to a human readable form and back to binary.

Currently, the best way to send CBOR over defmt is in `{=[u8]:02x}`, so that output such as `a1, 04, 41, 2b` can be copy-pasted into the right side of https://cbor.me/, so that after pressing the right-to-left green button, it shows what that means: `{4: h'2B'}`. Deriving `Format` on parsed items is an alternative, but it has severe downsides of decreasing severity:
1. it does not work on parsing failures (eg. when there are mandatory-to-understand fields in the data item that the parsing struct does not have),

<details><summary>more reasons</summary>

2. it discards data that the parsing struct ignores (eg. because it is optional-to-understand fields in the data),
3. it is verbose on the wire (what is a single compact 4-byte string in the example becomes several short string references interspersed with chunks of data from the compact full CBOR item)
4. deriving `Format` shows the structure of the parsed item, and manually implementing it to look like CBOR EDN again is manual work (and moreover, there may be situations in which one would *want* to see the struct's view rather than the original data view)

</details>

This PR proposes a new hint, `:cbor`, to defmt. If the same data `[a1, 04, 41, 2b]` is passed into `{=[u8]:cbor}`, the output is then `{4: h'2B'}` on display right away, which a developer can make better use of.

Note that this is *not* trying to hard-code an exception to the design choice that we don't take types that then need host knowledge of the type: This is not a concrete type, but a format of data serialization. It can be used with serialized data from a large set of CBOR serializing crates, and a large set of protocols and their implementations in types, using a single mechanism.

### Example code

```rust
trace!("Evaluating peer's credenital {=[u8]:cbor}", id_cred_x.as_full_value());
```

Output:

```
TRACE Evaluating peer's credenital {4: h'2b'}
[...]
TRACE Evaluating peer's credenital {14: {2: "me", 8: {1: {1: 2, 2: h'2b', -1: 1, -2: h'c0112830c95d49eaa15138c1160d29f45eb2bebeb0f544c326b05cd58e43fc82', -3: h'30'}}}}
```

### PR status

This is a working draft, but a bit minimal in that
* the error handling could be prettier and better thought-through
* I haven't even checked yet whether there are tests for all this or how they should be run
* the handling of empty CBOR sequences could be done better than just showing nothing
* so far this only works with `{=[u8]:cbor}` and not with `{:cbor}` -- maybe that's OK, maybe I'd just need to find the right spot in the code to put the code in (which will then need refactoring into a dedicated function)

I still ask for review now already because while I've seen some slight positive reaction on the Rust Embedded channel, I don't want to sink too much time in here if the project does not want to go this way at all.