### PR TITLE
add support for `#[defmt(transparent)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#937]: add support for `#[defmt(transparent)]` on `Format` derive
 * [#959]: Missing "unstable-test" cfg in tests module
 * [#956]: Link LICENSE-* in the crate folder
 * [#955]: Allow using the `defmt/alloc` feature on bare metal ESP32-S2

--- a/defmt/tests/derive-bounds.rs
+++ b/defmt/tests/derive-bounds.rs
@@ -34,3 +34,18 @@ enum Quux<T: Foo> {
 #[derive(defmt::Format)]
 #[defmt(crate = defmt2)]
 struct Quz;
+
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+#[allow(dead_code)]
+enum TransparentEnum<T: Foo> {
+    Quz(Quz),
+    Quux(Quux<T>),
+    Baz(Baz<T>),
+    U16(u16),
+}
+
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+#[allow(dead_code)]
+struct Transparent<T: Foo>(Quux<T>);

--- a/defmt/tests/ui/derive-transparent-empty.rs
+++ b/defmt/tests/ui/derive-transparent-empty.rs
@@ -1,0 +1,16 @@
+fn main() {}
+
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+enum Empty {}
+
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+struct Unit;
+
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+enum UnitVariants {
+    Foo,
+    Bar,
+}

--- a/defmt/tests/ui/derive-transparent-empty.stderr
+++ b/defmt/tests/ui/derive-transparent-empty.stderr
@@ -1,0 +1,29 @@
+error: proc-macro derive panicked
+ --> tests/ui/derive-transparent-empty.rs:7:10
+  |
+7 | #[derive(defmt::Format)]
+  |          ^^^^^^^^^^^^^
+  |
+  = help: message: called `Option::unwrap()` on a `None` value
+
+error: Transparent format can only be applied when all variants have exactly one field.
+  --> tests/ui/derive-transparent-empty.rs:11:10
+   |
+11 | #[derive(defmt::Format)]
+   |          ^^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0004]: non-exhaustive patterns: type `&&Empty` is non-empty
+ --> tests/ui/derive-transparent-empty.rs:3:10
+  |
+3 | #[derive(defmt::Format)]
+  |          ^^^^^^^^^^^^^
+  |
+note: `Empty` defined here
+ --> tests/ui/derive-transparent-empty.rs:5:6
+  |
+5 | enum Empty {}
+  |      ^^^^^
+  = note: the matched value is of type `&&Empty`
+  = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/defmt/tests/ui/derive-transparent-multiple-fields.rs
+++ b/defmt/tests/ui/derive-transparent-multiple-fields.rs
@@ -1,0 +1,14 @@
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+enum A {
+    Invalid { foo: u8, bar: i8 },
+}
+
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+struct Foo {
+    foo: u8,
+    bar: i8,
+}
+
+fn main() {}

--- a/defmt/tests/ui/derive-transparent-multiple-fields.stderr
+++ b/defmt/tests/ui/derive-transparent-multiple-fields.stderr
@@ -1,0 +1,7 @@
+error: Transparent format can only be applied when all variants have exactly one field.
+ --> tests/ui/derive-transparent-multiple-fields.rs:1:10
+  |
+1 | #[derive(defmt::Format)]
+  |          ^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macros/src/derives/format.rs
+++ b/macros/src/derives/format.rs
@@ -1,7 +1,8 @@
+use codegen::DefmtAttr;
 use proc_macro::TokenStream;
 use proc_macro_error2::{abort, abort_call_site};
-use quote::{quote, ToTokens};
-use syn::{parse_macro_input, parse_quote, Data, DeriveInput};
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput};
 
 mod codegen;
 
@@ -14,9 +15,18 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
         data,
     } = parse_macro_input!(input as DeriveInput);
 
-    let defmt_path = match defmt_crate_path(&attrs) {
-        Ok(defmt_path) => defmt_path,
-        Err(e) => abort!(e),
+    let DefmtAttr {
+        transparent,
+        defmt_path,
+    } = match attrs
+        .iter()
+        .find(|meta| meta.path().is_ident("defmt"))
+        .cloned()
+        .map(DefmtAttr::try_from)
+        .unwrap_or_else(|| Ok(DefmtAttr::default()))
+    {
+        Ok(maybe_attr) => maybe_attr,
+        Err(err) => abort!(err),
     };
 
     let encode_data = match &data {
@@ -58,24 +68,4 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
         }
     )
     .into()
-}
-
-fn defmt_crate_path(attrs: &[syn::Attribute]) -> Result<syn::Path, syn::Error> {
-    let mut defmt_path = parse_quote!(defmt);
-    let res = attrs
-        .iter()
-        .filter(|attr| attr.path().is_ident("defmt"))
-        .try_for_each(|attr| {
-            attr.parse_nested_meta(|meta| {
-                if meta.path.get_ident().is_some_and(|ident| ident == "crate") {
-                    meta.input.parse::<syn::Token![=]>()?;
-                    defmt_path = meta.input.parse::<syn::Path>()?;
-                    Ok(())
-                } else {
-                    let path = meta.path.to_token_stream().to_string().replace(' ', "");
-                    Err(meta.error(format_args!("unknown defmt attribute `{path}`")))
-                }
-            })
-        });
-    res.map(|()| defmt_path)
 }

