### PR TITLE
add `impl Format for std::sync::Mutex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#956]: Link LICENSE-* in the crate folder
 * [#955]: Allow using the `defmt/alloc` feature on bare metal ESP32-S2
 * [#972]: Fix logic bug in env_filter
+* [#978]: Add `std` feature and add initial `Format` impl for `Mutex` and `MutexGuard`
 
 ### [defmt-v1.0.1] (2025-04-01)
 

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -18,6 +18,7 @@ homepage = "https://knurling.ferrous-systems.com/"
 version = "1.0.1"
 
 [features]
+std = ["alloc"]
 alloc = []
 avoid-default-panic = []
 ip_in_core = []

--- a/defmt/src/impls/mod.rs
+++ b/defmt/src/impls/mod.rs
@@ -33,6 +33,8 @@ mod alloc_;
 mod arrays;
 mod core_;
 mod primitives;
+#[cfg(feature = "std")]
+mod std_;
 mod tuples;
 
 use defmt_macros::internp;

--- a/defmt/src/impls/std_.rs
+++ b/defmt/src/impls/std_.rs
@@ -1,0 +1,37 @@
+use super::*;
+use std::sync::TryLockError;
+
+impl<T> Format for std::sync::Mutex<T>
+where
+    T: ?Sized + Format,
+{
+    #[inline]
+    fn format(&self, fmt: Formatter) {
+        match self.try_lock() {
+            Ok(guard) => crate::write!(fmt, "Mutex {{ data: {=?} }}", guard),
+            Err(TryLockError::Poisoned(err)) => {
+                crate::write!(fmt, "Mutex {{ data: {=?} }}", err.get_ref())
+            }
+            Err(TryLockError::WouldBlock) => crate::write!(fmt, "Mutex {{ data: <locked> }}"),
+        }
+    }
+}
+
+impl<T> Format for std::sync::MutexGuard<'_, T>
+where
+    T: ?Sized + Format,
+{
+    delegate_format!(T, self, &*self);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate as defmt;
+    use std::sync::Mutex;
+
+    #[test]
+    fn mutex() {
+        let m = Mutex::new(42);
+        defmt::info!("{}", m);
+    }
+}


### PR DESCRIPTION
this introduces a new optional feature `std` and an initial `Format` implementation just for `Mutex`. the hope is that over time more and more `Format` impls for `std` can be added for those who need it.

the trigger for this is that i broke the `embassy-sync` build for `std` by adding a `Format` derive to something which was using `Mutex` internally and it wasn't covered by CI there (which by now is rectified). in the ensuing conversation on Matrix it was stated that it might be nice to have `defmt` impls for `std` as well, even if only very few users would exist for this (i'm not one of them, which is how i ended up breaking CI).