### PR TITLE
Support sending dtr on connection for serial port input of defmt-print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,6 +475,8 @@ Initial release
 
 ### [defmt-print-next]
 
+* [#952] Support sending dtr on connection for serial port input
+
 ### [defmt-print-v0.3.13] (2024-11-27)
 
 * [#807] Add `watch_elf` flag to allow ELF file reload without restarting `defmt-print`


### PR DESCRIPTION
This PR adds an option to send a DTR(data terminal ready) signal when a serial port is connected.
This is useful if there is a buffer in the embedded device to hold the log and wait for the log to be sent until defmt-print is connected.