### PR TITLE
Link LICENSE-* into defmt/ macros/ and parser/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#956]: Link LICENSE-* in the crate folder
 * [#955]: Allow using the `defmt/alloc` feature on bare metal ESP32-S2
 
 ### [defmt-v1.0.1] (2025-04-01)
@@ -423,7 +424,8 @@ Initial release
 
 ### [defmt-macros-next]
 
-* No changes
+* [#956]: Link LICENSE-* in the crate folder
+
 
 ### [defmt-macros-v1.0.1] (2025-04-01)
 
@@ -656,7 +658,7 @@ Initial release
 
 ### [defmt-parser-next]
 
-* No changes
+* [#956]: Link LICENSE-* in the crate folder
 
 ### [defmt-parser-v1.0.0] (2025-04-01)
 
@@ -942,6 +944,7 @@ Initial release
 
 ---
 
+[#956]: https://github.com/knurling-rs/defmt/pull/956
 [#955]: https://github.com/knurling-rs/defmt/pull/955
 [#954]: https://github.com/knurling-rs/defmt/pull/954
 [#950]: https://github.com/knurling-rs/defmt/pull/950

--- a/defmt/LICENSE-APACHE
+++ b/defmt/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/defmt/LICENSE-MIT
+++ b/defmt/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/macros/LICENSE-APACHE
+++ b/macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/macros/LICENSE-MIT
+++ b/macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/parser/LICENSE-APACHE
+++ b/parser/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/parser/LICENSE-MIT
+++ b/parser/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
I'm working on packaging defmt, defmt-macros and defmt-parser for Fedora and it's necessary to have the LICENSE files inside the crate. A link to the file is fine.