### PR TITLE
Pin `time` version to fix backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#1007] `defmt`: impl `Format` for `core::fmt::Error`
 * [#983] Add `Format` implementation for `core::num::Wrapping<T>`
 * [#1022] Re-fix accidental breaking change in `Format` macro
+* [#1031] Fix backcompat test
 
 ### [defmt-v1.0.1] (2025-04-01)
 

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -17,7 +17,7 @@ ryu = "1"
 nom = "7"
 
 # display
-time = { version = "0.3", default-features = false, features = [
+time = { version = "=0.3.44", default-features = false, features = [
     "alloc",
     "formatting",
     "large-dates",

--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -44,7 +44,7 @@ const DISABLED: bool = false;
 
 // use this format: PR <number> - <what feature / change broke compatibility>
 // PR #747 - Bump wire format
-const REVISION_UNDER_TEST: &str = "0e92d3a88aa472377b964979f522829d961d8986";
+const REVISION_UNDER_TEST: &str = "306d45db6ea94972e4acb3e4dec8387f0fc439ff";
 
 // the target name is in `firmware/qemu/.cargo/config.toml` but it'd be hard to extract it from that file
 const RUNNER_ENV_VAR: &str = "CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER";

--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -115,7 +115,10 @@ impl QemuRun {
                 .args(["-q", command, name])
                 .args(["--features", feature])
                 .current_dir(SNAPSHOT_TESTS_DIRECTORY)
-                .env(RUNNER_ENV_VAR, self.path()),
+                .env(
+                    RUNNER_ENV_VAR,
+                    format!("{} --machine lm3s6965evb", self.path().display()),
+                ),
             || anyhow!("{}", name),
         )?;
 


### PR DESCRIPTION
Looks like the current version of `main` is compatible except for the `time` version issue, so once this is merged you can change `REVISION_UNDER_TEST` to `origin/main` or to the next release tag.