### PR TITLE
Update CI & Bump Host MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - windows-latest
         toolchain:
           - "stable"
-          - "1.78" # host MSRV
+          - "1.81" # host MSRV
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
@@ -36,7 +36,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
       - name: Check that all crates that can be compiled for the host build, check that defmt compiles with different features, run all unit tests on the host
-        run: cargo xtask -d test-host ${{ matrix.toolchain == '1.78' && '--skip-ui-tests' || '' }}
+        run: cargo xtask -d test-host ${{ matrix.toolchain == '1.81' && '--skip-ui-tests' || '' }}
 
   cross:
     strategy:
@@ -91,7 +91,7 @@ jobs:
       matrix:
         toolchain:
           - "1.87" # we pin clippy because it keeps adding new lints
-          - "1.78" # host MSRV
+          - "1.81" # host MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.78" # host MSRV
+          - "1.81" # host MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.78" # host MSRV
+          - "1.81" # host MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -145,7 +145,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.78" # host MSRV
+          - "1.81" # host MSRV
           - nightly-2025-08-05 # some tests use unstable features, but avoid LLVM21 due to https://github.com/rust-lang/rust/issues/146065
     runs-on: ubuntu-latest
     steps:
@@ -166,7 +166,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.78" # host MSRV
+          - "1.81" # host MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         toolchain:
           - stable
           - "1.78" # host MSRV
-          - nightly # some tests use unstable features
+          - nightly-2025-08-05 # some tests use unstable features, but avoid LLVM21 due to https://github.com/rust-lang/rust/issues/146065
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,20 @@ jobs:
         run: cargo xtask test-lint-cross
 
   cargo-deny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2
+      with:
+        command: check ${{ matrix.checks }}
+        rust-version: stable
 
   lint:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - windows-latest
         toolchain:
           - "stable"
-          - "1.76" # MSRV
+          - "1.78" # host MSRV
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
@@ -36,14 +36,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
       - name: Check that all crates that can be compiled for the host build, check that defmt compiles with different features, run all unit tests on the host
-        run: cargo xtask -d test-host ${{ matrix.toolchain == '1.76' && '--skip-ui-tests' || '' }}
+        run: cargo xtask -d test-host ${{ matrix.toolchain == '1.78' && '--skip-ui-tests' || '' }}
 
   cross:
     strategy:
       matrix:
         toolchain:
           - "stable"
-          - "1.76" # MSRV
+          - "1.76" # firmware MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
       matrix:
         toolchain:
           - "1.87" # we pin clippy because it keeps adding new lints
-          - "1.76" # MSRV
+          - "1.76" # firmware MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
       matrix:
         toolchain:
           - "1.87" # we pin clippy because it keeps adding new lints
-          - "1.76" # MSRV
+          - "1.78" # host MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.76" # MSRV
+          - "1.78" # host MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.76" # MSRV
+          - "1.78" # host MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -145,7 +145,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.76" # MSRV
+          - "1.78" # host MSRV
           - nightly # some tests use unstable features
     runs-on: ubuntu-latest
     steps:
