### PR TITLE
defmt-rtt is performance sensitive, so remove the redundant checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -663,6 +663,7 @@ Initial release
 * [#901] `defmt-rtt`: Update to critical-section 1.2
 * [#915] Introduced `disable-blocking-mode` feature
 * [#949] Re-worked to remove all usage of `static mut`
+* [#950] Removed some redundant checks from `write` and `flush`
 
 ### [defmt-rtt-v0.4.1] (2024-05-13)
 
@@ -851,6 +852,7 @@ Initial release
 
 ---
 
+[#950]: https://github.com/knurling-rs/defmt/pull/950
 [#949]: https://github.com/knurling-rs/defmt/pull/949
 [#948]: https://github.com/knurling-rs/defmt/pull/948
 [#914]: https://github.com/knurling-rs/defmt/pull/914

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -153,11 +153,11 @@ impl RttEncoder {
     }
 
     /// Write bytes to the defmt encoder.
+    ///
+    /// # Safety
+    ///
+    /// Do not call unless you have called `acquire`.
     unsafe fn write(&self, bytes: &[u8]) {
-        if !self.taken.load(Ordering::Relaxed) {
-            panic!("defmt write out of context")
-        }
-
         // safety: accessing the cell is OK because we have acquired a critical
         // section.
         unsafe {
@@ -169,17 +169,23 @@ impl RttEncoder {
     }
 
     /// Flush the encoder
+    ///
+    /// # Safety
+    ///
+    /// Do not call unless you have called `acquire`.
     unsafe fn flush(&self) {
-        if !self.taken.load(Ordering::Relaxed) {
-            panic!("defmt write out of context")
-        }
-
         // safety: accessing the `&'static _` is OK because we have acquired a
         // critical section.
         _SEGGER_RTT.up_channel.flush();
     }
 
     /// Release the defmt encoder.
+    ///
+    /// # Safety
+    ///
+    /// Do not call unless you have called `acquire`. This will release
+    /// your lock - do not call `flush` and `write` until you have done another
+    /// `acquire`.
     unsafe fn release(&self) {
         if !self.taken.load(Ordering::Relaxed) {
             panic!("defmt release out of context")


### PR DESCRIPTION
Also adds # Safety comments for the unsafe functions.