### PR TITLE
Add one job to mark as required for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,3 +156,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
       - name: Run backward compatibility test
         run: cargo xtask test-backcompat
+
+  ci-success:
+    name: CI finished successfully
+    runs-on: ubuntu-latest
+    if: success()
+    needs:
+        - host
+        - cross
+        - cargo-deny
+        - lint
+        - ui
+        - mdbook
+        - qemu-snapshot
+        - backcompat
+    steps:
+        - name: Mark the build as successful
+          run: exit 0


### PR DESCRIPTION
Instead of marking all individual jobs as required in the branch protection rules we can mark this one job, which depends on all other jobs, as required.