@@ -166,7 +166,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.76" # MSRV
+          - "1.78" # host MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,6 +510,7 @@ Initial release
 
 * [#952] Support sending dtr on connection for serial port input
 * [#965] Also support `--log-format=online` or  `--log-format=default`
+* [#986] Bump MSRV to 1.78
 
 ### [defmt-print-v1.0.0] (2025-04-01)
 
@@ -590,6 +591,7 @@ Initial release
 ### [defmt-decoder-next]
 
 * [#958] Update to object 0.36
+* [#986] Bump MSRV to 1.78
 
 ### [defmt-decoder-v1.0.0] (2025-04-01)
 
@@ -663,6 +665,7 @@ Initial release
 ### [defmt-parser-next]
 
 * [#956]: Link LICENSE-* in the crate folder
+* [#986] Bump MSRV to 1.78
 
 ### [defmt-parser-v1.0.0] (2025-04-01)
 
@@ -918,7 +921,7 @@ Initial release
 
 ### [defmt-json-schema-next]
 
-* No changes
+* [#986] Bump MSRV to 1.78
 
 ### [defmt-json-schema-v0.1.0] (2022-03-10)
 
@@ -948,6 +951,7 @@ Initial release
 
 ---
 
+[#986]: https://github.com/knurling-rs/defmt/pull/986
 [#972]: https://github.com/knurling-rs/defmt/pull/972
 [#968]: https://github.com/knurling-rs/defmt/pull/968
 [#965]: https://github.com/knurling-rs/defmt/pull/965

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,7 +510,7 @@ Initial release
 
 * [#952] Support sending dtr on connection for serial port input
 * [#965] Also support `--log-format=online` or  `--log-format=default`
-* [#986] Bump MSRV to 1.78
+* [#986] Bump MSRV to 1.81
 
 ### [defmt-print-v1.0.0] (2025-04-01)
 
@@ -591,7 +591,7 @@ Initial release
 ### [defmt-decoder-next]
 
 * [#958] Update to object 0.36
-* [#986] Bump MSRV to 1.78
+* [#986] Bump MSRV to 1.81
 
 ### [defmt-decoder-v1.0.0] (2025-04-01)
 
@@ -665,7 +665,7 @@ Initial release
 ### [defmt-parser-next]
 
 * [#956]: Link LICENSE-* in the crate folder
-* [#986] Bump MSRV to 1.78
+* [#986] Bump MSRV to 1.81
 
 ### [defmt-parser-v1.0.0] (2025-04-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -664,7 +664,7 @@ Initial release
 
 ### [defmt-parser-next]
 
-* [#956]: Link LICENSE-* in the crate folder
+* [#956] Link `LICENSE-*` in the crate folder
 * [#986] Bump MSRV to 1.81
 
 ### [defmt-parser-v1.0.0] (2025-04-01)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains the following packages:
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.78 for all host-side crates.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.81 for all host-side crates.
 
 `defmt` is tested against the latest stable Rust version and the MSRV.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ This repository contains the following packages:
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.78 for all host-side crates.
+
+`defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Developer Information
 

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -10,7 +10,7 @@ into formatted strings. It is used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.78. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.81. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -10,7 +10,7 @@ into formatted strings. It is used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.78. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/decoder/defmt-json-schema/README.md
+++ b/decoder/defmt-json-schema/README.md
@@ -9,7 +9,7 @@ This library describes the JSON output from
 
 ## MSRV
 
-The minimum supported Rust version is 1.78. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.81. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/decoder/defmt-json-schema/README.md
+++ b/decoder/defmt-json-schema/README.md
@@ -9,7 +9,7 @@ This library describes the JSON output from
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.78. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/deny.toml
+++ b/deny.toml
@@ -105,9 +105,11 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
+    # These crates are only used host-side so we are more flexible with
+    # the licences. We only need to avoid copyleft on the firmware side.
+    { allow = ["MPL-2.0"], crate = "serialport" },
+    { allow = ["MPL-2.0"], crate = "colored" },
+    { allow = ["MPL-2.0"], crate = "alterable_logger" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/parser/README.md
+++ b/parser/README.md
@@ -10,7 +10,7 @@ using that crate to this one.
 
 ## MSRV
 
-The minimum supported Rust version is 1.78. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.81. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/parser/README.md
+++ b/parser/README.md
@@ -10,7 +10,7 @@ using that crate to this one.
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.78. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -17,6 +17,6 @@ anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
 defmt-decoder = { version = "=1.0.0", path = "../decoder" }
 log = "0.4"
-notify = "7"
+notify = "8"
 tokio = { version = "1.38", features = ["full"] }
 tokio-serial = "5.4"


### PR DESCRIPTION
Updates the CI pipeline to resolve the failures and close #984 

Changes:

* bump rust version to latest stable for cargo-deny as some files in the tree require 2024?
* check cargo-deny advisories separately to bans, licences and sources as recommend in the docs
