### PR TITLE
improve panic printout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.76" # firmware MSRV
+          - "1.81" # firmware MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
       matrix:
         toolchain:
           - "1.87" # we pin clippy because it keeps adding new lints
-          - "1.76" # firmware MSRV
+          - "1.81" # firmware MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         toolchain:
           - "stable"
-          - "1.76" # firmware MSRV
+          - "1.81" # firmware MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +59,7 @@ jobs:
       matrix:
         toolchain:
           - "1.87" # we pin clippy because it keeps adding new lints
-          - "1.76" # firmware MSRV
+          - "1.81" # firmware MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#1007] `defmt`: impl `Format` for `core::fmt::Error`
 * [#983] Add `Format` implementation for `core::num::Wrapping<T>`
 * [#1022] Re-fix accidental breaking change in `Format` macro
+* [#1039] Add support for `PanicInfo::message` if the message is a static string
 
 ### [defmt-v1.0.1] (2025-04-01)
 
@@ -1003,6 +1004,7 @@ Initial release
 
 ---
 
+[#1039]: https://github.com/knurling-rs/defmt/pull/1039
 [#1036]: https://github.com/knurling-rs/defmt/pull/1036
 [#1028]: https://github.com/knurling-rs/defmt/pull/1028
 [#1022]: https://github.com/knurling-rs/defmt/pull/1022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 ### [defmt-next]
 
 * [#1091](https://github.com/knurling-rs/defmt/pull/1091) Allow inner modules to decrease env filter verbosity
+* [#1039](https://github.com/knurling-rs/defmt/pull/1039) Add support for `PanicInfo::message` if the message is a static string.
+* [#1039](https://github.com/knurling-rs/defmt/pull/1039) Add rust-version 1.81 for `defmt` package configuration.
 * [#1089](https://github.com/knurling-rs/defmt/pull/1089) Retain timestamp and bitflags metadata when linking without `defmt.x`.
 * [#1068](https://github.com/knurling-rs/defmt/pull/1068) Adding `Format` impl for `core::str` errors
 * [#1096](https://github.com/knurling-rs/defmt/pull/1096) Implement `Format` for `alloc` Errors

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains the following packages:
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.83 for all host-side crates.
+The minimum supported Rust version is 1.81 (or Ferrocene 24.11) for the crates that cross-compile to your microcontroller. The minimum supported Rust version is 1.83 for all host-side crates.
 
 The `defmt` crates are tested against the latest stable Rust version and the MSRV.
 

--- a/defmt-03/Cargo.toml
+++ b/defmt-03/Cargo.toml
@@ -10,6 +10,7 @@ description = "A highly efficient logging framework that targets resource-constr
 edition = "2021"
 keywords = [ "knurling", "logging", "logger", "formatting", "formatter" ]
 license = "MIT OR Apache-2.0"
+rust-version = "1.81"
 name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"

--- a/defmt-03/README.md
+++ b/defmt-03/README.md
@@ -22,7 +22,7 @@ To include `defmt` in your existing project, follow our [Application Setup guide
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.81 (or Ferrocene 24.11). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -10,6 +10,7 @@ description = "A highly efficient logging framework that targets resource-constr
 edition = "2021"
 keywords = [ "knurling", "logging", "logger", "formatting", "formatter" ]
 license = "MIT OR Apache-2.0"
+rust-version = "1.81"
 links = "defmt" # Prevent multiple versions of defmt being linked
 name = "defmt"
 readme = "README.md"

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -22,6 +22,9 @@ version = "1.1.1"
 alloc = []
 avoid-default-panic = []
 ip_in_core = []
+# Include the panic information message if it is a single string literal. This might increase
+# the code size, but panic printouts might become more useful.
+panic-message = []
 
 # Encoding feature flags. These should only be set by end-user crates, not by library crates.
 #

--- a/defmt/README.md
+++ b/defmt/README.md
@@ -20,7 +20,7 @@ To include `defmt` in your existing project, follow our [Application Setup guide
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.81 (or Ferrocene 24.11). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/defmt/src/impls/core_/panic.rs
+++ b/defmt/src/impls/core_/panic.rs
@@ -9,8 +9,9 @@ impl Format for panic::PanicInfo<'_> {
         } else {
             crate::write!(f, "panicked");
         }
-        // TODO: consider supporting self.message() once stabilized, or add a crate feature for
-        // conditional support
+        if let Some(message) = self.message().as_str() {
+            crate::write!(f, ": {}", message);
+        }
     }
 }
 

--- a/defmt/src/impls/core_/panic.rs
+++ b/defmt/src/impls/core_/panic.rs
@@ -9,6 +9,7 @@ impl Format for panic::PanicInfo<'_> {
         } else {
             crate::write!(f, "panicked");
         }
+        #[cfg(feature = "panic-message")]
         if let Some(message) = self.message().as_str() {
             crate::write!(f, ": {}", message);
         }

--- a/firmware/defmt-test/macros/README.md
+++ b/firmware/defmt-test/macros/README.md
@@ -9,7 +9,7 @@ This library contains the proc macros used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.81 (or Ferrocene 24.11). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -25,6 +25,7 @@ linked_list_allocator = { version = "0.10.2", optional = true }
 alloc = ["defmt/alloc", "alloc-cortex-m", "linked_list_allocator/const_mut_refs"]
 drop-on-contention = ["dep:defmt-rtt", "defmt-rtt/drop-on-contention"]
 ip_in_core = ["defmt/ip_in_core"]
+panic-message = ["defmt/panic-message"]
 
 [[bin]]
 name = "alloc"

--- a/firmware/qemu/src/bin/panic_info.out
+++ b/firmware/qemu/src/bin/panic_info.out
@@ -1,1 +1,1 @@
-INFO  PanicInfo: panicked at qemu/src/bin/panic_info.rs:14:5
+INFO  PanicInfo: panicked at qemu/src/bin/panic_info.rs:14:5: aaah!

--- a/firmware/qemu/src/bin/panic_info.out
+++ b/firmware/qemu/src/bin/panic_info.out
@@ -1,1 +1,1 @@
-INFO  PanicInfo: panicked at qemu/src/bin/panic_info.rs:16:5
+INFO  PanicInfo: panicked at qemu/src/bin/panic_info.rs:16:5: aaah!

--- a/macros/README.md
+++ b/macros/README.md
@@ -9,7 +9,7 @@ This library contains the proc macros used by
 
 ## MSRV
 
-The minimum supported Rust version is 1.76 (or Ferrocene 24.05). This crate is tested against the latest stable Rust version and the MSRV.
+The minimum supported Rust version is 1.81 (or Ferrocene 24.11). This crate is tested against the latest stable Rust version and the MSRV.
 
 ## Support
 

--- a/xtask/src/snapshot.rs
+++ b/xtask/src/snapshot.rs
@@ -97,6 +97,7 @@ fn snapshot_features(test: &str) -> &str {
         "alloc" => "alloc",
         "drop-on-contention" => "drop-on-contention",
         "net" => "ip_in_core",
+        "panic_info" => "panic-message",
         _ => "",
     }
 }

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -96,7 +96,7 @@ pub fn rustc_is_nightly() -> bool {
 }
 
 pub fn rustc_is_msrv() -> bool {
-    const MSRV: &str = "1.76";
+    const MSRV: &str = "1.81";
     let out = run_capturing_stdout(Command::new("rustc").args(["-V"])).unwrap();
     out.contains(MSRV)
 }


### PR DESCRIPTION
Adds a call to the [`PanicInfo::message`](https://doc.rust-lang.org/stable/core/panic/struct.PanicInfo.html#method.message) function, which was added in Rust 1.81. This means doing a defmt write of a `core::panic::PanicInfo` now includes the panic message, if and only if the panic message was a single string literal.