### PR TITLE
fix: use section-relative offsets for .defmt symbol lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -608,6 +608,8 @@ Initial release
 
 ### [defmt-decoder-next]
 
+* [#1040] Fix tag lookup failure when `.defmt` section has a non-zero base address
+
 ### [defmt-decoder-v1.1.0] (2026-01-20)
 
 * [#1004] decoder: add `Send + Sync` bound to returned `StreamDecoder`

--- a/decoder/src/elf2table/mod.rs
+++ b/decoder/src/elf2table/mod.rs
@@ -157,7 +157,7 @@ pub fn parse_impl(elf: &[u8], check_version: bool) -> Result<Option<Table>, anyh
                     }
 
                     let defmt_data = defmt_section.data()?;
-                    let addr = entry.address() as usize;
+                    let addr = (entry.address() - defmt_section.address()) as usize;
                     let value = match defmt_data.get(addr..addr + 16) {
                         Some(bytes) => u128::from_le_bytes(bytes.try_into().unwrap()),
                         None => bail!(
@@ -190,7 +190,7 @@ pub fn parse_impl(elf: &[u8], check_version: bool) -> Result<Option<Table>, anyh
                 }
                 symbol::SymbolTag::Defmt(tag) => {
                     map.insert(
-                        entry.address() as usize,
+                        (entry.address() - defmt_section.address()) as usize,
                         TableEntry::new(
                             StringEntry::new(tag, sym.data().to_string()),
                             name.to_string(),


### PR DESCRIPTION
**Summary**

- Fix tag lookup failure when the `.defmt` section has a non-zero base address
- Use section-relative offsets (matching what the firmware encodes) instead of raw VMAs as map keys

**Problem**

The firmware side encodes defmt tags by casting the symbol address to `u16`:

```rust
&#var_name as *const u8 as u16
```

This naturally truncates the address to a section-relative offset when the `.defmt` section is aligned (e.g. at `0x20000000` → tag becomes `0x0006`).

However, `elf2table` builds its lookup map using the full VMA (`entry.address()`) as the key. When the decoder extracts tag `6` from the wire format and looks up `entries[6]`, it finds nothing because the entry is actually stored under `entries[0x20000006]`, and the frame is reported as malformed.

This potentially affects any linker configuration where `.defmt` has a non-zero section address, which is sometimes needed for RISC-V (when `.defmt` must be within ±2 GiB of `.text` for `auipc` relocations).

**Fix**

Subtract `defmt_section.address()` from `entry.address()` when building the map keys and when indexing into section data for bitflags values, so the keys match the truncated `u16` tags the firmware sends.

**Testing**

- Verified with a RISC-V bare-metal kernel where `.defmt` is at VMA `0x20000000`
- Before: all frames reported as "malformed frame skipped"
- After: frames decode correctly

---

This patch and commit massage were written with the help of Claude Code, but I have personally (and manually) refined and verified its outputs.