### PR TITLE
Add `in_blocking_mode` method to defmt-rtt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -712,7 +712,7 @@ Initial release
 
 ### [defmt-rtt-next]
 
-* No changes
+* [#968] Add `in_blocking_mode` public method
 
 ### [defmt-rtt-v1.0.0] (2025-04-01)
 
@@ -947,6 +947,7 @@ Initial release
 
 ---
 
+[#968]: https://github.com/knurling-rs/defmt/pull/968
 [#965]: https://github.com/knurling-rs/defmt/pull/965
 [#960]: https://github.com/knurling-rs/defmt/pull/960
 [#959]: https://github.com/knurling-rs/defmt/pull/959

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -93,6 +93,17 @@ static _SEGGER_RTT: Header = Header {
     },
 };
 
+/// Report whether the SEGGER RTT up channel is in blocking mode.
+///
+/// Returns true if the mode bitfield within the flags value has been set to
+/// `SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL`.
+///
+/// Currently we start-up in non-blocking mode, so if it's been set to blocking
+/// mode then the connected client (e.g. probe-rs) must have done it.
+pub fn in_blocking_mode() -> bool {
+    (_SEGGER_RTT.up_channel.flags.load(Ordering::Relaxed) & MODE_MASK) == MODE_BLOCK_IF_FULL
+}
+
 /// Our shared buffer
 #[cfg_attr(target_os = "macos", link_section = ".uninit,defmt-rtt.BUFFER")]
 #[cfg_attr(not(target_os = "macos"), link_section = ".uninit.defmt-rtt.BUFFER")]


### PR DESCRIPTION
Lets you know if a client has connected, because most clients put the SEGGER RTT transport into blocking mode (probe-rs does).