### PR TITLE
Update object crate to version 0.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -585,7 +585,7 @@ Initial release
 
 ### [defmt-decoder-next]
 
-* No changes
+* [#958] Update to object 0.36
 
 ### [defmt-decoder-v1.0.0] (2025-04-01)
 
@@ -944,6 +944,7 @@ Initial release
 
 ---
 
+[#958]: https://github.com/knurling-rs/defmt/pull/958
 [#956]: https://github.com/knurling-rs/defmt/pull/956
 [#955]: https://github.com/knurling-rs/defmt/pull/955
 [#954]: https://github.com/knurling-rs/defmt/pull/954

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -35,7 +35,7 @@ gimli = { version = "0.29", default-features = false, features = [
     "read",
     "std",
 ] }
-object = { version = "0.35", default-features = false, features = [
+object = { version = "0.36", default-features = false, features = [
     "read_core",
     "elf",
     "std",

--- a/defmt/tests/ui/derive-invalid-crate-overwrite.stderr
+++ b/defmt/tests/ui/derive-invalid-crate-overwrite.stderr
@@ -18,8 +18,16 @@ error[E0432]: unresolved import `unresolved`
   |
   = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `unresolved`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
  --> tests/ui/derive-invalid-crate-overwrite.rs:2:17
   |
 2 | #[defmt(crate = unresolved)]
-  |                 ^^^^^^^^^^ use of undeclared crate or module `unresolved`
+  |                 ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
+ --> tests/ui/derive-invalid-crate-overwrite.rs:2:17
+  |
+2 | #[defmt(crate = unresolved)]
+  |                 ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
+  |
+  = help: if you wanted to use a crate named `unresolved`, use `cargo add unresolved` to add it to your `Cargo.toml`


### PR DESCRIPTION
This fixes an issue I was having in probe-rs trying to flash a sealed binary for the RP Pico 2 (rp235x).

I'm using `picotool seal` to modify the binary to have the correct load_map headers, but then probe-rs seems
to have an issue with the resulting binary. It seems that it doesn't read the new ELF sections correctly.

Bumping object to 0.36 in defmt-decoder seems to fix this.