### PR TITLE
Prepare defmt-decoder 1.1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - windows-latest
         toolchain:
           - "stable"
-          - "1.81" # host MSRV
+          - "1.83" # host MSRV
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
@@ -36,7 +36,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
       - name: Check that all crates that can be compiled for the host build, check that defmt compiles with different features, run all unit tests on the host
-        run: cargo xtask -d test-host ${{ matrix.toolchain == '1.81' && '--skip-ui-tests' || '' }}
+        run: cargo xtask -d test-host ${{ matrix.toolchain == '1.83' && '--skip-ui-tests' || '' }}
 
   cross:
     strategy:
@@ -91,7 +91,7 @@ jobs:
       matrix:
         toolchain:
           - "1.87" # we pin clippy because it keeps adding new lints
-          - "1.81" # host MSRV
+          - "1.83" # host MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         toolchain:
           - "1.91" # pinned because compiler output changes
-          - "1.81" # host MSRV
+          - "1.83" # host MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.81" # host MSRV
+          - "1.83" # host MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -146,7 +146,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.81" # host MSRV
+          - "1.83" # host MSRV
           - nightly
     runs-on: ubuntu-latest
     steps:
@@ -167,7 +167,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.81" # host MSRV
+          - "1.83" # host MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,7 +577,8 @@ Initial release
 
 > Decodes defmt log frames
 
