### PR TITLE
Don't install "qemu" package - it's gone on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install QEMU_TARGET
         run: rustup target add ${{ env.QEMU_TARGET }}
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
+        run: sudo apt-get update && sudo apt-get install qemu-system-arm
       - name: Run QEMU snapshot tests
         run: cargo xtask test-snapshot
 
@@ -153,6 +153,6 @@ jobs:
       - name: Install QEMU_TARGET
         run: rustup target add ${{ env.QEMU_TARGET }}
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install qemu qemu-system-arm
+        run: sudo apt-get update && sudo apt-get install qemu-system-arm
       - name: Run backward compatibility test
         run: cargo xtask test-backcompat


### PR DESCRIPTION
Not sure what the qemu package used to do, but Ubuntu 24.04 doesn't have it so this PR doesn't install it. Just leaves `qemu-system-arm`.