### PR TITLE
decoder: add `Send + Sync` bound to returned `StreamDecoder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -592,6 +592,7 @@ Initial release
 
 ### [defmt-decoder-next]
 
+* [#1004] decoder: add `Send + Sync` bound to returned `StreamDecoder`
 * [#990] improve version mismatch error message, don't mention probe-run.
 * [#958] Update to object 0.36
 * [#986] Bump MSRV to 1.81

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -262,7 +262,7 @@ impl Table {
         Ok((frame, consumed))
     }
 
-    pub fn new_stream_decoder(&self) -> Box<dyn StreamDecoder + '_> {
+    pub fn new_stream_decoder(&self) -> Box<dyn StreamDecoder + Send + Sync + '_> {
         match self.encoding {
             Encoding::Raw => Box::new(stream::Raw::new(self)),
             Encoding::Rzcobs => Box::new(stream::Rzcobs::new(self)),


### PR DESCRIPTION
As `Send + Sync` is already derived on the type implementations of `StreamDecoder`, this should
not have any other effects. Unless there are any limitations in doing so for future implementations?

This enables one to easily use the returned `StreamDecoder` in threaded contexts like async code.