### PR TITLE
Fix accidental breaking change in `Format` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 > A highly efficient logging framework that targets resource-constrained devices, like microcontrollers
 
-[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v1.0.0...main
+[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v1.0.1...main
+[defmt-v1.0.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.0.1
 [defmt-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.0.0
 [defmt-v0.3.100]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.3.100
 [defmt-v0.3.10]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.3.10
@@ -52,6 +53,10 @@ We have several packages which live in this repository. Changes are tracked sepa
 ### [defmt-next]
 
 * No changes
+
+### [defmt-v1.0.1] (2025-04-01)
+
+* [#954]: Fix accidental breaking change in `Format` macro
 
 ### [defmt-v1.0.0] (2025-04-01)
 
@@ -394,7 +399,8 @@ Initial release
 
 > Macros for [defmt](#defmt)
 
-[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v1.0.0...main
+[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v1.0.1...main
+[defmt-macros-v1.0.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.0.1
 [defmt-macros-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.0.0
 [defmt-macros-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.4.0
 [defmt-macros-v0.3.10]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.3.10
@@ -418,6 +424,10 @@ Initial release
 ### [defmt-macros-next]
 
 * No changes
+
+### [defmt-macros-v1.0.1] (2025-04-01)
+
+* [#954]: Fix accidental breaking change in `Format` macro
 
 ### [defmt-macros-v1.0.0] (2025-04-01)
 
@@ -932,6 +942,7 @@ Initial release
 
 ---
 
+[#954]: https://github.com/knurling-rs/defmt/pull/954
 [#950]: https://github.com/knurling-rs/defmt/pull/950
 [#949]: https://github.com/knurling-rs/defmt/pull/949
 [#948]: https://github.com/knurling-rs/defmt/pull/948

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "1.0.0"
+version = "1.0.1"
 
 [features]
 alloc = []
@@ -45,7 +45,7 @@ unstable-test = [ "defmt-macros/unstable-test" ]
 [dependencies]
 # There is exactly one version of defmt-macros supported in this version of
 # defmt. Although, multiple versions of defmt might use the *same* defmt-macros.
-defmt-macros = { path = "../macros", version = "=1.0.0" }
+defmt-macros = { path = "../macros", version = "=1.0.1" }
 bitflags = "1"
 
 [dev-dependencies]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0"
+version = "1.0.1"
 
 [lib]
 proc-macro = true

--- a/macros/src/derives/format.rs
+++ b/macros/src/derives/format.rs
@@ -61,7 +61,7 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
 }
 
 fn defmt_crate_path(attrs: &[syn::Attribute]) -> Result<syn::Path, syn::Error> {
-    let mut defmt_path = parse_quote!(::defmt);
+    let mut defmt_path = parse_quote!(defmt);
     let res = attrs
         .iter()
         .filter(|attr| attr.path().is_ident("defmt"))


### PR DESCRIPTION
https://github.com/knurling-rs/defmt/pull/948/files#diff-0613bd222ac6714be0d35f8f2f1ecaa685b8fa455726083f7ed6e866f5161b2f accidentally fully qualified the `defmt` path being used, forcing the lookup to happen exclusively in the extern prelude which is a breaking change
Fixes https://github.com/knurling-rs/defmt/issues/953

We'll need to yank the 1.0.0 release after this 😬 