### PR TITLE
add `rust-toolchain.toml` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#957]: add `rust-toolchain.toml` file
 * [#956]: Link LICENSE-* in the crate folder
 * [#955]: Allow using the `defmt/alloc` feature on bare metal ESP32-S2
 

--- a/defmt/tests/ui/derive-invalid-crate-overwrite.stderr
+++ b/defmt/tests/ui/derive-invalid-crate-overwrite.stderr
@@ -18,8 +18,16 @@ error[E0432]: unresolved import `unresolved`
   |
   = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `unresolved`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
  --> tests/ui/derive-invalid-crate-overwrite.rs:2:17
   |
 2 | #[defmt(crate = unresolved)]
-  |                 ^^^^^^^^^^ use of undeclared crate or module `unresolved`
+  |                 ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
+ --> tests/ui/derive-invalid-crate-overwrite.rs:2:17
+  |
+2 | #[defmt(crate = unresolved)]
+  |                 ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
+  |
+  = help: if you wanted to use a crate named `unresolved`, use `cargo add unresolved` to add it to your `Cargo.toml`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+# https://github.com/dtolnay/trybuild?tab=readme-ov-file#troubleshooting
+components = ["rust-src"]


### PR DESCRIPTION
Currently the CI jobs fails even on main's schedule
This is might be the known inconsistency problem, which is talked about in trybuild's [README](https://github.com/dtolnay/trybuild?tab=readme-ov-file#troubleshooting).
This change is the proposed fix from trybuild