### PR TITLE
Re-work defmt-rtt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -662,6 +662,7 @@ Initial release
 * [#902] Use `core::ptr::addr_of_mut!` instead of `&mut` on mutable statics. No observable change.
 * [#901] `defmt-rtt`: Update to critical-section 1.2
 * [#915] Introduced `disable-blocking-mode` feature
+* [#949] Re-worked to remove all usage of `static mut`
 
 ### [defmt-rtt-v0.4.1] (2024-05-13)
 
@@ -850,6 +851,7 @@ Initial release
 
 ---
 
+[#949]: https://github.com/knurling-rs/defmt/pull/949
 [#948]: https://github.com/knurling-rs/defmt/pull/948
 [#914]: https://github.com/knurling-rs/defmt/pull/914
 [#902]: https://github.com/knurling-rs/defmt/pull/902

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -704,7 +704,7 @@ Initial release
 
 ## defmt-semihosting
 
-> Transmit defmt log messages over the semihosting (Instrumentation Trace Macrocell) stimulus port
+> Transmit defmt log messages using semi-hosting breakpoints
 
 [defmt-semihosting-next]: https://github.com/knurling-rs/defmt/compare/defmt-semihosting-v0.1.0...main
 [defmt-semihosting-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-semihosting-v0.1.0

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -61,7 +61,7 @@ const MODE_BLOCK_IF_FULL: usize = 2;
 const MODE_NON_BLOCKING_TRIM: usize = 1;
 
 /// The defmt global logger
-/// 
+///
 /// The defmt crate requires that this be a unit type, so our state is stored in
 /// [`RTT_ENCODER`] instead.
 #[defmt::global_logger]
@@ -71,7 +71,7 @@ struct Logger;
 static RTT_ENCODER: RttEncoder = RttEncoder::new();
 
 /// Our shared header structure.
-/// 
+///
 /// The host will read this structure so it must be arranged as expected.
 ///
 /// NOTE the `rtt-target` API is too permissive. It allows writing arbitrary
@@ -99,7 +99,7 @@ static _SEGGER_RTT: Header = Header {
 static BUFFER: Buffer = Buffer::new();
 
 /// The name of our channel.
-/// 
+///
 /// This is in a data section, so the whole RTT header can be read from RAM.
 /// This is useful if flash access gets disabled by the firmware at runtime.
 #[link_section = ".data"]
@@ -253,4 +253,3 @@ impl Buffer {
 }
 
 unsafe impl Sync for Buffer {}
-

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -1,6 +1,7 @@
 //! [`defmt`](https://github.com/knurling-rs/defmt) global logger over RTT.
 //!
-//! NOTE when using this crate it's not possible to use (link to) the `rtt-target` crate
+//! NOTE when using this crate it's not possible to use (link to) the
+//! `rtt-target` crate
 //!
 //! To use this crate, link to it by importing it somewhere in your project.
 //!
@@ -11,23 +12,27 @@
 //!
 //! # Blocking/Non-blocking
 //!
-//! `probe-run` puts RTT into blocking-mode, to avoid losing data.
+//! `probe-rs` puts RTT into blocking-mode, to avoid losing data.
 //!
-//! As an effect this implementation may block forever if `probe-run` disconnects on runtime. This
-//! is because the RTT buffer will fill up and writing will eventually halt the program execution.
+//! As an effect this implementation may block forever if `probe-rs` disconnects
+//! at runtime. This is because the RTT buffer will fill up and writing will
+//! eventually halt the program execution.
 //!
 //! `defmt::flush` would also block forever in that case.
 //!
-//! If losing data is not an concern you can disable blocking mode by enabling the feature
-//! `disable-blocking-mode`
+//! If losing data is not an concern you can disable blocking mode by enabling
+//! the feature `disable-blocking-mode`
 //!
 //! # Critical section implementation
 //!
-//! This crate uses [`critical-section`](https://github.com/rust-embedded/critical-section) to ensure only one thread
-//! is writing to the buffer at a time. You must import a crate that provides a `critical-section` implementation
-//! suitable for the current target. See the `critical-section` README for details.
+//! This crate uses
+//! [`critical-section`](https://github.com/rust-embedded/critical-section) to
+//! ensure only one thread is writing to the buffer at a time. You must import a
+//! crate that provides a `critical-section` implementation suitable for the
+//! current target. See the `critical-section` README for details.
 //!
-//! For example, for single-core privileged-mode Cortex-M targets, you can add the following to your Cargo.toml.
+//! For example, for single-core privileged-mode Cortex-M targets, you can add
+//! the following to your Cargo.toml.
 //!
 //! ```toml
 //! [dependencies]
@@ -39,76 +44,186 @@
 mod channel;
 mod consts;
 
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use core::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 
 use crate::{channel::Channel, consts::BUF_SIZE};
 
+/// The relevant bits in the mode field in the Header
+const MODE_MASK: usize = 0b11;
+
+/// Block the application if the RTT buffer is full, wait for the host to read data.
+const MODE_BLOCK_IF_FULL: usize = 2;
+
+/// Don't block if the RTT buffer is full. Truncate data to output as much as fits.
+const MODE_NON_BLOCKING_TRIM: usize = 1;
+
+/// The defmt global logger
+/// 
+/// The defmt crate requires that this be a unit type, so our state is stored in
+/// [`RTT_ENCODER`] instead.
 #[defmt::global_logger]
 struct Logger;
 
-/// Global logger lock.
-static TAKEN: AtomicBool = AtomicBool::new(false);
-static mut CS_RESTORE: critical_section::RestoreState = critical_section::RestoreState::invalid();
-static mut ENCODER: defmt::Encoder = defmt::Encoder::new();
+/// Our defmt encoder state
+static RTT_ENCODER: RttEncoder = RttEncoder::new();
 
-unsafe impl defmt::Logger for Logger {
-    fn acquire() {
+/// Our shared header structure.
+/// 
+/// The host will read this structure so it must be arranged as expected.
+///
+/// NOTE the `rtt-target` API is too permissive. It allows writing arbitrary
+/// data to any channel (`set_print_channel` + `rprint*`) and that can corrupt
+/// defmt log frames. So we declare the RTT control block here and make it
+/// impossible to use `rtt-target` together with this crate.
+#[no_mangle]
+static _SEGGER_RTT: Header = Header {
+    id: *b"SEGGER RTT\0\0\0\0\0\0",
+    max_up_channels: 1,
+    max_down_channels: 0,
+    up_channel: Channel {
+        name: NAME.as_ptr(),
+        buffer: BUFFER.get(),
+        size: BUF_SIZE,
+        write: AtomicUsize::new(0),
+        read: AtomicUsize::new(0),
+        flags: AtomicUsize::new(MODE_NON_BLOCKING_TRIM),
+    },
+};
+
+/// Our shared buffer
+#[cfg_attr(target_os = "macos", link_section = ".uninit,defmt-rtt.BUFFER")]
+#[cfg_attr(not(target_os = "macos"), link_section = ".uninit.defmt-rtt.BUFFER")]
+static BUFFER: Buffer = Buffer::new();
+
+/// The name of our channel.
+/// 
+/// This is in a data section, so the whole RTT header can be read from RAM.
+/// This is useful if flash access gets disabled by the firmware at runtime.
+#[link_section = ".data"]
+static NAME: [u8; 6] = *b"defmt\0";
+
+struct RttEncoder {
+    /// A boolean lock
+    ///
+    /// Is `true` when `acquire` has been called and we have exclusive access to
+    /// the rest of this structure.
+    taken: AtomicBool,
+    /// We need to remember this to exit a critical section
+    cs_restore: UnsafeCell<critical_section::RestoreState>,
+    /// A defmt::Encoder for encoding frames
+    encoder: UnsafeCell<defmt::Encoder>,
+}
+
+impl RttEncoder {
+    /// Create a new semihosting-based defmt-encoder
+    const fn new() -> RttEncoder {
+        RttEncoder {
+            taken: AtomicBool::new(false),
+            cs_restore: UnsafeCell::new(critical_section::RestoreState::invalid()),
+            encoder: UnsafeCell::new(defmt::Encoder::new()),
+        }
+    }
+
+    /// Acquire the defmt encoder.
+    fn acquire(&self) {
         // safety: Must be paired with corresponding call to release(), see below
         let restore = unsafe { critical_section::acquire() };
 
-        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
-        if TAKEN.load(Ordering::Relaxed) {
+        // NB: You can re-enter critical sections but we need to make sure
+        // no-one does that.
+        if self.taken.load(Ordering::Relaxed) {
             panic!("defmt logger taken reentrantly")
         }
 
-        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
-        TAKEN.store(true, Ordering::Relaxed);
+        // no need for CAS because we are in a critical section
+        self.taken.store(true, Ordering::Relaxed);
 
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        unsafe { CS_RESTORE = restore };
-
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        // safety: accessing the cell is OK because we have acquired a critical
+        // section.
         unsafe {
-            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
-            encoder.start_frame(do_write)
+            self.cs_restore.get().write(restore);
+            let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
+            encoder.start_frame(|b| {
+                _SEGGER_RTT.up_channel.write_all(b);
+            });
         }
     }
 
-    unsafe fn flush() {
-        // safety: accessing the `&'static _` is OK because we have acquired a critical section.
-        handle().flush();
-    }
-
-    unsafe fn release() {
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        unsafe {
-            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
-            encoder.end_frame(do_write);
+    /// Write bytes to the defmt encoder.
+    unsafe fn write(&self, bytes: &[u8]) {
+        if !self.taken.load(Ordering::Relaxed) {
+            panic!("defmt write out of context")
         }
 
-        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
-        TAKEN.store(false, Ordering::Relaxed);
-
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        let restore = unsafe { CS_RESTORE };
-
-        // safety: Must be paired with corresponding call to acquire(), see above
+        // safety: accessing the cell is OK because we have acquired a critical
+        // section.
         unsafe {
+            let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
+            encoder.write(bytes, |b| {
+                _SEGGER_RTT.up_channel.write_all(b);
+            });
+        }
+    }
+
+    /// Flush the encoder
+    unsafe fn flush(&self) {
+        if !self.taken.load(Ordering::Relaxed) {
+            panic!("defmt write out of context")
+        }
+
+        // safety: accessing the `&'static _` is OK because we have acquired a
+        // critical section.
+        _SEGGER_RTT.up_channel.flush();
+    }
+
+    /// Release the defmt encoder.
+    unsafe fn release(&self) {
+        if !self.taken.load(Ordering::Relaxed) {
+            panic!("defmt release out of context")
+        }
+
+        // safety: accessing the cell is OK because we have acquired a critical
+        // section.
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
+            encoder.end_frame(|b| {
+                _SEGGER_RTT.up_channel.write_all(b);
+            });
+            let restore = self.cs_restore.get().read();
+            self.taken.store(false, Ordering::Relaxed);
+            // paired with exactly one acquire call
             critical_section::release(restore);
-        }
-    }
-
-    unsafe fn write(bytes: &[u8]) {
-        // safety: accessing the `static mut` is OK because we have acquired a critical section.
-        unsafe {
-            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
-            encoder.write(bytes, do_write);
         }
     }
 }
 
-fn do_write(bytes: &[u8]) {
-    unsafe { handle().write_all(bytes) }
+unsafe impl Sync for RttEncoder {}
+
+unsafe impl defmt::Logger for Logger {
+    fn acquire() {
+        RTT_ENCODER.acquire();
+    }
+
+    unsafe fn write(bytes: &[u8]) {
+        unsafe {
+            RTT_ENCODER.write(bytes);
+        }
+    }
+
+    unsafe fn flush() {
+        unsafe {
+            RTT_ENCODER.flush();
+        }
+    }
+
+    unsafe fn release() {
+        unsafe {
+            RTT_ENCODER.release();
+        }
+    }
 }
 
 #[repr(C)]
@@ -119,45 +234,23 @@ struct Header {
     up_channel: Channel,
 }
 
-const MODE_MASK: usize = 0b11;
-/// Block the application if the RTT buffer is full, wait for the host to read data.
-const MODE_BLOCK_IF_FULL: usize = 2;
-/// Don't block if the RTT buffer is full. Truncate data to output as much as fits.
-const MODE_NON_BLOCKING_TRIM: usize = 1;
+unsafe impl Sync for Header {}
 
-// make sure we only get shared references to the header/channel (avoid UB)
-/// # Safety
-/// `Channel` API is not re-entrant; this handle should not be held from different execution
-/// contexts (e.g. thread-mode, interrupt context)
-unsafe fn handle() -> &'static Channel {
-    // NOTE the `rtt-target` API is too permissive. It allows writing arbitrary data to any
-    // channel (`set_print_channel` + `rprint*`) and that can corrupt defmt log frames.
-    // So we declare the RTT control block here and make it impossible to use `rtt-target` together
-    // with this crate.
-    #[no_mangle]
-    static mut _SEGGER_RTT: Header = Header {
-        id: *b"SEGGER RTT\0\0\0\0\0\0",
-        max_up_channels: 1,
-        max_down_channels: 0,
-        up_channel: Channel {
-            name: &NAME as *const _ as *const u8,
-            #[allow(static_mut_refs)]
-            buffer: unsafe { BUFFER.as_mut_ptr() },
-            size: BUF_SIZE,
-            write: AtomicUsize::new(0),
-            read: AtomicUsize::new(0),
-            flags: AtomicUsize::new(MODE_NON_BLOCKING_TRIM),
-        },
-    };
-
-    #[cfg_attr(target_os = "macos", link_section = ".uninit,defmt-rtt.BUFFER")]
-    #[cfg_attr(not(target_os = "macos"), link_section = ".uninit.defmt-rtt.BUFFER")]
-    static mut BUFFER: [u8; BUF_SIZE] = [0; BUF_SIZE];
-
-    // Place NAME in data section, so the whole RTT header can be read from RAM.
-    // This is useful if flash access gets disabled by the firmware at runtime.
-    #[link_section = ".data"]
-    static NAME: [u8; 6] = *b"defmt\0";
-
-    unsafe { &*core::ptr::addr_of!(_SEGGER_RTT.up_channel) }
+struct Buffer {
+    inner: UnsafeCell<[u8; BUF_SIZE]>,
 }
+
+impl Buffer {
+    const fn new() -> Buffer {
+        Buffer {
+            inner: UnsafeCell::new([0; BUF_SIZE]),
+        }
+    }
+
+    const fn get(&self) -> *mut u8 {
+        self.inner.get() as _
+    }
+}
+
+unsafe impl Sync for Buffer {}
+


### PR DESCRIPTION
* Remove all static mut variables - now we use UnsafeCell, and we wrap all the state into a single static variable.
* Moved all the static variables to the top and put the implementation below.

Tested with the rust-exercises code for the nRF52-DK.
