### PR TITLE
defmt-rtt: drop-on-contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -755,7 +755,7 @@ Initial release
 
 * [#1006] Fix `available_buffer_size` ignoring available buffer space when `read < write`
 * [#1013] Switch to fixed 32-bit types, to support 64-bit targets
-* [#1053] Add the `disable-irq-masking` feature to trade low interrupt latency for reliable RTT delivery
+* [#1053] Add the `drop-on-contention` feature to trade low interrupt latency for reliable RTT delivery
 
 ### [defmt-rtt-v1.1.0] (2025-10-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -755,6 +755,7 @@ Initial release
 
 * [#1006] Fix `available_buffer_size` ignoring available buffer space when `read < write`
 * [#1013] Switch to fixed 32-bit types, to support 64-bit targets
+* [#1053] Add the `disable-irq-masking` feature to trade low interrupt latency for reliable RTT delivery
 
 ### [defmt-rtt-v1.1.0] (2025-10-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1019,6 +1019,7 @@ Initial release
 
 ---
 
+[#1053]: https://github.com/knurling-rs/defmt/pull/1053
 [#1055]: https://github.com/knurling-rs/defmt/pull/1055
 [#1052]: https://github.com/knurling-rs/defmt/pull/1052
 [#1049]: https://github.com/knurling-rs/defmt/pull/1049

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -12,7 +12,7 @@ version = "1.2.0"
 
 [features]
 disable-blocking-mode = []
-disable-irq-masking = []
+drop-on-contention = []
 
 [dependencies]
 defmt = { version = "1", path = "../../defmt" }

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -12,6 +12,7 @@ version = "1.2.0"
 
 [features]
 disable-blocking-mode = []
+disable-irq-masking = []
 
 [dependencies]
 defmt = { version = "1", path = "../../defmt" }

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -24,6 +24,7 @@ pub(crate) struct Channel {
     pub flags: AtomicU32,
 }
 
+#[cfg(not(feature = "disable-irq-masking"))]
 impl Channel {
     pub fn write_all(&self, mut bytes: &[u8]) {
         // the host-connection-status is only modified after RAM initialization while the device is
@@ -92,7 +93,62 @@ impl Channel {
         // return the number of bytes written
         len
     }
+}
 
+#[cfg(feature = "disable-irq-masking")]
+impl Channel {
+    pub fn stage_bytes(&self, cursor: &mut usize, bytes: &[u8]) -> bool {
+        if bytes.is_empty() || bytes.len() >= BUF_SIZE {
+            return bytes.is_empty();
+        }
+
+        #[cfg(feature = "disable-blocking-mode")]
+        {
+            let read = self.read.load(Ordering::Relaxed) as usize;
+            if available_buffer_size(read, *cursor) < bytes.len() {
+                return false;
+            }
+        }
+
+        #[cfg(not(feature = "disable-blocking-mode"))]
+        if !self.host_is_connected() {
+            let read = self.read.load(Ordering::Relaxed) as usize;
+            if available_buffer_size(read, *cursor) < bytes.len() {
+                return false;
+            }
+        } else {
+            while {
+                let read = self.read.load(Ordering::Relaxed) as usize;
+                available_buffer_size(read, *cursor) < bytes.len()
+            } {}
+        }
+
+        unsafe {
+            if *cursor + bytes.len() > BUF_SIZE {
+                let pivot = BUF_SIZE - *cursor;
+                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(*cursor), pivot);
+                ptr::copy_nonoverlapping(
+                    bytes.as_ptr().add(pivot),
+                    self.buffer,
+                    bytes.len() - pivot,
+                );
+            } else {
+                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(*cursor), bytes.len());
+            }
+        }
+
+        *cursor = cursor.wrapping_add(bytes.len()) % BUF_SIZE;
+        true
+    }
+
+    pub fn commit(&self, cursor: usize) {
+        // The owner staged the complete frame first, so a single write-pointer
+        // update publishes either the whole frame or nothing.
+        self.write.store(cursor as u32, Ordering::Release);
+    }
+}
+
+impl Channel {
     pub fn flush(&self) {
         // return early, if host is disconnected
         if !self.host_is_connected() {
@@ -112,7 +168,7 @@ impl Channel {
 }
 
 /// How much space is left in the buffer?
-fn available_buffer_size(read_cursor: usize, write_cursor: usize) -> usize {
+pub(crate) fn available_buffer_size(read_cursor: usize, write_cursor: usize) -> usize {
     if read_cursor > write_cursor {
         read_cursor - write_cursor - 1
     } else {
@@ -122,8 +178,12 @@ fn available_buffer_size(read_cursor: usize, write_cursor: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::available_buffer_size;
-    use crate::consts::BUF_SIZE;
+    use super::{available_buffer_size, Channel};
+    use crate::{consts::BUF_SIZE, MODE_NON_BLOCKING_TRIM};
+    use core::{
+        ptr,
+        sync::atomic::{AtomicU32, Ordering},
+    };
 
     #[test]
     fn test_rtt_available_buffer_size() {
@@ -176,5 +236,49 @@ mod tests {
                 assert_eq!(actual, expected, "Mismatch at read={read}, write={write}");
             }
         }
+    }
+
+    #[cfg(feature = "disable-irq-masking")]
+    #[test]
+    fn staged_bytes_stay_hidden_until_commit() {
+        let mut buffer = [0u8; BUF_SIZE];
+        let channel = Channel {
+            name: ptr::null(),
+            buffer: buffer.as_mut_ptr(),
+            size: BUF_SIZE as u32,
+            write: AtomicU32::new(0),
+            read: AtomicU32::new(0),
+            flags: AtomicU32::new(MODE_NON_BLOCKING_TRIM),
+        };
+        let mut cursor = 0;
+
+        assert!(channel.stage_bytes(&mut cursor, b"abc"));
+        assert_eq!(cursor, 3);
+        assert_eq!(channel.write.load(Ordering::Relaxed), 0);
+        assert_eq!(&buffer[..3], b"abc");
+
+        channel.commit(cursor);
+        assert_eq!(channel.write.load(Ordering::Relaxed), 3);
+    }
+
+    #[cfg(feature = "disable-irq-masking")]
+    #[test]
+    fn staged_bytes_wrap_without_publishing() {
+        let mut buffer = [0u8; BUF_SIZE];
+        let channel = Channel {
+            name: ptr::null(),
+            buffer: buffer.as_mut_ptr(),
+            size: BUF_SIZE as u32,
+            write: AtomicU32::new(0),
+            read: AtomicU32::new(8),
+            flags: AtomicU32::new(MODE_NON_BLOCKING_TRIM),
+        };
+        let mut cursor = BUF_SIZE - 2;
+
+        assert!(channel.stage_bytes(&mut cursor, b"wxyz"));
+        assert_eq!(cursor, 2);
+        assert_eq!(channel.write.load(Ordering::Relaxed), 0);
+        assert_eq!(&buffer[BUF_SIZE - 2..], b"wx");
+        assert_eq!(&buffer[..2], b"yz");
     }
 }

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -73,15 +73,7 @@ impl Channel {
 
         // copy `bytes[..len]` to the RTT buffer
         unsafe {
-            if cursor + len > BUF_SIZE {
-                // split memcpy
-                let pivot = BUF_SIZE - cursor;
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), pivot);
-                ptr::copy_nonoverlapping(bytes.as_ptr().add(pivot), self.buffer, len - pivot);
-            } else {
-                // single memcpy
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), len);
-            }
+            self.copy_wrapping(&bytes[..len], cursor);
         }
 
         // adjust the write pointer, so the host knows that there is new data
@@ -102,16 +94,7 @@ impl Channel {
             return bytes.is_empty();
         }
 
-        #[cfg(feature = "disable-blocking-mode")]
-        {
-            let read = self.read.load(Ordering::Relaxed) as usize;
-            if available_buffer_size(read, *cursor) < bytes.len() {
-                return false;
-            }
-        }
-
-        #[cfg(not(feature = "disable-blocking-mode"))]
-        if !self.host_is_connected() {
+        if cfg!(feature = "disable-blocking-mode") || !self.host_is_connected() {
             let read = self.read.load(Ordering::Relaxed) as usize;
             if available_buffer_size(read, *cursor) < bytes.len() {
                 return false;
@@ -123,20 +106,12 @@ impl Channel {
             } {}
         }
 
+        // copy `bytes` to the RTT buffer
         unsafe {
-            if *cursor + bytes.len() > BUF_SIZE {
-                let pivot = BUF_SIZE - *cursor;
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(*cursor), pivot);
-                ptr::copy_nonoverlapping(
-                    bytes.as_ptr().add(pivot),
-                    self.buffer,
-                    bytes.len() - pivot,
-                );
-            } else {
-                ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(*cursor), bytes.len());
-            }
+            self.copy_wrapping(&bytes, *cursor);
         }
 
+        // advance the cursor
         *cursor = cursor.wrapping_add(bytes.len()) % BUF_SIZE;
         true
     }
@@ -149,6 +124,18 @@ impl Channel {
 }
 
 impl Channel {
+    unsafe fn copy_wrapping(&self, bytes: &[u8], cursor: usize) {
+        if cursor + bytes.len() > BUF_SIZE {
+            // split memcpy
+            let pivot = BUF_SIZE - cursor;
+            ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), pivot);
+            ptr::copy_nonoverlapping(bytes.as_ptr().add(pivot), self.buffer, bytes.len() - pivot);
+        } else {
+            // single memcpy
+            ptr::copy_nonoverlapping(bytes.as_ptr(), self.buffer.add(cursor), bytes.len());
+        }
+    }
+
     pub fn flush(&self) {
         // return early, if host is disconnected
         if !self.host_is_connected() {

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -24,7 +24,7 @@ pub(crate) struct Channel {
     pub flags: AtomicU32,
 }
 
-#[cfg(not(feature = "disable-irq-masking"))]
+#[cfg(not(feature = "drop-on-contention"))]
 impl Channel {
     pub fn write_all(&self, mut bytes: &[u8]) {
         // the host-connection-status is only modified after RAM initialization while the device is
@@ -87,7 +87,7 @@ impl Channel {
     }
 }
 
-#[cfg(feature = "disable-irq-masking")]
+#[cfg(feature = "drop-on-contention")]
 impl Channel {
     pub fn stage_bytes(&self, cursor: &mut usize, bytes: &[u8]) -> bool {
         if bytes.is_empty() || bytes.len() >= BUF_SIZE {
@@ -222,8 +222,8 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "disable-irq-masking"))]
-mod test_disable_irq_masking {
+#[cfg(all(test, feature = "drop-on-contention"))]
+mod test_drop_on_contention {
     use super::available_buffer_size;
     use crate::consts::BUF_SIZE;
 

--- a/firmware/defmt-rtt/src/channel.rs
+++ b/firmware/defmt-rtt/src/channel.rs
@@ -108,7 +108,7 @@ impl Channel {
 
         // copy `bytes` to the RTT buffer
         unsafe {
-            self.copy_wrapping(&bytes, *cursor);
+            self.copy_wrapping(bytes, *cursor);
         }
 
         // advance the cursor
@@ -165,12 +165,8 @@ pub(crate) fn available_buffer_size(read_cursor: usize, write_cursor: usize) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::{available_buffer_size, Channel};
-    use crate::{consts::BUF_SIZE, MODE_NON_BLOCKING_TRIM};
-    use core::{
-        ptr,
-        sync::atomic::{AtomicU32, Ordering},
-    };
+    use super::available_buffer_size;
+    use crate::consts::BUF_SIZE;
 
     #[test]
     fn test_rtt_available_buffer_size() {
@@ -224,8 +220,20 @@ mod tests {
             }
         }
     }
+}
 
-    #[cfg(feature = "disable-irq-masking")]
+#[cfg(all(test, feature = "disable-irq-masking"))]
+mod test_disable_irq_masking {
+    use super::available_buffer_size;
+    use crate::consts::BUF_SIZE;
+
+    use super::Channel;
+    use crate::MODE_NON_BLOCKING_TRIM;
+    use core::{
+        ptr,
+        sync::atomic::{AtomicU32, Ordering},
+    };
+
     #[test]
     fn staged_bytes_stay_hidden_until_commit() {
         let mut buffer = [0u8; BUF_SIZE];
@@ -248,7 +256,6 @@ mod tests {
         assert_eq!(channel.write.load(Ordering::Relaxed), 3);
     }
 
-    #[cfg(feature = "disable-irq-masking")]
     #[test]
     fn staged_bytes_wrap_without_publishing() {
         let mut buffer = [0u8; BUF_SIZE];
@@ -267,5 +274,45 @@ mod tests {
         assert_eq!(channel.write.load(Ordering::Relaxed), 0);
         assert_eq!(&buffer[BUF_SIZE - 2..], b"wx");
         assert_eq!(&buffer[..2], b"yz");
+    }
+
+    #[test]
+    fn staged_bytes_rejects_oversized_frame_without_side_effects() {
+        let mut buffer = [0xAA; BUF_SIZE];
+        let channel = Channel {
+            name: ptr::null(),
+            buffer: buffer.as_mut_ptr(),
+            size: BUF_SIZE as u32,
+            write: AtomicU32::new(7),
+            read: AtomicU32::new(7),
+            flags: AtomicU32::new(MODE_NON_BLOCKING_TRIM),
+        };
+        let mut cursor = 7;
+        let bytes = [0x55; BUF_SIZE];
+
+        assert!(!channel.stage_bytes(&mut cursor, &bytes));
+        assert_eq!(cursor, 7);
+        assert_eq!(channel.write.load(Ordering::Relaxed), 7);
+        assert!(buffer.iter().all(|&b| b == 0xAA));
+    }
+
+    #[test]
+    fn staged_bytes_rejects_when_space_is_insufficient_without_partial_copy() {
+        let mut buffer = [0xAA; BUF_SIZE];
+        let channel = Channel {
+            name: ptr::null(),
+            buffer: buffer.as_mut_ptr(),
+            size: BUF_SIZE as u32,
+            write: AtomicU32::new(0),
+            read: AtomicU32::new(4),
+            flags: AtomicU32::new(MODE_NON_BLOCKING_TRIM),
+        };
+        let mut cursor = 0;
+
+        assert_eq!(available_buffer_size(4, cursor), 3);
+        assert!(!channel.stage_bytes(&mut cursor, b"wxyz"));
+        assert_eq!(cursor, 0);
+        assert_eq!(channel.write.load(Ordering::Relaxed), 0);
+        assert!(buffer.iter().all(|&b| b == 0xAA));
     }
 }

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -148,22 +148,9 @@ struct RttEncoder {
     encoder: UnsafeCell<defmt::Encoder>,
 }
 
-#[cfg(feature = "disable-irq-masking")]
-const NO_OWNER: u32 = u32::MAX;
-
-#[cfg(feature = "disable-irq-masking")]
-struct AtomicRttEncoder {
-    /// A defmt::Encoder for encoding frames
-    encoder: UnsafeCell<defmt::Encoder>,
-    owner: AtomicU32,
-    overflowed: UnsafeCell<bool>,
-    start: UnsafeCell<usize>,
-    cursor: UnsafeCell<usize>,
-}
-
 #[cfg(not(feature = "disable-irq-masking"))]
 impl RttEncoder {
-    /// Create a new semihosting-based defmt-encoder
+    /// Create a new rtt-based defmt-encoder
     const fn new() -> RttEncoder {
         RttEncoder {
             taken: AtomicBool::new(false),
@@ -252,8 +239,21 @@ impl RttEncoder {
 }
 
 #[cfg(feature = "disable-irq-masking")]
+const NO_OWNER: u32 = u32::MAX;
+
+#[cfg(feature = "disable-irq-masking")]
+struct AtomicRttEncoder {
+    /// A defmt::Encoder for encoding frames
+    encoder: UnsafeCell<defmt::Encoder>,
+    owner: AtomicU32,
+    overflowed: UnsafeCell<bool>,
+    start: UnsafeCell<usize>,
+    cursor: UnsafeCell<usize>,
+}
+
+#[cfg(feature = "disable-irq-masking")]
 impl AtomicRttEncoder {
-    /// Create a new semihosting-based defmt-encoder
+    /// Create a new rtt-based defmt-encoder
     const fn new() -> AtomicRttEncoder {
         AtomicRttEncoder {
             encoder: UnsafeCell::new(defmt::Encoder::new()),
@@ -286,6 +286,7 @@ impl AtomicRttEncoder {
         0
     }
 
+    /// Acquire the defmt encoder.
     fn acquire(&self) {
         let context = Self::current_context();
         if self.owner.load(Ordering::Relaxed) == context {
@@ -310,7 +311,7 @@ impl AtomicRttEncoder {
             *self.start.get() = cursor;
             *self.cursor.get() = cursor;
             let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
-            encoder.start_frame(stage_bytes);
+            encoder.start_frame(|b| RTT_ENCODER.stage(b));
         }
     }
 
@@ -325,7 +326,7 @@ impl AtomicRttEncoder {
         }
         unsafe {
             let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
-            encoder.write(bytes, stage_bytes);
+            encoder.write(bytes, |b| RTT_ENCODER.stage(b));
         }
     }
 
@@ -351,7 +352,7 @@ impl AtomicRttEncoder {
         }
         unsafe {
             let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
-            encoder.end_frame(stage_bytes);
+            encoder.end_frame(|b| RTT_ENCODER.stage(b));
             if !*self.overflowed.get() {
                 _SEGGER_RTT.up_channel.commit(*self.cursor.get());
             }
@@ -389,13 +390,6 @@ impl AtomicRttEncoder {
 unsafe impl Sync for RttEncoder {}
 #[cfg(feature = "disable-irq-masking")]
 unsafe impl Sync for AtomicRttEncoder {}
-
-#[cfg(feature = "disable-irq-masking")]
-fn stage_bytes(bytes: &[u8]) {
-    unsafe {
-        RTT_ENCODER.stage(bytes);
-    }
-}
 
 unsafe impl defmt::Logger for Logger {
     fn acquire() {

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -53,6 +53,9 @@
 
 #![no_std]
 
+#[cfg(all(feature = "drop-on-contention", not(target_arch = "arm"), not(doc)))]
+compile_error!("the `drop-on-contention` feature is only supported on ARM targets");
+
 mod channel;
 mod consts;
 
@@ -283,9 +286,13 @@ impl AtomicRttEncoder {
         }
     }
 
-    #[cfg(not(target_arch = "arm"))]
+    #[cfg(all(not(target_arch = "arm"), doc))]
     fn current_context() -> u32 {
-        compile_error!("the `drop-on-contention` feature is only supported on ARM targets");
+        NO_OWNER
+    }
+
+    #[cfg(all(not(target_arch = "arm"), not(doc)))]
+    fn current_context() -> u32 {
         loop {}
     }
 

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -39,7 +39,7 @@
 //! cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
 //! ```
 //!
-//! With feature `disable-irq-masking` you do not need a critical section
+//! With feature `drop-on-contention` you do not need a critical section
 //! implementation and interrupts are not disabled. Instead, when execution
 //! contexts collide, frames are dropped. This mode is for bare-metal
 //! Cortex-M use where thread mode is a single execution context. It is not
@@ -61,7 +61,7 @@ use core::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-#[cfg(not(feature = "disable-irq-masking"))]
+#[cfg(not(feature = "drop-on-contention"))]
 use core::sync::atomic::AtomicBool;
 
 use crate::{channel::Channel, consts::BUF_SIZE};
@@ -83,9 +83,9 @@ const MODE_NON_BLOCKING_TRIM: u32 = 1;
 struct Logger;
 
 /// Our defmt encoder state
-#[cfg(not(feature = "disable-irq-masking"))]
+#[cfg(not(feature = "drop-on-contention"))]
 static RTT_ENCODER: RttEncoder = RttEncoder::new();
-#[cfg(feature = "disable-irq-masking")]
+#[cfg(feature = "drop-on-contention")]
 static RTT_ENCODER: AtomicRttEncoder = AtomicRttEncoder::new();
 
 /// Our shared header structure.
@@ -135,7 +135,7 @@ static BUFFER: Buffer = Buffer::new();
 #[cfg_attr(not(target_os = "macos"), link_section = ".data.defmt-rtt.NAME")]
 static NAME: [u8; 6] = *b"defmt\0";
 
-#[cfg(not(feature = "disable-irq-masking"))]
+#[cfg(not(feature = "drop-on-contention"))]
 struct RttEncoder {
     /// A boolean lock
     ///
@@ -148,7 +148,7 @@ struct RttEncoder {
     encoder: UnsafeCell<defmt::Encoder>,
 }
 
-#[cfg(not(feature = "disable-irq-masking"))]
+#[cfg(not(feature = "drop-on-contention"))]
 impl RttEncoder {
     /// Create a new rtt-based defmt-encoder
     const fn new() -> RttEncoder {
@@ -238,10 +238,10 @@ impl RttEncoder {
     }
 }
 
-#[cfg(feature = "disable-irq-masking")]
+#[cfg(feature = "drop-on-contention")]
 const NO_OWNER: u32 = u32::MAX;
 
-#[cfg(feature = "disable-irq-masking")]
+#[cfg(feature = "drop-on-contention")]
 struct AtomicRttEncoder {
     /// A defmt::Encoder for encoding frames
     encoder: UnsafeCell<defmt::Encoder>,
@@ -251,7 +251,7 @@ struct AtomicRttEncoder {
     cursor: UnsafeCell<usize>,
 }
 
-#[cfg(feature = "disable-irq-masking")]
+#[cfg(feature = "drop-on-contention")]
 impl AtomicRttEncoder {
     /// Create a new rtt-based defmt-encoder
     const fn new() -> AtomicRttEncoder {
@@ -284,6 +284,10 @@ impl AtomicRttEncoder {
 
         #[cfg(not(target_arch = "arm"))]
         0
+    }
+
+    fn is_owner(&self) -> bool {
+        self.owner.load(Ordering::Relaxed) == Self::current_context()
     }
 
     /// Acquire the defmt encoder.
@@ -319,9 +323,10 @@ impl AtomicRttEncoder {
     ///
     /// # Safety
     ///
-    /// Do not call unless you have called `acquire`.
+    /// No safety constraints. If this context did not become the active writer
+    /// during `acquire`, this call is ignored and the message is dropped.
     unsafe fn write(&self, bytes: &[u8]) {
-        if self.owner.load(Ordering::Relaxed) != Self::current_context() {
+        if !self.is_owner() {
             return;
         }
         unsafe {
@@ -334,8 +339,13 @@ impl AtomicRttEncoder {
     ///
     /// # Safety
     ///
-    /// Do not call unless you have called `acquire`.
+    /// No safety constraints. If this context did not become the active writer
+    /// during `acquire`, this call is ignored as part of dropping the message.
     unsafe fn flush(&self) {
+        if !self.is_owner() {
+            return;
+        }
+
         _SEGGER_RTT.up_channel.flush();
     }
 
@@ -343,11 +353,10 @@ impl AtomicRttEncoder {
     ///
     /// # Safety
     ///
-    /// Do not call unless you have called `acquire`. This will release your
-    /// lock - do not call `flush` and `write` until you have done another
-    /// `acquire`.
+    /// No safety constraints. If this context did not become the active writer
+    /// during `acquire`, this call is ignored as part of dropping the message.
     unsafe fn release(&self) {
-        if self.owner.load(Ordering::Relaxed) != Self::current_context() {
+        if !self.is_owner() {
             return;
         }
         unsafe {
@@ -386,9 +395,9 @@ impl AtomicRttEncoder {
     }
 }
 
-#[cfg(not(feature = "disable-irq-masking"))]
+#[cfg(not(feature = "drop-on-contention"))]
 unsafe impl Sync for RttEncoder {}
-#[cfg(feature = "disable-irq-masking")]
+#[cfg(feature = "drop-on-contention")]
 unsafe impl Sync for AtomicRttEncoder {}
 
 unsafe impl defmt::Logger for Logger {

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -320,12 +320,7 @@ impl AtomicRttEncoder {
     }
 
     /// Write bytes to the defmt encoder.
-    ///
-    /// # Safety
-    ///
-    /// No safety constraints. If this context did not become the active writer
-    /// during `acquire`, this call is ignored and the message is dropped.
-    unsafe fn write(&self, bytes: &[u8]) {
+    fn write(&self, bytes: &[u8]) {
         if !self.is_owner() {
             return;
         }
@@ -336,12 +331,7 @@ impl AtomicRttEncoder {
     }
 
     /// Flush the encoder.
-    ///
-    /// # Safety
-    ///
-    /// No safety constraints. If this context did not become the active writer
-    /// during `acquire`, this call is ignored as part of dropping the message.
-    unsafe fn flush(&self) {
+    fn flush(&self) {
         if !self.is_owner() {
             return;
         }
@@ -350,12 +340,7 @@ impl AtomicRttEncoder {
     }
 
     /// Release the defmt encoder.
-    ///
-    /// # Safety
-    ///
-    /// No safety constraints. If this context did not become the active writer
-    /// during `acquire`, this call is ignored as part of dropping the message.
-    unsafe fn release(&self) {
+    fn release(&self) {
         if !self.is_owner() {
             return;
         }
@@ -406,21 +391,15 @@ unsafe impl defmt::Logger for Logger {
     }
 
     unsafe fn write(bytes: &[u8]) {
-        unsafe {
-            RTT_ENCODER.write(bytes);
-        }
+        RTT_ENCODER.write(bytes);
     }
 
     unsafe fn flush() {
-        unsafe {
-            RTT_ENCODER.flush();
-        }
+        RTT_ENCODER.flush();
     }
 
     unsafe fn release() {
-        unsafe {
-            RTT_ENCODER.release();
-        }
+        RTT_ENCODER.release();
     }
 }
 

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -320,7 +320,12 @@ impl AtomicRttEncoder {
     }
 
     /// Write bytes to the defmt encoder.
-    fn write(&self, bytes: &[u8]) {
+    ///
+    /// # Safety
+    ///
+    /// No safety constraints. If this context did not become the active writer
+    /// during `acquire`, this call is ignored and the message is dropped.
+    unsafe fn write(&self, bytes: &[u8]) {
         if !self.is_owner() {
             return;
         }
@@ -331,7 +336,12 @@ impl AtomicRttEncoder {
     }
 
     /// Flush the encoder.
-    fn flush(&self) {
+    ///
+    /// # Safety
+    ///
+    /// No safety constraints. If this context did not become the active writer
+    /// during `acquire`, this call is ignored as part of dropping the message.
+    unsafe fn flush(&self) {
         if !self.is_owner() {
             return;
         }
@@ -340,7 +350,12 @@ impl AtomicRttEncoder {
     }
 
     /// Release the defmt encoder.
-    fn release(&self) {
+    ///
+    /// # Safety
+    ///
+    /// No safety constraints. If this context did not become the active writer
+    /// during `acquire`, this call is ignored as part of dropping the message.
+    unsafe fn release(&self) {
         if !self.is_owner() {
             return;
         }
@@ -391,15 +406,21 @@ unsafe impl defmt::Logger for Logger {
     }
 
     unsafe fn write(bytes: &[u8]) {
-        RTT_ENCODER.write(bytes);
+        unsafe {
+            RTT_ENCODER.write(bytes);
+        }
     }
 
     unsafe fn flush() {
-        RTT_ENCODER.flush();
+        unsafe {
+            RTT_ENCODER.flush();
+        }
     }
 
     unsafe fn release() {
-        RTT_ENCODER.release();
+        unsafe {
+            RTT_ENCODER.release();
+        }
     }
 }
 

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -264,8 +264,8 @@ impl AtomicRttEncoder {
         }
     }
 
+    #[cfg(target_arch = "arm")]
     fn current_context() -> u32 {
-        #[cfg(target_arch = "arm")]
         unsafe {
             // IPSR is 0 in thread mode and otherwise the active exception
             // number. That makes it a unique owner token for bare-metal
@@ -281,9 +281,12 @@ impl AtomicRttEncoder {
             );
             ipsr
         }
+    }
 
-        #[cfg(not(target_arch = "arm"))]
-        0
+    #[cfg(not(target_arch = "arm"))]
+    fn current_context() -> u32 {
+        compile_error!("the `drop-on-contention` feature is only supported on ARM targets");
+        loop {}
     }
 
     fn is_owner(&self) -> bool {
@@ -320,12 +323,7 @@ impl AtomicRttEncoder {
     }
 
     /// Write bytes to the defmt encoder.
-    ///
-    /// # Safety
-    ///
-    /// No safety constraints. If this context did not become the active writer
-    /// during `acquire`, this call is ignored and the message is dropped.
-    unsafe fn write(&self, bytes: &[u8]) {
+    fn write(&self, bytes: &[u8]) {
         if !self.is_owner() {
             return;
         }
@@ -336,12 +334,7 @@ impl AtomicRttEncoder {
     }
 
     /// Flush the encoder.
-    ///
-    /// # Safety
-    ///
-    /// No safety constraints. If this context did not become the active writer
-    /// during `acquire`, this call is ignored as part of dropping the message.
-    unsafe fn flush(&self) {
+    fn flush(&self) {
         if !self.is_owner() {
             return;
         }
@@ -350,12 +343,7 @@ impl AtomicRttEncoder {
     }
 
     /// Release the defmt encoder.
-    ///
-    /// # Safety
-    ///
-    /// No safety constraints. If this context did not become the active writer
-    /// during `acquire`, this call is ignored as part of dropping the message.
-    unsafe fn release(&self) {
+    fn release(&self) {
         if !self.is_owner() {
             return;
         }
@@ -400,6 +388,7 @@ unsafe impl Sync for RttEncoder {}
 #[cfg(feature = "drop-on-contention")]
 unsafe impl Sync for AtomicRttEncoder {}
 
+#[cfg_attr(feature = "drop-on-contention", allow(unused_unsafe))]
 unsafe impl defmt::Logger for Logger {
     fn acquire() {
         RTT_ENCODER.acquire();

--- a/firmware/defmt-rtt/src/lib.rs
+++ b/firmware/defmt-rtt/src/lib.rs
@@ -38,6 +38,18 @@
 //! [dependencies]
 //! cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
 //! ```
+//!
+//! With feature `disable-irq-masking` you do not need a critical section
+//! implementation and interrupts are not disabled. Instead, when execution
+//! contexts collide, frames are dropped. This mode is for bare-metal
+//! Cortex-M use where thread mode is a single execution context. It is not
+//! correct on RTOS or other multi-thread-mode systems because all thread-mode
+//! tasks share `IPSR == 0`, which can misidentify ownership and panic. It can
+//! be combined with `disable-blocking-mode`, in which case frames that do not
+//! already fit are dropped. Because the public write cursor advances only once
+//! at frame end, every encoded frame in this mode must fit within the RTT
+//! ring's usable capacity (`BUF_SIZE - 1`); oversized frames are dropped even
+//! in blocking mode.
 
 #![no_std]
 
@@ -46,8 +58,11 @@ mod consts;
 
 use core::{
     cell::UnsafeCell,
-    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
 };
+
+#[cfg(not(feature = "disable-irq-masking"))]
+use core::sync::atomic::AtomicBool;
 
 use crate::{channel::Channel, consts::BUF_SIZE};
 
@@ -68,7 +83,10 @@ const MODE_NON_BLOCKING_TRIM: u32 = 1;
 struct Logger;
 
 /// Our defmt encoder state
+#[cfg(not(feature = "disable-irq-masking"))]
 static RTT_ENCODER: RttEncoder = RttEncoder::new();
+#[cfg(feature = "disable-irq-masking")]
+static RTT_ENCODER: AtomicRttEncoder = AtomicRttEncoder::new();
 
 /// Our shared header structure.
 ///
@@ -117,6 +135,7 @@ static BUFFER: Buffer = Buffer::new();
 #[cfg_attr(not(target_os = "macos"), link_section = ".data.defmt-rtt.NAME")]
 static NAME: [u8; 6] = *b"defmt\0";
 
+#[cfg(not(feature = "disable-irq-masking"))]
 struct RttEncoder {
     /// A boolean lock
     ///
@@ -129,6 +148,20 @@ struct RttEncoder {
     encoder: UnsafeCell<defmt::Encoder>,
 }
 
+#[cfg(feature = "disable-irq-masking")]
+const NO_OWNER: u32 = u32::MAX;
+
+#[cfg(feature = "disable-irq-masking")]
+struct AtomicRttEncoder {
+    /// A defmt::Encoder for encoding frames
+    encoder: UnsafeCell<defmt::Encoder>,
+    owner: AtomicU32,
+    overflowed: UnsafeCell<bool>,
+    start: UnsafeCell<usize>,
+    cursor: UnsafeCell<usize>,
+}
+
+#[cfg(not(feature = "disable-irq-masking"))]
 impl RttEncoder {
     /// Create a new semihosting-based defmt-encoder
     const fn new() -> RttEncoder {
@@ -218,7 +251,151 @@ impl RttEncoder {
     }
 }
 
+#[cfg(feature = "disable-irq-masking")]
+impl AtomicRttEncoder {
+    /// Create a new semihosting-based defmt-encoder
+    const fn new() -> AtomicRttEncoder {
+        AtomicRttEncoder {
+            encoder: UnsafeCell::new(defmt::Encoder::new()),
+            owner: AtomicU32::new(NO_OWNER),
+            overflowed: UnsafeCell::new(false),
+            start: UnsafeCell::new(0),
+            cursor: UnsafeCell::new(0),
+        }
+    }
+
+    fn current_context() -> u32 {
+        #[cfg(target_arch = "arm")]
+        unsafe {
+            // IPSR is 0 in thread mode and otherwise the active exception
+            // number. That makes it a unique owner token for bare-metal
+            // Cortex-M execution: one thread-mode context plus interrupts. It
+            // is not suitable for systems that can switch between multiple
+            // thread-mode tasks mid-frame because those tasks all appear as
+            // owner 0 and can spuriously panic as "reentrant".
+            let ipsr: u32;
+            core::arch::asm!(
+                "mrs {}, ipsr",
+                out(reg) ipsr,
+                options(nomem, nostack, preserves_flags)
+            );
+            ipsr
+        }
+
+        #[cfg(not(target_arch = "arm"))]
+        0
+    }
+
+    fn acquire(&self) {
+        let context = Self::current_context();
+        if self.owner.load(Ordering::Relaxed) == context {
+            panic!("defmt logger taken reentrantly");
+        }
+
+        // Acquire publishes exclusive ownership before any frame staging starts.
+        // On failure we intentionally drop the whole colliding frame; the
+        // caller continues but all later methods become no-ops because it is
+        // not the owner.
+        if self
+            .owner
+            .compare_exchange(NO_OWNER, context, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+
+        unsafe {
+            *self.overflowed.get() = false;
+            let cursor = _SEGGER_RTT.up_channel.write.load(Ordering::Acquire) as usize;
+            *self.start.get() = cursor;
+            *self.cursor.get() = cursor;
+            let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
+            encoder.start_frame(stage_bytes);
+        }
+    }
+
+    /// Write bytes to the defmt encoder.
+    ///
+    /// # Safety
+    ///
+    /// Do not call unless you have called `acquire`.
+    unsafe fn write(&self, bytes: &[u8]) {
+        if self.owner.load(Ordering::Relaxed) != Self::current_context() {
+            return;
+        }
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
+            encoder.write(bytes, stage_bytes);
+        }
+    }
+
+    /// Flush the encoder.
+    ///
+    /// # Safety
+    ///
+    /// Do not call unless you have called `acquire`.
+    unsafe fn flush(&self) {
+        _SEGGER_RTT.up_channel.flush();
+    }
+
+    /// Release the defmt encoder.
+    ///
+    /// # Safety
+    ///
+    /// Do not call unless you have called `acquire`. This will release your
+    /// lock - do not call `flush` and `write` until you have done another
+    /// `acquire`.
+    unsafe fn release(&self) {
+        if self.owner.load(Ordering::Relaxed) != Self::current_context() {
+            return;
+        }
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *self.encoder.get();
+            encoder.end_frame(stage_bytes);
+            if !*self.overflowed.get() {
+                _SEGGER_RTT.up_channel.commit(*self.cursor.get());
+            }
+        }
+
+        self.owner.store(NO_OWNER, Ordering::Release);
+    }
+
+    unsafe fn stage(&self, bytes: &[u8]) {
+        unsafe {
+            if *self.overflowed.get() {
+                return;
+            }
+            if crate::channel::available_buffer_size(*self.start.get(), *self.cursor.get())
+                < bytes.len()
+            {
+                *self.overflowed.get() = true;
+                return;
+            }
+
+            // Only the owner stages bytes. Until `release()` commits the final
+            // cursor, the host still sees the old write pointer and therefore
+            // never consumes these bytes as a partial frame.
+            if !_SEGGER_RTT
+                .up_channel
+                .stage_bytes(&mut *self.cursor.get(), bytes)
+            {
+                *self.overflowed.get() = true;
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "disable-irq-masking"))]
 unsafe impl Sync for RttEncoder {}
+#[cfg(feature = "disable-irq-masking")]
+unsafe impl Sync for AtomicRttEncoder {}
+
+#[cfg(feature = "disable-irq-masking")]
+fn stage_bytes(bytes: &[u8]) {
+    unsafe {
+        RTT_ENCODER.stage(bytes);
+    }
+}
 
 unsafe impl defmt::Logger for Logger {
     fn acquire() {

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -12,6 +12,7 @@ harness = false
 
 [dependencies]
 defmt = { path = "../../defmt" }
+defmt-rtt = { path = "../defmt-rtt", optional = true }
 defmt-semihosting = { path = "../defmt-semihosting" }
 defmt-test = { path = "../defmt-test" }
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
@@ -22,6 +23,7 @@ linked_list_allocator = { version = "0.10.2", optional = true }
 
 [features]
 alloc = ["defmt/alloc", "alloc-cortex-m", "linked_list_allocator/const_mut_refs"]
+drop-on-contention = ["dep:defmt-rtt", "defmt-rtt/drop-on-contention"]
 ip_in_core = ["defmt/ip_in_core"]
 
 [[bin]]
@@ -31,3 +33,7 @@ required-features = ["alloc"]
 [[bin]]
 name = "net"
 required-features = ["ip_in_core"]
+
+[[bin]]
+name = "drop-on-contention"
+required-features = ["drop-on-contention"]

--- a/firmware/qemu/src/bin/drop-on-contention.rs
+++ b/firmware/qemu/src/bin/drop-on-contention.rs
@@ -1,0 +1,22 @@
+#![no_std]
+#![no_main]
+
+use cortex_m as _;
+use cortex_m_rt::entry;
+use semihosting::process::ExitCode;
+
+use defmt_rtt as _; // global logger
+
+#[entry]
+fn main() -> ! {
+    defmt::info!("drop-on-contention");
+
+    ExitCode::SUCCESS.exit_process()
+}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    ExitCode::FAILURE.exit_process()
+}

--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -71,7 +71,7 @@ pub fn test() {
         }
     };
 
-    for snapshot_test in all_snapshot_tests() {
+    for snapshot_test in all_backcompat_snapshot_tests() {
         let feature = match snapshot_test {
             "alloc" => "alloc",
             "net" => "ip_in_core",
@@ -83,6 +83,13 @@ pub fn test() {
             "backcompat (see xtask/src/backcompat.rs for FIXME instructions)",
         );
     }
+}
+
+fn all_backcompat_snapshot_tests() -> Vec<&'static str> {
+    all_snapshot_tests()
+        .into_iter()
+        .filter(|test| *test != "drop-on-contention")
+        .collect()
 }
 
 struct QemuRun {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -131,6 +131,20 @@ fn test_host(deny_warnings: bool, skip_ui_tests: bool) {
             "host",
         );
     }
+
+    for feat in ["drop-on-contention", "drop-on-contention,disable-blocking-mode"] {
+        do_test(
+            || {
+                run_command(
+                    "cargo",
+                    &["test", "--features", feat],
+                    Some("firmware/defmt-rtt"),
+                    &env,
+                )
+            },
+            "host defmt-rtt",
+        );
+    }
 }
 
 fn test_cross(deny_warnings: bool) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -131,22 +131,6 @@ fn test_host(deny_warnings: bool, skip_ui_tests: bool) {
             "host",
         );
     }
-
-    if cfg!(target_os = "linux") {
-        for feat in ["drop-on-contention", "drop-on-contention,disable-blocking-mode"] {
-            do_test(
-                || {
-                    run_command(
-                        "cargo",
-                        &["test", "--features", feat],
-                        Some("firmware/defmt-rtt"),
-                        &env,
-                    )
-                },
-                "host defmt-rtt",
-            );
-        }
-    }
 }
 
 fn test_cross(deny_warnings: bool) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -132,18 +132,20 @@ fn test_host(deny_warnings: bool, skip_ui_tests: bool) {
         );
     }
 
-    for feat in ["drop-on-contention", "drop-on-contention,disable-blocking-mode"] {
-        do_test(
-            || {
-                run_command(
-                    "cargo",
-                    &["test", "--features", feat],
-                    Some("firmware/defmt-rtt"),
-                    &env,
-                )
-            },
-            "host defmt-rtt",
-        );
+    if cfg!(target_os = "linux") {
+        for feat in ["drop-on-contention", "drop-on-contention,disable-blocking-mode"] {
+            do_test(
+                || {
+                    run_command(
+                        "cargo",
+                        &["test", "--features", feat],
+                        Some("firmware/defmt-rtt"),
+                        &env,
+                    )
+                },
+                "host defmt-rtt",
+            );
+        }
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -225,6 +225,20 @@ fn test_cross(deny_warnings: bool) {
         "cross",
     );
 
+    for feature in ["drop-on-contention", "drop-on-contention,disable-blocking-mode"] {
+        do_test(
+            || {
+                run_command(
+                    "cargo",
+                    &["check", "--target", "thumbv7m-none-eabi", "--features", feature],
+                    Some("firmware/defmt-rtt"),
+                    &env,
+                )
+            },
+            "cross",
+        );
+    }
+
     for feature in ["print-defmt", "print-rtt"] {
         do_test(
             || {
@@ -268,6 +282,31 @@ fn test_lint_cross(deny_warnings: bool) {
         },
         "cross",
     );
+
+    for feature in ["drop-on-contention", "drop-on-contention,disable-blocking-mode"] {
+        do_test(
+            || {
+                run_command(
+                    "cargo",
+                    &[
+                        "clippy",
+                        "--target",
+                        "thumbv7m-none-eabi",
+                        "--features",
+                        feature,
+                        "--",
+                        "-D",
+                        "warnings",
+                        "-A",
+                        "unknown-lints",
+                    ],
+                    Some("firmware/defmt-rtt"),
+                    &env,
+                )
+            },
+            "cross",
+        );
+    }
 }
 
 fn test_book() {

--- a/xtask/src/snapshot.rs
+++ b/xtask/src/snapshot.rs
@@ -29,6 +29,7 @@ pub(crate) fn all_snapshot_tests() -> Vec<&'static str> {
         "hints_inner",
         "dbg",
         "panic_info",
+        "drop-on-contention",
     ];
     const NIGHTLY_SNAPSHOT_TESTS: &[&str] = &["alloc"];
     const POST_MSRV_SNAPSHOT_TESTS: &[&str] = &["net"];
@@ -75,7 +76,7 @@ pub fn test_snapshot(overwrite: bool, snapshot: Option<Snapshot>) {
         None => test_all_snapshots(overwrite),
         Some(snapshot) => {
             do_test(
-                || test_single_snapshot(snapshot.name(), "", overwrite),
+                || test_single_snapshot(snapshot.name(), snapshot_features(snapshot.name()), overwrite),
                 "qemu/snapshot",
             );
         }
@@ -84,16 +85,19 @@ pub fn test_snapshot(overwrite: bool, snapshot: Option<Snapshot>) {
 
 fn test_all_snapshots(overwrite: bool) {
     for test in all_snapshot_tests() {
-        let features = match test {
-            "alloc" => "alloc",
-            "net" => "ip_in_core",
-            _ => "",
-        };
-
         do_test(
-            || test_single_snapshot(test, features, overwrite),
+            || test_single_snapshot(test, snapshot_features(test), overwrite),
             "qemu/snapshot",
         );
+    }
+}
+
+fn snapshot_features(test: &str) -> &str {
+    match test {
+        "alloc" => "alloc",
+        "drop-on-contention" => "drop-on-contention",
+        "net" => "ip_in_core",
+        _ => "",
     }
 }
 


### PR DESCRIPTION
This adds the `drop-on-contention` feature to `defmt-rtt`.

Instead of using a critical section to ensure sequential access to the RTT buffer from different execution contexts, this uses an atomic execution context "owner" set from Cortex-M IPSR. It removes the need to disable interrupts during logging at the cost of discarding defmt frames from high priority contexts when a lower priority context is already writing a frame.

It also adds testing (check cross and qemu snapshot) for that feature.