-[defmt-decoder-next]: https://github.com/knurling-rs/defmt/compare/defmt-decoder-v1.0.0...main
+[defmt-decoder-next]: https://github.com/knurling-rs/defmt/compare/defmt-decoder-v1.0.1...main
+[defmt-decoder-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v1.1.0
 [defmt-decoder-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v1.0.0
 [defmt-decoder-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v0.4.0
 [defmt-decoder-v0.3.11]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v0.3.11
@@ -600,6 +601,8 @@ Initial release
 [defmt-decoder-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-decoder-v0.1.0
 
 ### [defmt-decoder-next]
+
+### [defmt-decoder-v1.1.0] (2026-01-20)
 
 * [#1004] decoder: add `Send + Sync` bound to returned `StreamDecoder`
 * [#990] improve version mismatch error message, don't mention probe-run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,7 @@ Initial release
 > A tool that decodes defmt logs and prints them to the console
 
 [defmt-print-next]: https://github.com/knurling-rs/defmt/compare/defmt-print-v1.0.0...main
+[defmt-print-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v1.1.0
 [defmt-print-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v1.0.0
 [defmt-print-v0.3.13]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v0.3.13
 [defmt-print-v0.3.12]: https://github.com/knurling-rs/defmt/releases/tag/defmt-print-v0.3.12
@@ -518,10 +519,15 @@ Initial release
 
 ### [defmt-print-next]
 
+* No changes
+
+### [defmt-print-v1.1.0] (2026-01-20)
+
 * [#985] Add `--set-addr` option to actively set the `_SEGGER_RTT` address
 * [#952] Support sending dtr on connection for serial port input
 * [#965] Also support `--log-format=online` or  `--log-format=default`
 * [#986] Bump MSRV to 1.81
+* [#1028] Bump MSRV to 1.83
 
 ### [defmt-print-v1.0.0] (2025-04-01)
 
@@ -609,6 +615,7 @@ Initial release
 * [#986] Bump MSRV to 1.81
 * [#966] Add Frame::fragments() and Frame::display_fragments()
 * [#958] Update to object 0.36
+* [#1028] Bump MSRV to 1.83
 * [#1036] Impl `serde::{Serialize, Deserialize}` and `Clone` on `Table` and related types
 
 ### [defmt-decoder-v1.0.0] (2025-04-01)
@@ -684,6 +691,7 @@ Initial release
 
 * [#956] Link `LICENSE-*` in the crate folder
 * [#986] Bump MSRV to 1.81
+* [#1028] Bump MSRV to 1.83
 
 ### [defmt-parser-v1.0.0] (2025-04-01)
 
@@ -956,11 +964,17 @@ Initial release
 > Runs [`qemu-system-arm`] but decodes [`defmt`] data sent to semihosting
 
 [qemu-run-next]: https://github.com/knurling-rs/defmt/compare/qemu-run-v0.1.0...main
+[qemu-run-v0.1.1]: https://github.com/knurling-rs/defmt/releases/tag/qemu-run-v0.1.1
 [qemu-run-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/qemu-run-v0.1.0
 
 ### [qemu-run-next]
 
 * No changes
+
+### [qemu-run-v0.1.1]
+
+* [#1028] Bump MSRV to 1.83
+* [#1028] Use latest `defmt-decoder` (moves location of `(HOST)` in log messages to end of line)
 
 ### [qemu-run-v0.1.0]
 
@@ -991,6 +1005,7 @@ Initial release
 ---
 
 [#1036]: https://github.com/knurling-rs/defmt/pull/1036
+[#1028]: https://github.com/knurling-rs/defmt/pull/1028
 [#1022]: https://github.com/knurling-rs/defmt/pull/1022
 [#1013]: https://github.com/knurling-rs/defmt/pull/1013
 [#1011]: https://github.com/knurling-rs/defmt/pull/1011

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -690,8 +690,7 @@ Initial release
 ### [defmt-parser-next]
 
 * [#956] Link `LICENSE-*` in the crate folder
-* [#986] Bump MSRV to 1.81
-* [#1028] Bump MSRV to 1.83
+* [#1028] Clarify that MSRV is 1.76
 
 ### [defmt-parser-v1.0.0] (2025-04-01)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "defmt-decoder"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "alterable_logger",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbor-edn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "defmt-print"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "qemu-run"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains the following packages:
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.81 for all host-side crates.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.83 for all host-side crates.
 
 `defmt` is tested against the latest stable Rust version and the MSRV.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains the following packages:
 
 The minimum supported Rust version is 1.76 (or Ferrocene 24.05) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.83 for all host-side crates.
 
-`defmt` is tested against the latest stable Rust version and the MSRV.
+The `defmt` crates are tested against the latest stable Rust version and the MSRV.
 
 ## Developer Information
 

--- a/check_changelog.md
+++ b/check_changelog.md
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Checks that all the github links in CHANGELOG.md are correctly defined
+
+for link in `rg '\[(#\d+)\] ' CHANGELOG.md -o | sort | uniq | sed 's/\]/\\\\]/' | sed 's/\[/\\\\[/'`
+do
+    rg "${link}:" CHANGELOG.md -q || echo $link is MISSING
+done

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 byteorder = "1"

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-decoder"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
+rust-version = "1.83"
 version = "1.1.0"
 
 [dependencies]

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -10,7 +10,7 @@ into formatted strings. It is used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.81. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/decoder/README.md
+++ b/decoder/README.md
@@ -10,7 +10,7 @@ into formatted strings. It is used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.83. This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/decoder/defmt-json-schema/README.md
+++ b/decoder/defmt-json-schema/README.md
@@ -9,7 +9,7 @@ This library describes the JSON output from
 
 ## MSRV
 
-The minimum supported Rust version is 1.81. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/decoder/defmt-json-schema/README.md
+++ b/decoder/defmt-json-schema/README.md
@@ -9,7 +9,7 @@ This library describes the JSON output from
 
 ## MSRV
 
-The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.83. This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/defmt-03/README.md
+++ b/defmt-03/README.md
@@ -22,7 +22,7 @@ To include `defmt` in your existing project, follow our [Application Setup guide
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/defmt/README.md
+++ b/defmt/README.md
@@ -20,7 +20,7 @@ To include `defmt` in your existing project, follow our [Application Setup guide
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/firmware/defmt-test/macros/README.md
+++ b/firmware/defmt-test/macros/README.md
@@ -9,7 +9,7 @@ This library contains the proc macros used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/macros/README.md
+++ b/macros/README.md
@@ -9,7 +9,7 @@ This library contains the proc macros used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-parser"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
+rust-version = "1.83"
 version = "1.0.0"
 
 [dependencies]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-parser"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-rust-version = "1.83"
+rust-version = "1.76"
 version = "1.0.0"
 
 [dependencies]

--- a/parser/README.md
+++ b/parser/README.md
@@ -10,7 +10,7 @@ using that crate to this one.
 
 ## MSRV
 
-The minimum supported Rust version is 1.81. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/parser/README.md
+++ b/parser/README.md
@@ -10,7 +10,7 @@ using that crate to this one.
 
 ## MSRV
 
-The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.76. `defmt` is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/parser/README.md
+++ b/parser/README.md
@@ -10,7 +10,7 @@ using that crate to this one.
 
 ## MSRV
 
-The minimum supported Rust version is 1.76. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.76. This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -15,7 +15,7 @@ version = "1.0.0"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=1.0.0", path = "../decoder" }
+defmt-decoder = { version = "1", path = "../decoder" }
 goblin = "0.9"
 log = "0.4"
 notify = "8"

--- a/print/Cargo.toml
+++ b/print/Cargo.toml
@@ -8,7 +8,8 @@ license = "MIT OR Apache-2.0"
 name = "defmt-print"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.0"
+rust-version = "1.83"
+version = "1.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/print/README.md
+++ b/print/README.md
@@ -9,7 +9,7 @@ data and print it to the console.
 
 ## MSRV
 
-The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.83. This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/print/README.md
+++ b/print/README.md
@@ -7,6 +7,10 @@
 There's no stable library API to decode `defmt` log frames but this tool can be used to decode defmt
 data and print it to the console.
 
+## MSRV
+
+The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
+
 ## Support
 
 `defmt-print` is part of the [Knurling] project, [Ferrous Systems]' effort at

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -13,5 +13,5 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0", features = ["derive", "env"] }
-defmt-decoder = { version = "=1.0.0", path = "../decoder" }
+defmt-decoder = { version = "1", path = "../decoder" }
 log = "0.4.28"

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -8,7 +8,8 @@ license = "MIT OR Apache-2.0"
 name = "qemu-run"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.1.0"
+rust-version = "1.83"
+version = "0.1.1"
 
 [dependencies]
 anyhow = "1"

--- a/qemu-run/README.md
+++ b/qemu-run/README.md
@@ -20,6 +20,10 @@ additional arguments to configure semihosting, and pipe semihosting data into
 
 Run `qemu-run --help` to see a list of other command-line arguments available.
 
+## MSRV
+
+The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
+
 ## Support
 
 `qemu-run` is part of the [Knurling] project, [Ferrous Systems]' effort at

--- a/qemu-run/README.md
+++ b/qemu-run/README.md
@@ -22,7 +22,7 @@ Run `qemu-run --help` to see a list of other command-line arguments available.
 
 ## MSRV
 
-The minimum supported Rust version is 1.83. `defmt` is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.83. This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 


### PR DESCRIPTION
I want to do a defmt-decoder release to get the fix that moves `(HOST)` to the end of the line instead of the start of the line.

It makes `qemu-run` output look much better.

I had to bump the MSRV to 1.83 to solve an issue with the `time` package, and so I will also release qemu-run 0.1.1 and defmt-print 1.1.0.
