### PR TITLE
Switch back to using latest nightly, now that the quote bug is fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         toolchain:
           - stable
           - "1.81" # host MSRV
-          - nightly-2025-08-05 # some tests use unstable features, but avoid LLVM21 due to https://github.com/rust-lang/rust/issues/146065
+          - nightly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Bug fixed in LLVM so pinning nightly no longer required