### PR TITLE
wire format: omit the inner type tag for empty slices and arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 ### [defmt-next]
 
 * [#914] Add cargo-deny as a CI action to check crate security and licensing
+* [#929] Change the wire format to omit the inner type tag for empty slices and empty arrays.
 
 ### [defmt-v0.3.10] (2024-11-29)
 

--- a/decoder/src/decoder.rs
+++ b/decoder/src/decoder.rs
@@ -72,6 +72,10 @@ impl<'t, 'b> Decoder<'t, 'b> {
         &mut self,
         num_elements: usize,
     ) -> Result<Vec<FormatSliceElement<'t>>, DecodeError> {
+        if num_elements == 0 {
+            return Ok(Vec::new());
+        }
+
         let format = self.get_format()?;
         let is_enum = format.contains('|');
 

--- a/decoder/src/decoder.rs
+++ b/decoder/src/decoder.rs
@@ -72,22 +72,21 @@ impl<'t, 'b> Decoder<'t, 'b> {
         &mut self,
         num_elements: usize,
     ) -> Result<Vec<FormatSliceElement<'t>>, DecodeError> {
-        if num_elements == 0 {
-            return Ok(Vec::new());
-        }
-
-        let format = self.get_format()?;
-        let is_enum = format.contains('|');
-
         let mut elements = Vec::with_capacity(num_elements);
-        for _i in 0..num_elements {
-            let format = if is_enum {
-                self.get_variant(format)?
-            } else {
-                format
-            };
-            let args = self.decode_format(format)?;
-            elements.push(FormatSliceElement { format, args });
+
+        if num_elements > 0 {
+            let format = self.get_format()?;
+            let is_enum = format.contains('|');
+
+            for _i in 0..num_elements {
+                let format = if is_enum {
+                    self.get_variant(format)?
+                } else {
+                    format
+                };
+                let args = self.decode_format(format)?;
+                elements.push(FormatSliceElement { format, args });
+            }
         }
 
         Ok(elements)

--- a/defmt/src/export/mod.rs
+++ b/defmt/src/export/mod.rs
@@ -142,6 +142,9 @@ pub fn fmt<T: Format + ?Sized>(f: &T) {
 /// Implementation detail
 pub fn fmt_slice<T: Format>(values: &[T]) {
     usize(&values.len());
+    if values.is_empty() {
+        return;
+    }
     istr(&T::_format_tag());
     for value in values {
         value._format_data();
@@ -180,6 +183,9 @@ pub fn u8_array(a: &[u8]) {
 
 // NOTE: This is passed `&[u8; N]` – it's just coerced to a slice.
 pub fn fmt_array<T: Format>(a: &[T]) {
+    if a.is_empty() {
+        return;
+    }
     istr(&T::_format_tag());
     for value in a {
         value._format_data();

--- a/defmt/src/export/mod.rs
+++ b/defmt/src/export/mod.rs
@@ -142,13 +142,7 @@ pub fn fmt<T: Format + ?Sized>(f: &T) {
 /// Implementation detail
 pub fn fmt_slice<T: Format>(values: &[T]) {
     usize(&values.len());
-    if values.is_empty() {
-        return;
-    }
-    istr(&T::_format_tag());
-    for value in values {
-        value._format_data();
-    }
+    fmt_array(values);
 }
 
 /// Implementation detail

--- a/defmt/tests/encode.rs
+++ b/defmt/tests/encode.rs
@@ -557,7 +557,16 @@ fn slice() {
             23u8,             // val[0]
             42u8,             // val[1]
         ],
-    )
+    );
+
+    let val: &[u8] = &[];
+    check_format!(
+        val,
+        [
+            inc(index, 2),    // "{=[?]}"
+            val.len() as u32, // length
+        ],
+    );
 }
 
 #[test]
@@ -737,7 +746,6 @@ fn format_arrays() {
         &array,
         [
             index,         // "{=[?;0]}"
-            inc(index, 1), // "{=u16}"
         ]
     );
 


### PR DESCRIPTION
When serializing a zero-length slice/array, the item type tag is currently always emitted.
That doesn't need to be the case. Removing it shortens the wire format (empty slices tend to be relatively common).

* [ ] Wire format bump

Originally this came about as a core part of #926 (making `Format` `dyn` compatible) which ultimately didn't pan out for other reasons. It still looks like a useful improvement independent of that PR.