### PR TITLE
Use general semihosting crate instead of cortex-m specific crate

### DIFF
--- a/.github/workflows/cargo-semver-check.yml
+++ b/.github/workflows/cargo-semver-check.yml
@@ -39,5 +39,5 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           manifest-path: firmware/
-          exclude: defmt-semihosting
+          exclude: defmt-semihosting,defmt-test
           # rust-target: thumbv7em-none-eabihf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -891,6 +891,7 @@ Initial release
 ### [defmt-test-next]
 
 * [#1049] Pin trybuild to 1.0.89
+* [#1046] Replace `cortex-m-semihosting` with generic `semihosting` crate to support non-Cortex-M thumb targets
 
 ### [defmt-test-v0.4.0] (2025-04-01)
 
@@ -1010,6 +1011,7 @@ Initial release
 [#1049]: https://github.com/knurling-rs/defmt/pull/1049
 [#1048]: https://github.com/knurling-rs/defmt/pull/1048
 [#1047]: https://github.com/knurling-rs/defmt/pull/1047
+[#1046]: https://github.com/knurling-rs/defmt/pull/1046
 [#1044]: https://github.com/knurling-rs/defmt/pull/1044
 [#1041]: https://github.com/knurling-rs/defmt/pull/1041
 [#1036]: https://github.com/knurling-rs/defmt/pull/1036

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.4.0"
 
 [dependencies]
-cortex-m-rt = "0.7"
-cortex-m-semihosting = "0.5"
+semihosting = { version = "0.1" }
 defmt = { version = "1", path = "../../defmt" }
 defmt-test-macros = { version = "=0.3.2", path = "macros" }

--- a/firmware/defmt-test/src/export.rs
+++ b/firmware/defmt-test/src/export.rs
@@ -1,15 +1,14 @@
-use cortex_m_rt as _;
-use cortex_m_semihosting::debug;
 pub use defmt::info;
 
 use crate::TestOutcome;
 
-/// Terminates the application and makes a semihosting-capable debug tool exit
-/// with status code 0.
+/// Terminates the application and reports successful exit to the debugger.
+///
+/// Uses ARM semihosting to signal program termination. First attempts the extended
+/// exit operation for better exit code support, then falls back to the standard
+/// operation if unsupported by the debugger.
 pub fn exit() -> ! {
-    loop {
-        debug::exit(debug::EXIT_SUCCESS);
-    }
+    semihosting::process::exit(0);
 }
 
 pub fn check_outcome<T: TestOutcome>(outcome: T, should_error: bool) {

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -16,7 +16,7 @@ defmt-semihosting = { path = "../defmt-semihosting" }
 defmt-test = { path = "../defmt-test" }
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
-cortex-m-semihosting = "0.5"
+semihosting = { version = "0.1" }
 alloc-cortex-m = { version = "0.4", optional = true }
 linked_list_allocator = { version = "0.10.2", optional = true }
 

--- a/firmware/qemu/src/bin/alloc.rs
+++ b/firmware/qemu/src/bin/alloc.rs
@@ -12,9 +12,10 @@ use alloc::sync::Arc;
 use alloc::vec;
 use core::sync::atomic::{AtomicU32, Ordering};
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 use defmt::Format;
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -43,9 +44,7 @@ fn main() -> ! {
     defmt::info!("Cow<str>: {=?}", Cow::from("moo"));
     defmt::info!("Cow<String>: {=?}", String::from("moo, but allocated"));
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process();
 }
 
 #[derive(Format)]
@@ -90,7 +89,5 @@ mod if_alloc {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/assert-eq.rs
+++ b/firmware/qemu/src/bin/assert-eq.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
 
 use defmt_semihosting as _; // global logger
@@ -19,9 +20,5 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    use cortex_m_semihosting::debug;
-
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    semihosting::process::ExitCode::SUCCESS.exit_process()
 }

--- a/firmware/qemu/src/bin/assert-ne.rs
+++ b/firmware/qemu/src/bin/assert-ne.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
 
 use defmt_semihosting as _; // global logger
@@ -19,9 +20,5 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    use cortex_m_semihosting::debug;
-
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    semihosting::process::ExitCode::SUCCESS.exit_process()
 }

--- a/firmware/qemu/src/bin/assert.rs
+++ b/firmware/qemu/src/bin/assert.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
 
 use defmt_semihosting as _; // global logger
@@ -20,9 +21,5 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    use cortex_m_semihosting::debug;
-
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    semihosting::process::ExitCode::SUCCESS.exit_process()
 }

--- a/firmware/qemu/src/bin/bitflags.rs
+++ b/firmware/qemu/src/bin/bitflags.rs
@@ -2,9 +2,10 @@
 #![no_main]
 #![allow(clippy::bad_bit_mask)]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 use defmt::{bitflags, Debug2Format};
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -66,16 +67,12 @@ fn main() -> ! {
         Debug2Format(&LargeFlags::empty())
     );
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 // like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/dbg.rs
+++ b/firmware/qemu/src/bin/dbg.rs
@@ -1,8 +1,9 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
+use semihosting::process::ExitCode;
 
 use defmt::dbg;
 use defmt_semihosting as _; // global logger
@@ -28,9 +29,7 @@ fn main() -> ! {
     #[allow(clippy::double_parens)]
     foo(dbg!(x,));
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 fn foo(_: i32) {}
@@ -39,7 +38,5 @@ fn foo(_: i32) {}
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/hints.rs
+++ b/firmware/qemu/src/bin/hints.rs
@@ -3,8 +3,9 @@
 
 use core::sync::atomic::{AtomicU32, Ordering};
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
+use semihosting::process::ExitCode;
 
 use defmt::{intern, write, Format, Formatter};
 use defmt_semihosting as _; // global logger
@@ -146,9 +147,7 @@ fn main() -> ! {
     defmt::info!("Time ms {:tms}", 1_234_567_u64);
     defmt::info!("Time us {:tus}", 1_234_567_u64);
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 static COUNT: AtomicU32 = AtomicU32::new(0);
@@ -158,7 +157,5 @@ defmt::timestamp!("{=u32:us}", COUNT.fetch_add(1, Ordering::Relaxed));
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/hints_inner.rs
+++ b/firmware/qemu/src/bin/hints_inner.rs
@@ -3,8 +3,9 @@
 
 use core::sync::atomic::{AtomicU32, Ordering};
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
+use semihosting::process::ExitCode;
 
 use defmt::write;
 use defmt_semihosting as _; // global logger
@@ -124,9 +125,7 @@ fn main() -> ! {
         defmt::info!("{:#x}", S1 { x: "hi", y: 42 });
     }
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 static COUNT: AtomicU32 = AtomicU32::new(0);
@@ -136,7 +135,5 @@ defmt::timestamp!("{=u32:us}", COUNT.fetch_add(1, Ordering::Relaxed));
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/log.rs
+++ b/firmware/qemu/src/bin/log.rs
@@ -2,9 +2,10 @@
 #![no_main]
 
 use core::{marker::PhantomData, num};
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 use defmt::{Debug2Format, Display2Format, Format, Formatter};
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -780,9 +781,7 @@ fn main() -> ! {
 
     defmt::info!("QEMU test finished!");
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 #[derive(Format)]
@@ -811,7 +810,5 @@ impl Format for True {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/net.rs
+++ b/firmware/qemu/src/bin/net.rs
@@ -5,8 +5,9 @@ use core::net::{
     AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6,
 };
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -26,16 +27,12 @@ fn main() -> ! {
 
     defmt::dbg!(a, b, c, d, e, f, g, h, i);
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 // like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/panic.rs
+++ b/firmware/qemu/src/bin/panic.rs
@@ -1,7 +1,9 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -20,9 +22,5 @@ fn main() -> ! {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    use cortex_m_semihosting::debug;
-
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }

--- a/firmware/qemu/src/bin/panic_info.out
+++ b/firmware/qemu/src/bin/panic_info.out
@@ -1,1 +1,1 @@
-INFO  PanicInfo: panicked at qemu/src/bin/panic_info.rs:14:5
+INFO  PanicInfo: panicked at qemu/src/bin/panic_info.rs:16:5

--- a/firmware/qemu/src/bin/panic_info.rs
+++ b/firmware/qemu/src/bin/panic_info.rs
@@ -1,8 +1,10 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
+
 use core::panic;
-use cortex_m_semihosting::debug;
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -17,7 +19,5 @@ fn main() -> ! {
 #[panic_handler]
 fn panic(panic_info: &panic::PanicInfo) -> ! {
     defmt::info!("PanicInfo: {=?}", panic_info);
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }

--- a/firmware/qemu/src/bin/timestamp.rs
+++ b/firmware/qemu/src/bin/timestamp.rs
@@ -1,9 +1,10 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
 use defmt::{write, Format, Formatter};
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -13,9 +14,7 @@ fn main() -> ! {
 
     defmt::println!("Hello {}{}", "World", '!');
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 struct Timestamp {
@@ -44,7 +43,5 @@ defmt::timestamp!(
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_FAILURE)
-    }
+    ExitCode::FAILURE.exit_process()
 }

--- a/firmware/qemu/src/bin/unwrap.rs
+++ b/firmware/qemu/src/bin/unwrap.rs
@@ -1,8 +1,9 @@
 #![no_std]
 #![no_main]
 
+use cortex_m as _;
 use cortex_m_rt::entry;
-use cortex_m_semihosting::debug;
+use semihosting::process::ExitCode;
 
 use defmt_semihosting as _; // global logger
 
@@ -18,16 +19,12 @@ fn main() -> ! {
     let x: Result<u32, Error> = Err(Error::Bar);
     defmt::info!("The answer is {=?}", defmt::unwrap!(x));
 
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }
 
 // like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        debug::exit(debug::EXIT_SUCCESS)
-    }
+    ExitCode::SUCCESS.exit_process()
 }

--- a/firmware/qemu/tests/defmt-test.rs
+++ b/firmware/qemu/tests/defmt-test.rs
@@ -2,6 +2,8 @@
 #![no_main]
 
 use core::sync::atomic::{AtomicBool, Ordering};
+use cortex_m as _;
+use cortex_m_rt as _;
 
 use defmt_semihosting as _; // global logger
 
@@ -98,14 +100,12 @@ mod tests {
 #[cfg(target_os = "none")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    use cortex_m_semihosting::debug;
+    use semihosting::process::ExitCode;
 
-    loop {
-        let exit_code = if MAY_PANIC.load(Ordering::Relaxed) {
-            debug::EXIT_SUCCESS
-        } else {
-            debug::EXIT_FAILURE
-        };
-        debug::exit(exit_code)
-    }
+    let exit_code = if MAY_PANIC.load(Ordering::Relaxed) {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    };
+    exit_code.exit_process();
 }


### PR DESCRIPTION
Defmt-test build fails for non-CortexM thumb targets. Instead of using a semihosting cortex-m specific crate, use a general semihosting crate.

Fixes #829