### PR TITLE
macros: Fix env_filter logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#959]: Missing "unstable-test" cfg in tests module
 * [#956]: Link LICENSE-* in the crate folder
 * [#955]: Allow using the `defmt/alloc` feature on bare metal ESP32-S2
+* [#972]: Fix logic bug in env_filter
 
 ### [defmt-v1.0.1] (2025-04-01)
 
@@ -947,6 +948,7 @@ Initial release
 
 ---
 
+[#972]: https://github.com/knurling-rs/defmt/pull/972
 [#968]: https://github.com/knurling-rs/defmt/pull/968
 [#965]: https://github.com/knurling-rs/defmt/pull/965
 [#960]: https://github.com/knurling-rs/defmt/pull/960

--- a/macros/src/function_like/log/env_filter/parse.rs
+++ b/macros/src/function_like/log/env_filter/parse.rs
@@ -53,7 +53,7 @@ pub(crate) enum Entry {
 
 impl ModulePath {
     pub(crate) fn from_crate_name(input: &str) -> Self {
-        if input.is_empty() && input.contains("::") {
+        if input.is_empty() || input.contains("::") {
             panic!(
                 "DEFMT_LOG env var: crate name cannot be an empty string or contain path separators"
             )


### PR DESCRIPTION
A str can't be empty AND contain a separator, this is probably a logic bug, looking at the comment.