### PR TITLE
Pin clippy because it keeps having *new* opinions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,22 @@ jobs:
       - name: Install Rust targets, build defmt crates for no_std targets, build defmt dependent crates for cortex-m targets, build panic-probe with different features
         run: cargo xtask test-cross
 
+  lint-cross:
+    strategy:
+      matrix:
+        toolchain:
+          - "1.87" # we pin clippy because it keeps adding new lints
+          - "1.76" # MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set Rust version
+        uses: ./.github/actions/update-rust
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Install Rust targets, lint defmt crates for no_std targets
+        run: cargo xtask test-lint-cross
+
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "stable"
+          - "1.87" # we pin clippy because it keeps adding new lints
           - "1.76" # MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,6 +37,7 @@ enum TestCommand {
     TestBackcompat,
     TestBook,
     TestCross,
+    TestLintCross,
     TestHost {
         /// Whether to skip running ui tests
         #[arg(long)]
@@ -70,6 +71,7 @@ fn main() -> anyhow::Result<()> {
             added_targets = Some(targets::install().expect("Error while installing required targets"));
             match cmd {
                 TestCommand::TestCross => test_cross(opt.deny_warnings),
+                TestCommand::TestLintCross => test_lint_cross(opt.deny_warnings),
                 TestCommand::TestSnapshot { overwrite, single } => {
                     test_snapshot(overwrite, single);
                 }
@@ -222,6 +224,15 @@ fn test_cross(deny_warnings: bool) {
             "cross",
         );
     }
+}
+
+fn test_lint_cross(deny_warnings: bool) {
+    println!("🧪 lint-cross");
+
+    let env = match deny_warnings {
+        true => vec![("RUSTFLAGS", "--deny warnings")],
+        false => vec![],
+    };
 
     do_test(
         || {


### PR DESCRIPTION
We'll deal with its new opinions, and opt into a newer version, on our timeline, not when a new release drops. I don't want broken CI on main, ever.