### PR TITLE
Pin trybuild to 1.0.89 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -888,7 +888,7 @@ Initial release
 
 ### [defmt-test-next]
 
-* No changes
+* [#1049] Pin trybuild to 1.0.89
 
 ### [defmt-test-v0.4.0] (2025-04-01)
 
@@ -1004,6 +1004,7 @@ Initial release
 
 ---
 
+[#1049]: https://github.com/knurling-rs/defmt/pull/1049
 [#1041]: https://github.com/knurling-rs/defmt/pull/1041
 [#1036]: https://github.com/knurling-rs/defmt/pull/1036
 [#1028]: https://github.com/knurling-rs/defmt/pull/1028

--- a/firmware/defmt-test/macros/Cargo.toml
+++ b/firmware/defmt-test/macros/Cargo.toml
@@ -18,4 +18,4 @@ quote = "1"
 syn = { version = "2", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
-trybuild = "1"
+trybuild = "=1.0.89"


### PR DESCRIPTION
This PR pins the trybuild dependency only for macro UI tests to keep compatibility with 2021 edition.
Fixes CI failures like [this](https://github.com/knurling-rs/defmt/actions/runs/24139792481/job/70437664901?pr=1048) in #1048 