### PR TITLE
Fix qemu-run uart printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -969,7 +969,7 @@ Initial release
 
 ### [qemu-run-next]
 
-* No changes
+* [#1048] Fixed UART read timeout issue ([#1047])
 
 ### [qemu-run-v0.1.1]
 
@@ -1004,6 +1004,8 @@ Initial release
 
 ---
 
+[#1048]: https://github.com/knurling-rs/defmt/pull/1048
+[#1047]: https://github.com/knurling-rs/defmt/pull/1047
 [#1041]: https://github.com/knurling-rs/defmt/pull/1041
 [#1036]: https://github.com/knurling-rs/defmt/pull/1036
 [#1028]: https://github.com/knurling-rs/defmt/pull/1028

--- a/qemu-run/README.md
+++ b/qemu-run/README.md
@@ -11,7 +11,7 @@ Set as your cargo runner, e.g. in your `.cargo/config.toml` file:
 
 ```toml
 [target.thumbv7em-none-eabihf]
-runner = "qemu-run -machine lm3s6965evb"
+runner = "qemu-run --machine lm3s6965evb --cpu cortex-m3"
 ```
 
 It will execute `qemu-system-arm`, pass the given `-machine` argument, pass
@@ -19,6 +19,9 @@ additional arguments to configure semihosting, and pipe semihosting data into
 `defmt-decoder` to be decoded and printed to the console.
 
 Run `qemu-run --help` to see a list of other command-line arguments available.
+
+Note that `qemu-system-arm` takes long arguments with a single dash (`-`), but
+`qemu-run` takes long arguments with a double dash (`--`).
 
 ## MSRV
 

--- a/qemu-run/src/main.rs
+++ b/qemu-run/src/main.rs
@@ -310,17 +310,28 @@ fn print_version() -> anyhow::Result<Option<i32>> {
 
 /// Dumps UTF-8 data received on a socket to stdout, line by line
 fn print_loop(socket: std::net::TcpListener) {
+    use std::io::{BufReader, ErrorKind};
     for conn in socket.incoming().flatten() {
         conn.set_read_timeout(Some(std::time::Duration::from_millis(100)))
             .expect("Setting socket timeout");
-        let mut reader = std::io::BufReader::new(conn);
+        let mut reader = BufReader::new(conn);
         loop {
             let mut buffer = String::new();
-            let Ok(_len) = reader.read_line(&mut buffer) else {
-                break;
-            };
+            let res = reader.read_line(&mut buffer);
             if !buffer.is_empty() {
                 log::info!("UART got: {:?}", buffer);
+            }
+            match res {
+                Ok(_n) => {
+                    // do nothing
+                }
+                Err(e) if e.kind() == ErrorKind::TimedOut || e.kind() == ErrorKind::WouldBlock => {
+                    // do nothing
+                }
+                Err(e) => {
+                    log::warn!("UART disconnected ({e:?}");
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Fix for #1047 - now we carry on in the event of a UART-over-TCP read timeout.
