### PR TITLE
Pin UI tests to host MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
       - name: Check that all crates that can be compiled for the host build, check that defmt compiles with different features, run all unit tests on the host
-        run: cargo xtask -d test-host ${{ matrix.toolchain == '1.83' && '--skip-ui-tests' || '' }}
+        run: cargo xtask -d test-host ${{ matrix.toolchain == 'stable' && '--skip-ui-tests' || '' }}
 
   cross:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 * [#983] Add `Format` implementation for `core::num::Wrapping<T>`
 * [#1022] Re-fix accidental breaking change in `Format` macro
 * [#1041] Ignore RUSTSEC-2026-0009
+* [#1052] Pin UI tests to host MSRV
 
 ### [defmt-v1.0.1] (2025-04-01)
 
@@ -1004,6 +1005,7 @@ Initial release
 
 ---
 
+[#1052]: https://github.com/knurling-rs/defmt/pull/1052
 [#1049]: https://github.com/knurling-rs/defmt/pull/1049
 [#1048]: https://github.com/knurling-rs/defmt/pull/1048
 [#1047]: https://github.com/knurling-rs/defmt/pull/1047

--- a/defmt/tests/ui/derive-invalid-crate-overwrite.stderr
+++ b/defmt/tests/ui/derive-invalid-crate-overwrite.stderr
@@ -18,16 +18,8 @@ error[E0432]: unresolved import `unresolved`
   |
   = note: this error originates in the derive macro `defmt::Format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
+error[E0433]: failed to resolve: use of undeclared crate or module `unresolved`
  --> tests/ui/derive-invalid-crate-overwrite.rs:2:17
   |
 2 | #[defmt(crate = unresolved)]
-  |                 ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
-
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
- --> tests/ui/derive-invalid-crate-overwrite.rs:2:17
-  |
-2 | #[defmt(crate = unresolved)]
-  |                 ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
-  |
-  = help: if you wanted to use a crate named `unresolved`, use `cargo add unresolved` to add it to your `Cargo.toml`
+  |                 ^^^^^^^^^^ use of undeclared crate or module `unresolved`

--- a/defmt/tests/ui/log-missing-format-impl.stderr
+++ b/defmt/tests/ui/log-missing-format-impl.stderr
@@ -2,13 +2,8 @@ error[E0277]: the trait bound `Foo: Format` is not satisfied
  --> tests/ui/log-missing-format-impl.rs:4:5
   |
 4 |     defmt::info!("{}", Foo)
-  |     ^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+  |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Format` is not implemented for `Foo`
   |
-help: the trait `Format` is not implemented for `Foo`
- --> tests/ui/log-missing-format-impl.rs:1:1
-  |
-1 | struct Foo;
-  | ^^^^^^^^^^
   = help: the following other types implement trait `Format`:
             &T
             &mut T


### PR DESCRIPTION
### What?

Change the Rust version UI tests are executed on from stable to the project's host MSRV.

### Why?

The UI tests ensure that the error messages generated by the compiler are reasonable for each test case.
But since these error messages also depend on the compiler version, it doesn't make sense to check against multiple compiler version (or we'd have to duplicate the expected output).
#948 limited the UI tests to only run with the stable compiler version.
However, as "stable" as that sounds, it is still a moving target, leading to CI breakage on main and causing unnecessary friction for PR authors.