--- a/macros/src/derives/format.rs
+++ b/macros/src/derives/format.rs
@@ -2,7 +2,7 @@ use codegen::DefmtAttr;
 use proc_macro::TokenStream;
 use proc_macro_error2::{abort, abort_call_site};
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput};
+use syn::{parse_macro_input, parse_quote, Data, DeriveInput, Generics, Ident};
 
 mod codegen;
 
@@ -28,6 +28,10 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
         Ok(maybe_attr) => maybe_attr,
         Err(err) => abort!(err),
     };
+
+    if transparent {
+        return expand_transparent(ident, data, generics, defmt_path);
+    }
 
     let encode_data = match &data {
         Data::Enum(data) => codegen::encode_enum_data(&ident, data, &defmt_path),
@@ -67,5 +71,67 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
             }
         }
     )
+    .into()
+}
+
+pub(crate) fn expand_transparent(
+    ident: Ident,
+    data: Data,
+    mut generics: Generics,
+    defmt_path: syn::Path,
+) -> TokenStream {
+    let mut where_clause = generics.make_where_clause().clone();
+    let (impl_generics, ty_generics, ..) = generics.split_for_impl();
+
+    let mut member_types: Vec<syn::Type> = vec![];
+    let body = match data {
+        Data::Enum(data) => {
+            let match_arms = data.variants.iter().map(|v| -> syn::Arm {
+                let variant_name = &v.ident;
+                if v.fields.len() != 1 {
+                    abort_call_site!("Transparent format can only be applied when all variants have exactly one field.")
+                }
+
+                member_types.push(v.fields.iter().next().unwrap().ty.clone());
+                let field = v.fields.members().next().unwrap();
+                parse_quote! {
+                    Self::#variant_name{ #field: inner } => inner.format(f)
+                }
+            });
+            quote! {
+                match &self {
+                    #( #match_arms, )*
+                }
+            }
+        }
+        Data::Struct(data) => {
+            if !data.fields.len() == 1 {
+                abort_call_site!(
+                    "Transparent format can only be applied to structs with one field."
+                );
+            }
+
+            member_types.push(data.fields.iter().next().unwrap().ty.clone());
+            let members = data.fields.members();
+            quote! {
+                #(self.#members.format(f));*
+            }
+        }
+        Data::Union(_) => abort_call_site!("`#[derive(Format)]` does not support unions"),
+    };
+
+    let generic_bounds: Vec<syn::WherePredicate> = member_types
+        .iter()
+        .map(|ty| parse_quote! { #ty: #defmt_path::Format })
+        .collect();
+    where_clause.predicates.extend(generic_bounds);
+
+    quote! {
+        impl #impl_generics #defmt_path::Format for #ident #ty_generics #where_clause {
+            fn format(&self, f: #defmt_path::Formatter) {
+                #body
+            }
+        }
+    }
     .into()
 }


### PR DESCRIPTION
Fixes: #934, inspired by https://defmt.ferrous-systems.com/format#newtypes

Here's a proposition implementing a new attribute `#[defmt(transparent)]` for newtypes and enums (where each variant has only one field).

I tested using
```rs
#[derive(defmt::Format)]
#[defmt(transparent)]
struct Unnamed(u8);
#[derive(defmt::Format)]
#[defmt(transparent)]
struct Named {
    foo: u8,
}
#[derive(defmt::Format)]
#[defmt(transparent)]
enum Mixed {
    Unnamed(u8),
    Named { foo: u8 },
    StructUnnamed(Unnamed),
    StructNamed { named: Named },
}
```

<details>
<summary> generated code </summary>

```rs
#[defmt(transparent)]
struct Unnamed(u8);
impl defmt::Format for Unnamed {
    fn format(&self, f: defmt::Formatter) {
        self.0.format(f)
    }
}
#[defmt(transparent)]
struct Named {
    foo: u8,
}
impl defmt::Format for Named {
    fn format(&self, f: defmt::Formatter) {
        self.foo.format(f)
    }
}
#[defmt(transparent)]
enum Mixed {
    Unnamed(u8),
    Named { foo: u8 },
    StructUnnamed(Unnamed),
    StructNamed { named: Named },
}
impl defmt::Format for Mixed {
    fn format(&self, f: defmt::Formatter) {
        match &self {
            Self::Unnamed { 0: inner } => inner.format(f),
            Self::Named { foo: inner } => inner.format(f),
            Self::StructUnnamed { 0: inner } => inner.format(f),
            Self::StructNamed { named: inner } => inner.format(f),
        }
    }
}
```

</details>

Waiting for suggestion's approbation before finishing the PR (docs, changelog, generic super trait requirements etc).

