### PR TITLE
make Format trait dyn compatible

### DIFF
--- a/defmt/src/export/mod.rs
+++ b/defmt/src/export/mod.rs
@@ -185,7 +185,13 @@ pub fn u8_array(a: &[u8]) {
 
 // NOTE: This is passed `&[u8; N]` – it's just coerced to a slice.
 pub fn fmt_array<T: Format>(a: &[T]) {
-    fmt_slice(a)
+    if let Some((first, remainder)) = a.split_first() {
+        istr(&first._format_tag());
+        first._format_data();
+        for value in remainder {
+            value._format_data();
+        }
+    }
 }
 
 /// Implementation detail

--- a/defmt/src/export/mod.rs
+++ b/defmt/src/export/mod.rs
@@ -135,16 +135,21 @@ pub fn panic() -> ! {
 
 /// Implementation detail
 pub fn fmt<T: Format + ?Sized>(f: &T) {
-    istr(&T::_format_tag());
+    istr(&f._format_tag());
     f._format_data();
 }
 
 /// Implementation detail
 pub fn fmt_slice<T: Format>(values: &[T]) {
-    usize(&values.len());
-    istr(&T::_format_tag());
-    for value in values {
-        value._format_data();
+    if let Some((first, remainder)) = values.split_first() {
+        usize(&values.len());
+        istr(&first._format_tag());
+        first._format_data();
+        for value in remainder {
+            value._format_data();
+        }
+    } else {
+        usize(&0);
     }
 }
 
@@ -180,10 +185,7 @@ pub fn u8_array(a: &[u8]) {
 
 // NOTE: This is passed `&[u8; N]` – it's just coerced to a slice.
 pub fn fmt_array<T: Format>(a: &[T]) {
-    istr(&T::_format_tag());
-    for value in a {
-        value._format_data();
-    }
+    fmt_slice(a)
 }
 
 /// Implementation detail

--- a/defmt/src/export/traits.rs
+++ b/defmt/src/export/traits.rs
@@ -44,7 +44,7 @@ impl Format for NoneError {
         unreachable!();
     }
 
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         defmt_macros::internp!("Unwrap of a None option value")
     }
 

--- a/defmt/src/impls/adapter.rs
+++ b/defmt/src/impls/adapter.rs
@@ -33,7 +33,7 @@ impl<T: fmt::Debug + ?Sized> fmt::Debug for Debug2Format<'_, T> {
 impl<T: fmt::Debug + ?Sized> Format for Debug2Format<'_, T> {
     default_format!();
 
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         defmt_macros::internp!("{=__internal_Debug}")
     }
 
@@ -77,7 +77,7 @@ impl<T: fmt::Display + ?Sized> fmt::Display for Display2Format<'_, T> {
 impl<T: fmt::Display + ?Sized> Format for Display2Format<'_, T> {
     default_format!();
 
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         defmt_macros::internp!("{=__internal_Display}")
     }
 

--- a/defmt/src/impls/arrays.rs
+++ b/defmt/src/impls/arrays.rs
@@ -10,7 +10,7 @@ macro_rules! arrays {
             default_format!();
 
             #[inline]
-            fn _format_tag() -> Str {
+            fn _format_tag(&self) -> Str {
                 match N {
                     $(
                         $len => internp!($fmt),

--- a/defmt/src/impls/core_/cell.rs
+++ b/defmt/src/impls/core_/cell.rs
@@ -16,7 +16,7 @@ where
     default_format!();
 
     #[inline]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         internp!("RefCell {{ value: <borrowed> }}|RefCell {{ value: {=?} }}")
     }
 
@@ -26,7 +26,7 @@ where
             Err(_) => export::u8(&0),
             Ok(x) => {
                 export::u8(&1);
-                export::istr(&T::_format_tag());
+                export::istr(&self._format_tag());
                 x._format_data()
             }
         }

--- a/defmt/src/impls/core_/cell.rs
+++ b/defmt/src/impls/core_/cell.rs
@@ -26,7 +26,7 @@ where
             Err(_) => export::u8(&0),
             Ok(x) => {
                 export::u8(&1);
-                export::istr(&self._format_tag());
+                export::istr(&x._format_tag());
                 x._format_data()
             }
         }

--- a/defmt/src/impls/core_/mod.rs
+++ b/defmt/src/impls/core_/mod.rs
@@ -26,7 +26,7 @@ where
     default_format!();
 
     #[inline]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         internp!("None|Some({=?})")
     }
 
@@ -36,7 +36,7 @@ where
             None => export::u8(&0),
             Some(x) => {
                 export::u8(&1);
-                export::istr(&T::_format_tag());
+                export::istr(&self._format_tag());
                 x._format_data()
             }
         }
@@ -51,7 +51,7 @@ where
     default_format!();
 
     #[inline]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         internp!("Err({=?})|Ok({=?})")
     }
 
@@ -60,12 +60,12 @@ where
         match self {
             Err(e) => {
                 export::u8(&0);
-                export::istr(&E::_format_tag());
+                export::istr(&e._format_tag());
                 e._format_data()
             }
             Ok(x) => {
                 export::u8(&1);
-                export::istr(&T::_format_tag());
+                export::istr(&x._format_tag());
                 x._format_data()
             }
         }
