### PR TITLE
Ignore RUSTSEC-2026-0009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#1007] `defmt`: impl `Format` for `core::fmt::Error`
 * [#983] Add `Format` implementation for `core::num::Wrapping<T>`
 * [#1022] Re-fix accidental breaking change in `Format` macro
+* [#1041] Ignore RUSTSEC-2026-0009
 
 ### [defmt-v1.0.1] (2025-04-01)
 
@@ -1003,6 +1004,7 @@ Initial release
 
 ---
 
+[#1041]: https://github.com/knurling-rs/defmt/pull/1041
 [#1036]: https://github.com/knurling-rs/defmt/pull/1036
 [#1028]: https://github.com/knurling-rs/defmt/pull/1028
 [#1022]: https://github.com/knurling-rs/defmt/pull/1022

--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,7 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+    "RUSTSEC-2026-0009", # Only affects functionality gated by the `parsing`-feature which we don't use
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
I believe this is safe to ignore the advisory because the vulnerability only affects functionality gated by the `parsing` feature in the `time` crate, which we don't have enabled.
Bumping the time dependency would also require bumping the MSRV.

- Closes #1038 