### PR TITLE
defmt-semihosting: use critical_section for synchronization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -705,6 +705,8 @@ Initial release
 
 ### [defmt-semihosting-next]
 
+* [#943] use critical_section for synchronization.
+
 ### [defmt-semihosting-v0.1.0] (2024-11-27)
 
 Initial release

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -15,3 +15,6 @@ defmt = { version = "0.3", path = "../../defmt" }
 cortex-m = "0.7"
 cortex-m-semihosting = "0.5"
 critical-section = "1.2"
+
+[features]
+critical-section-single-core = ["cortex-m/critical-section-single-core"]

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -14,3 +14,4 @@ version = "0.1.0"
 defmt = { version = "0.3", path = "../../defmt" }
 cortex-m = "0.7"
 cortex-m-semihosting = "0.5"
+critical-section = "1.2"

--- a/firmware/defmt-semihosting/src/lib.rs
+++ b/firmware/defmt-semihosting/src/lib.rs
@@ -4,6 +4,19 @@
 //!
 //! WARNING using `cortex_m_semihosting`'s `hprintln!` macro or `HStdout` API will corrupt `defmt`
 //! log frames so don't use those APIs.
+//!
+//! # Critical section implementation
+//!
+//! This crate uses [`critical-section`](https://github.com/rust-embedded/critical-section) to ensure only one thread
+//! is writing to the buffer at a time. You must import a crate that provides a `critical-section` implementation
+//! suitable for the current target. See the `critical-section` README for details.
+//!
+//! For example, for single-core privileged-mode Cortex-M targets, you can add the following to your Cargo.toml.
+//!
+//! ```toml
+//! [dependencies]
+//! cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
+//! ```
 
 #![no_std]
 // nightly warns about static_mut_refs, but 1.76 (our MSRV) does not know about

--- a/firmware/defmt-semihosting/src/lib.rs
+++ b/firmware/defmt-semihosting/src/lib.rs
@@ -12,7 +12,6 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use cortex_m::{interrupt, register};
 use cortex_m_semihosting::hio;
 
 #[defmt::global_logger]

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -14,7 +14,7 @@ harness = false
 defmt = { path = "../../defmt" }
 defmt-semihosting = { path = "../defmt-semihosting" }
 defmt-test = { path = "../defmt-test" }
-cortex-m = "0.7"
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
 cortex-m-semihosting = "0.5"
 alloc-cortex-m = { version = "0.4", optional = true }


### PR DESCRIPTION
This change allows `defmt-semihosting` to be used in multi-core contexts. It updates synchronization to match that of `defmt-rtt`.