@@ -76,7 +76,7 @@ impl<T> Format for core::marker::PhantomData<T> {
     default_format!();
 
     #[inline]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         internp!("PhantomData")
     }
 
@@ -88,7 +88,7 @@ impl Format for core::convert::Infallible {
     default_format!();
 
     #[inline]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         unreachable!();
     }
 

--- a/defmt/src/impls/core_/mod.rs
+++ b/defmt/src/impls/core_/mod.rs
@@ -36,7 +36,7 @@ where
             None => export::u8(&0),
             Some(x) => {
                 export::u8(&1);
-                export::istr(&self._format_tag());
+                export::istr(&x._format_tag());
                 x._format_data()
             }
         }

--- a/defmt/src/impls/mod.rs
+++ b/defmt/src/impls/mod.rs
@@ -2,7 +2,7 @@ macro_rules! default_format {
     () => {
         #[inline]
         fn format(&self, _fmt: Formatter) {
-            crate::export::istr(&Self::_format_tag());
+            crate::export::istr(&self._format_tag());
             self._format_data();
         }
     };
@@ -16,8 +16,8 @@ macro_rules! delegate_format {
         }
 
         #[inline]
-        fn _format_tag() -> Str {
-            <$ty as Format>::_format_tag()
+        fn _format_tag(&$self_) -> Str {
+            <$ty as Format>::_format_tag($val)
         }
 
         #[inline]

--- a/defmt/src/impls/primitives.rs
+++ b/defmt/src/impls/primitives.rs
@@ -8,7 +8,7 @@ macro_rules! prim {
             default_format!();
 
             #[inline]
-            fn _format_tag() -> Str {
+            fn _format_tag(&self) -> Str {
                 internp!($fmt)
             }
 
@@ -46,7 +46,7 @@ where
     default_format!();
 
     #[inline]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         internp!("{=[?]}")
     }
 

--- a/defmt/src/impls/tuples.rs
+++ b/defmt/src/impls/tuples.rs
@@ -28,7 +28,7 @@ macro_rules! tuple {
             fn _format_data(&self) {
                 let ($(ref $name,)+) = *self;
                 $(
-                    export::istr(&self._format_tag());
+                    export::istr(&$name._format_tag());
                     $name._format_data();
                 )+
             }

--- a/defmt/src/impls/tuples.rs
+++ b/defmt/src/impls/tuples.rs
@@ -5,7 +5,7 @@ impl Format for () {
     default_format!();
 
     #[inline]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         internp!("()")
     }
 
@@ -19,7 +19,7 @@ macro_rules! tuple {
             default_format!();
 
             #[inline]
-            fn _format_tag() -> Str {
+            fn _format_tag(&self) -> Str {
                 internp!($format)
             }
 
@@ -28,7 +28,7 @@ macro_rules! tuple {
             fn _format_data(&self) {
                 let ($(ref $name,)+) = *self;
                 $(
-                    export::istr(&$name::_format_tag());
+                    export::istr(&self._format_tag());
                     $name._format_data();
                 )+
             }

--- a/defmt/src/traits.rs
+++ b/defmt/src/traits.rs
@@ -48,7 +48,7 @@ pub trait Format {
     fn format(&self, fmt: Formatter);
 
     #[doc(hidden)]
-    fn _format_tag() -> Str {
+    fn _format_tag(&self) -> Str {
         internp!("{=__internal_FormatSequence}")
     }
 

--- a/defmt/tests/encode.rs
+++ b/defmt/tests/encode.rs
@@ -44,7 +44,7 @@ fn inc(index: u16, n: u16) -> u16 {
 }
 
 fn write_format<T: Format + ?Sized>(val: &T) {
-    defmt::export::istr(&T::_format_tag());
+    defmt::export::istr(&val._format_tag());
     val._format_data();
 }
 

--- a/defmt/tests/encode.rs
+++ b/defmt/tests/encode.rs
@@ -557,6 +557,15 @@ fn slice() {
             23u8,             // val[0]
             42u8,             // val[1]
         ],
+    );
+
+    let val: &[u8] = &[];
+    check_format!(
+        val,
+        [
+            inc(index, 2),    // "{=[?]}"
+            val.len() as u32, // length
+        ],
     )
 }
 
@@ -737,7 +746,6 @@ fn format_arrays() {
         &array,
         [
             index,         // "{=[?;0]}"
-            inc(index, 1), // "{=u16}"
         ]
     );
 

--- a/macros/src/derives/format.rs
+++ b/macros/src/derives/format.rs
@@ -36,7 +36,7 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
                 defmt::unreachable!()
             }
 
-            fn _format_tag() -> defmt::Str {
+            fn _format_tag(&self) -> defmt::Str {
                 #format_tag
             }
 

--- a/macros/src/items/bitflags.rs
+++ b/macros/src/items/bitflags.rs
@@ -45,7 +45,7 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
                 defmt::unreachable!()
             }
 
-            fn _format_tag() -> defmt::Str {
+            fn _format_tag(&self) -> defmt::Str {
                 #format_tag
             }
 


### PR DESCRIPTION
* `Format::_format_tag()` -> `Format::_format_tag(&self)`
* change the wire format for empty slices a `usize(0)`
* change the wire format for empty arrays to be empty

closes: #861