### PR TITLE
Add serde Serialize/Deserialize derives to Table and related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,6 +606,7 @@ Initial release
 * [#986] Bump MSRV to 1.81
 * [#966] Add Frame::fragments() and Frame::display_fragments()
 * [#958] Update to object 0.36
+* [#1033] Impl `serde::{Serialize, Deserialize}` and `Clone` on `Table` and related types
 
 ### [defmt-decoder-v1.0.0] (2025-04-01)
 
@@ -986,16 +987,21 @@ Initial release
 
 ---
 
+[#1033]: https://github.com/knurling-rs/defmt/pull/1033
+[#1022]: https://github.com/knurling-rs/defmt/pull/1022
 [#1013]: https://github.com/knurling-rs/defmt/pull/1013
+[#1011]: https://github.com/knurling-rs/defmt/pull/1011
 [#1007]: https://github.com/knurling-rs/defmt/pull/1007
 [#1006]: https://github.com/knurling-rs/defmt/pull/1006
+[#1004]: https://github.com/knurling-rs/defmt/pull/1004
 [#990]: https://github.com/knurling-rs/defmt/pull/990
 [#986]: https://github.com/knurling-rs/defmt/pull/986
+[#985]: https://github.com/knurling-rs/defmt/pull/985
 [#983]: https://github.com/knurling-rs/defmt/pull/983
 [#974]: https://github.com/knurling-rs/defmt/pull/974
 [#972]: https://github.com/knurling-rs/defmt/pull/972
-[#966]: https://github.com/knurling-rs/defmt/pull/966
 [#968]: https://github.com/knurling-rs/defmt/pull/968
+[#966]: https://github.com/knurling-rs/defmt/pull/966
 [#965]: https://github.com/knurling-rs/defmt/pull/965
 [#960]: https://github.com/knurling-rs/defmt/pull/960
 [#959]: https://github.com/knurling-rs/defmt/pull/959
@@ -1003,14 +1009,15 @@ Initial release
 [#956]: https://github.com/knurling-rs/defmt/pull/956
 [#955]: https://github.com/knurling-rs/defmt/pull/955
 [#954]: https://github.com/knurling-rs/defmt/pull/954
+[#952]: https://github.com/knurling-rs/defmt/pull/952
 [#950]: https://github.com/knurling-rs/defmt/pull/950
 [#949]: https://github.com/knurling-rs/defmt/pull/949
 [#948]: https://github.com/knurling-rs/defmt/pull/948
 [#945]: https://github.com/knurling-rs/defmt/pull/945
 [#943]: https://github.com/knurling-rs/defmt/pull/943
 [#940]: https://github.com/knurling-rs/defmt/pull/940
-[#937]: https://github.com/knurling-rs/defmt/pull/937
 [#938]: https://github.com/knurling-rs/defmt/pull/938
+[#937]: https://github.com/knurling-rs/defmt/pull/937
 [#935]: https://github.com/knurling-rs/defmt/pull/935
 [#916]: https://github.com/knurling-rs/defmt/pull/916
 [#915]: https://github.com/knurling-rs/defmt/pull/915

--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -15,6 +15,7 @@ use std::{
 
 use anyhow::{anyhow, bail, ensure};
 use object::{Object, ObjectSection, ObjectSymbol};
+use serde::{Deserialize, Serialize};
 
 use crate::{BitflagsKey, StringEntry, Table, TableEntry, Tag, DEFMT_VERSIONS};
 
@@ -240,7 +241,7 @@ fn check_version(version: &str) -> Result<(), String> {
 }
 
 /// Location of a defmt log statement in the elf-file
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Location {
     pub file: PathBuf,
     pub line: u64,

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
 
 use byteorder::{ReadBytesExt, LE};
 use defmt_parser::Level;
+use serde::{Deserialize, Serialize};
 
 use crate::{decoder::Decoder, elf2table::parse_impl};
 
@@ -35,7 +36,7 @@ pub use crate::{
 };
 
 /// Specifies the origin of a format string
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub enum Tag {
     /// Defmt-controlled format string for primitive types.
     Prim,
@@ -76,7 +77,7 @@ impl Tag {
 }
 
 /// Entry in [`Table`] combining a format string with its raw symbol
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct TableEntry {
     string: StringEntry,
     raw_symbol: String,
@@ -97,7 +98,7 @@ impl TableEntry {
 }
 
 /// A format string and it's [`Tag`]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct StringEntry {
     tag: Tag,
     string: String,
@@ -110,7 +111,7 @@ impl StringEntry {
 }
 
 /// Data that uniquely identifies a `defmt::bitflags!` invocation.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct BitflagsKey {
     /// Name of the bitflags struct (this is really redundant with `disambig`).
     ident: String,
@@ -120,7 +121,7 @@ struct BitflagsKey {
 }
 
 /// How a defmt frame is encoded
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Encoding {
     /// raw data, that is no encoding.
@@ -152,7 +153,7 @@ impl Encoding {
 }
 
 /// Internal table that holds log levels and maps format strings to indices
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Table {
     timestamp: Option<TableEntry>,
     entries: BTreeMap<usize, TableEntry>,


### PR DESCRIPTION
This enables caching the parsed defmt Table to disk, avoiding the need to parse the full ELF file for each test process. The cached table can be loaded in milliseconds instead of the ~6 seconds needed to parse a large ELF.

Types modified:
- Table, TableEntry, StringEntry, Tag, Encoding, BitflagsKey (lib.rs)
- Location (elf2table/mod.rs)

The Locations type is already a BTreeMap alias which supports serde.