### PR TITLE
add Cargo.lock file to revision used for backcompat test

### DIFF
--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -44,7 +44,7 @@ const DISABLED: bool = false;
 
 // use this format: PR <number> - <what feature / change broke compatibility>
 // PR #747 - Bump wire format
-const REVISION_UNDER_TEST: &str = "0e92d3a88aa472377b964979f522829d961d8986";
+const REVISION_UNDER_TEST: &str = "3d66b3160bdba5ec0f9fa38fcfe80c3495b2da32";
 
 // the target name is in `firmware/qemu/.cargo/config.toml` but it'd be hard to extract it from that file
 const RUNNER_ENV_VAR: &str = "CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER";


### PR DESCRIPTION
the revision was missing a lockfile and the workspace resolver defaulted to version 1 which is the non-MSRV (non-`rust-version`) aware resolver

said resolver was choosing package versions incompatible with the MSRV toolchain which caused the build of `qemu-run` to fail after a new package version of `time-core` was published

a commit adding a Rust 1.81 lockfile has been added to the previous under test revision; the resulting revision is tagged
'defmt-v0.3.4-plus-1.81-compatible-lockfile'