### PR TITLE
clarify setup for static libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#935] Add note in book's setup chapter to clarify staticlib setup
 * [#914] Add cargo-deny as a CI action to check crate security and licensing
 
 ### [defmt-v0.3.10] (2024-11-29)

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -36,7 +36,7 @@ rustflags = [
 
 > Note :
 > If you intend on linking your project as a **static library** the linkerscript contents should be applied to the final binary.
-> Applying `defmt.x` to the static lib has no effect.
+> Adding the `-C link-arg=` option to static libraries has no effect because they are only archived, not linked.
 
 ### `#[global_logger]`
 

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -34,6 +34,10 @@ rustflags = [
 ]
 ```
 
+> Note :
+> If you intend on linking your project as a **static library** the linkerscript contents should be applied to the final binary.
+> Applying `defmt.x` to the static lib has no effect.
+
 ### `#[global_logger]`
 
 The application must link to or define a `global_logger`.


### PR DESCRIPTION
Applying the defmt linker args to a cargo package which produces a static lib does not yield any warning.
A user attempting to use this as a module of a larger C project may be surprised to not receive any logs.

After dealing with this issue myself I think its worth putting this into a somewhat prominent user guide section as the final binary gets built and the issue isn't immediately obvious.