### PR TITLE
Refactor avoid-default-panic to not rely on the linker script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#983] Add `Format` implementation for `core::num::Wrapping<T>`
 * [#1022] Re-fix accidental breaking change in `Format` macro
 * [#1041] Ignore RUSTSEC-2026-0009
+* [#1050] Refactor avoid-default-panic to not rely on the linker script
 
 ### [defmt-v1.0.1] (2025-04-01)
 
@@ -1004,6 +1005,7 @@ Initial release
 
 ---
 
+[#1050]: https://github.com/knurling-rs/defmt/pull/1050
 [#1049]: https://github.com/knurling-rs/defmt/pull/1049
 [#1041]: https://github.com/knurling-rs/defmt/pull/1041
 [#1036]: https://github.com/knurling-rs/defmt/pull/1036

--- a/defmt/build.rs
+++ b/defmt/build.rs
@@ -2,12 +2,7 @@ use std::{env, error::Error, fs, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Read the linker script
-    let mut linker_script = fs::read_to_string("defmt.x.in")?;
-
-    // Optionally exclude default panic handler
-    if cfg!(feature = "avoid-default-panic") {
-        linker_script = avoid_default_panic(linker_script);
-    }
+    let linker_script = fs::read_to_string("defmt.x.in")?;
 
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var("OUT_DIR")?);
@@ -36,8 +31,4 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
-}
-
-fn avoid_default_panic(linker_script: String) -> String {
-    linker_script.replacen("PROVIDE(_defmt_panic = __defmt_default_panic);", "", 1)
 }

--- a/defmt/defmt.x.in
+++ b/defmt/defmt.x.in
@@ -4,7 +4,6 @@ EXTERN(_defmt_release);
 EXTERN(__defmt_default_timestamp);
 EXTERN(__DEFMT_MARKER_TIMESTAMP_WAS_DEFINED);
 PROVIDE(_defmt_timestamp = __defmt_default_timestamp);
-PROVIDE(_defmt_panic = __defmt_default_panic);
 
 SECTIONS
 {

--- a/defmt/src/lib.rs
+++ b/defmt/src/lib.rs
@@ -380,8 +380,9 @@ pub use defmt_macros::Format;
 #[export_name = "__defmt_default_timestamp"]
 fn default_timestamp(_f: Formatter<'_>) {}
 
-#[export_name = "__defmt_default_panic"]
-fn default_panic() -> ! {
+#[cfg(not(feature = "avoid-default-panic"))]
+#[export_name = "_defmt_panic"]
+fn defmt_panic() -> ! {
     core::panic!()
 }
 


### PR DESCRIPTION
#812 introduced a feature to remove the default panicking behavior from for `defmt::panic` in case the user provides [their own panic handler](https://docs.rs/defmt/latest/defmt/attr.panic_handler.html).
I don't know why this was implemented by modifying the linker script instead of just `cfg`ing out the whole function.

Not using the linker script for this also improves compatibility with macOS, see https://github.com/knurling-rs/defmt/pull/1029#issuecomment-4188847484

# Details

- `defmt::panic` logs its error message, then calls `_defmt_panic` to do the actual panicking.
- Previously, `_defmt_panic` wasn't defined anywhere but instead there was `__defmt_default_panic`.
- These two symbols were then combined in the linker script unless the `avoid-default-panic` feature was enabled.
- The new behavior just defines `_defmt_panic` IFF the feature is not enabled