### PR TITLE
fix: Fix `Format` not accepting multiple helper attribute instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#960]: Fix `Format` not accepting multiple helper attribute instances
 * [#937]: add support for `#[defmt(transparent)]` on `Format` derive
 * [#959]: Missing "unstable-test" cfg in tests module
 * [#956]: Link LICENSE-* in the crate folder
@@ -945,6 +946,7 @@ Initial release
 
 ---
 
+[#960]: https://github.com/knurling-rs/defmt/pull/959
 [#959]: https://github.com/knurling-rs/defmt/pull/959
 [#958]: https://github.com/knurling-rs/defmt/pull/958
 [#956]: https://github.com/knurling-rs/defmt/pull/956

--- a/defmt/tests/derive-bounds.rs
+++ b/defmt/tests/derive-bounds.rs
@@ -49,3 +49,10 @@ enum TransparentEnum<T: Foo> {
 #[defmt(transparent)]
 #[allow(dead_code)]
 struct Transparent<T: Foo>(Quux<T>);
+
+#[derive(defmt::Format)]
+#[defmt(transparent)]
+#[defmt(transparent, crate = defmt4)]
+#[defmt(crate = defmt3, crate = defmt2)]
+#[allow(dead_code)]
+struct Variations<T: Foo>(Quux<T>);

--- a/defmt/tests/ui/derive-transparent-empty.stderr
+++ b/defmt/tests/ui/derive-transparent-empty.stderr
@@ -1,10 +1,10 @@
-error: proc-macro derive panicked
+error: Transparent format can only be applied to structs with one field.
  --> tests/ui/derive-transparent-empty.rs:7:10
   |
 7 | #[derive(defmt::Format)]
   |          ^^^^^^^^^^^^^
   |
-  = help: message: called `Option::unwrap()` on a `None` value
+  = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Transparent format can only be applied when all variants have exactly one field.
   --> tests/ui/derive-transparent-empty.rs:11:10

--- a/defmt/tests/ui/derive-transparent-multiple-fields.stderr
+++ b/defmt/tests/ui/derive-transparent-multiple-fields.stderr
@@ -5,3 +5,11 @@ error: Transparent format can only be applied when all variants have exactly one
   |          ^^^^^^^^^^^^^
   |
   = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Transparent format can only be applied to structs with one field.
+ --> tests/ui/derive-transparent-multiple-fields.rs:7:10
+  |
+7 | #[derive(defmt::Format)]
+  |          ^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macros/src/derives/format.rs
+++ b/macros/src/derives/format.rs
@@ -2,7 +2,7 @@ use codegen::DefmtAttr;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error2::{abort, abort_call_site};
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{parse_macro_input, parse_quote, Data, DeriveInput, Generics, Ident};
 
 mod codegen;
@@ -19,13 +19,7 @@ pub(crate) fn expand(input: TokenStream) -> TokenStream {
     let DefmtAttr {
         transparent,
         defmt_path,
-    } = match attrs
-        .iter()
-        .find(|meta| meta.path().is_ident("defmt"))
-        .cloned()
-        .map(DefmtAttr::try_from)
-        .unwrap_or_else(|| Ok(DefmtAttr::default()))
-    {
+    } = match DefmtAttr::from_attrs(&attrs) {
         Ok(maybe_attr) => maybe_attr,
         Err(err) => abort!(err),
     };
@@ -94,8 +88,7 @@ pub(crate) fn expand_transparent(
                 let Some(field) = field.filter(|_| one_or_less) else {
                     abort_call_site!(
                         "Transparent format can only be applied \
-                        when all variants have exactly one field.
-                    "
+                        when all variants have exactly one field."
                     )
                 };
 
@@ -126,9 +119,7 @@ pub(crate) fn expand_transparent(
             let one_or_less = fields.next().is_none();
             let Some(field) = field.filter(|_| one_or_less) else {
                 abort_call_site!(
-                    "Transparent format can only be applied \
-                    when all variants have exactly one field.
-                "
+                    "Transparent format can only be applied to structs with one field."
                 )
             };
 


### PR DESCRIPTION
Quick followup to https://github.com/knurling-rs/defmt/pull/937. I only meant to remove the unwraps but noticed that we regressed in functionality here regarding the derive helper