### PR TITLE
Release defmt-rtt and defmt-semihosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -649,6 +649,7 @@ Initial release
 > Transmit defmt log messages over the RTT (Real-Time Transfer) protocol
 
 [defmt-rtt-next]: https://github.com/knurling-rs/defmt/compare/defmt-rtt-v0.4.1...main
+[defmt-rtt-v0.4.2]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.4.2
 [defmt-rtt-v0.4.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.4.1
 [defmt-rtt-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.4.0
 [defmt-rtt-v0.3.2]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.3.2
@@ -658,6 +659,8 @@ Initial release
 [defmt-rtt-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.1.0
 
 ### [defmt-rtt-next]
+
+### [defmt-rtt-v0.4.2] (2025-03-27)
 
 * [#902] Use `core::ptr::addr_of_mut!` instead of `&mut` on mutable statics. No observable change.
 * [#901] `defmt-rtt`: Update to critical-section 1.2
@@ -708,10 +711,13 @@ Initial release
 
 > Transmit defmt log messages using semi-hosting breakpoints
 
-[defmt-semihosting-next]: https://github.com/knurling-rs/defmt/compare/defmt-semihosting-v0.1.0...main
+[defmt-semihosting-next]: https://github.com/knurling-rs/defmt/compare/defmt-semihosting-v0.2.0...main
+[defmt-semihosting-v0.2.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-semihosting-v0.2.0
 [defmt-semihosting-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-semihosting-v0.1.0
 
 ### [defmt-semihosting-next]
+
+### [defmt-semihosting-v0.2.0] (2025-03-27)
 
 * [#943] use critical_section for synchronization.
 * [#945] switch to using semihosting crate and `UnsafeCell`

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.1"
+version = "0.4.2"
 
 [features]
 disable-blocking-mode = []

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -102,7 +102,8 @@ static BUFFER: Buffer = Buffer::new();
 ///
 /// This is in a data section, so the whole RTT header can be read from RAM.
 /// This is useful if flash access gets disabled by the firmware at runtime.
-#[link_section = ".data"]
+#[cfg_attr(target_os = "macos", link_section = ".data,defmt-rtt.NAME")]
+#[cfg_attr(not(target_os = "macos"), link_section = ".data.defmt-rtt.NAME")]
 static NAME: [u8; 6] = *b"defmt\0";
 
 struct RttEncoder {

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-semihosting"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 cortex-m = "0.7"


### PR DESCRIPTION
* Bump defmt-rtt to 0.4.2 (minor bump)
* Bump defmt-semihosting to 0.2.0 (major bump)
* Update CHANGELOG
* Fix linker section for defmt-rtt variable on macOS (it stopped `cargo publish` from working on macOS)
