### PR TITLE
fix: missing "unstable-test" cfg in deftmt/tests/encode.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#959]: Missing "unstable-test" cfg in tests module
 * [#956]: Link LICENSE-* in the crate folder
 * [#955]: Allow using the `defmt/alloc` feature on bare metal ESP32-S2
 
@@ -425,7 +426,6 @@ Initial release
 ### [defmt-macros-next]
 
 * [#956]: Link LICENSE-* in the crate folder
-
 
 ### [defmt-macros-v1.0.1] (2025-04-01)
 
@@ -944,6 +944,7 @@ Initial release
 
 ---
 
+[#959]: https://github.com/knurling-rs/defmt/pull/959
 [#958]: https://github.com/knurling-rs/defmt/pull/958
 [#956]: https://github.com/knurling-rs/defmt/pull/956
 [#955]: https://github.com/knurling-rs/defmt/pull/955

--- a/defmt/tests/encode.rs
+++ b/defmt/tests/encode.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unstable-test")]
+
 // NOTE these tests should live in `defmt-macros` but the expansion of the macros defined there
 // depend on `defmt` and `defmt` depends on `defmt-macros` -- the circular dependency may get in
 // the way of `cargo test`


### PR DESCRIPTION
File-wide because all tests in `encode.rs` use either the `check!` or `check_format!` macro, which in turn depends on the feature flagged `defmt::export::fetch_bytes()` function.

https://github.com/knurling-rs/defmt/blob/2c356885ee3b311c3dacff7fb57c01026725b0a3/defmt/src/export/mod.rs#L36-L40

https://github.com/knurling-rs/defmt/blob/2c356885ee3b311c3dacff7fb57c01026725b0a3/defmt/tests/encode.rs#L51-L74