### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 > A highly efficient logging framework that targets resource-constrained devices, like microcontrollers
 
-[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v1.0.1...main
+[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v1.1.0...main
+[defmt-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.1.0
 [defmt-v1.0.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.0.1
 [defmt-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.0.0
 [defmt-v0.3.100]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.3.100
@@ -58,6 +59,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+### [defmt-v1.1.0] (2026-05-12)
+
 * [#974] Ensure typechecking is still performed on disabled log statement.
 * [#960] Fix `Format` not accepting multiple helper attribute instances
 * [#937] add support for `#[defmt(transparent)]` on `Format` derive
@@ -78,7 +81,6 @@ We have several packages which live in this repository. Changes are tracked sepa
 ### [defmt-v1.0.0] (2025-04-01)
 
 * [#909] First 1.0 stable release :tada:
-* [#940] `defmt-print`: Allow reading from a serial port
 * [#938] Emit `option_env!("DEFMT_LOG")` so rustc depinfo can track it
 * [#935] Add note in book's setup chapter to clarify staticlib setup
 * [#914] Add cargo-deny as a CI action to check crate security and licensing
@@ -416,7 +418,8 @@ Initial release
 
 > Macros for [defmt](#defmt)
 
-[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v1.0.1...main
+[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v1.1.0...main
+[defmt-macros-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.1.0
 [defmt-macros-v1.0.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.0.1
 [defmt-macros-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.0.0
 [defmt-macros-v0.4.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.4.0
@@ -439,6 +442,8 @@ Initial release
 [defmt-macros-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.1.0
 
 ### [defmt-macros-next]
+
+### [defmt-macros-v1.1.0] (2026-05-12)
 
 * [#1044]: Add support for `bound` attribute via a `#[defmt(bound(T: MyCustomBound))]`
 * [#956]: Link LICENSE-* in the crate folder
@@ -522,15 +527,15 @@ Initial release
 
 ### [defmt-print-next]
 
-* No changes
 
-### [defmt-print-v1.1.0] (2026-01-20)
+### [defmt-print-v1.1.0] (2026-05-12)
 
 * [#985] Add `--set-addr` option to actively set the `_SEGGER_RTT` address
 * [#952] Support sending dtr on connection for serial port input
 * [#965] Also support `--log-format=online` or  `--log-format=default`
 * [#986] Bump MSRV to 1.81
 * [#1028] Bump MSRV to 1.83
+* [#940] Allow reading from a serial port
 
 ### [defmt-print-v1.0.0] (2025-04-01)
 
@@ -731,7 +736,8 @@ Initial release
 
 > Transmit defmt log messages over the RTT (Real-Time Transfer) protocol
 
-[defmt-rtt-next]: https://github.com/knurling-rs/defmt/compare/defmt-rtt-v1.1.0...main
+[defmt-rtt-next]: https://github.com/knurling-rs/defmt/compare/defmt-rtt-v1.2.0...main
+[defmt-rtt-v1.2.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.2.0
 [defmt-rtt-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.1.0
 [defmt-rtt-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.0.0
 [defmt-rtt-v0.4.2]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.4.2
@@ -744,6 +750,8 @@ Initial release
 [defmt-rtt-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v0.1.0
 
 ### [defmt-rtt-next]
+
+### [defmt-rtt-v1.2.0] (2026-05-12)
 
 * [#1006] Fix `available_buffer_size` ignoring available buffer space when `read < write`
 * [#1013] Switch to fixed 32-bit types, to support 64-bit targets
@@ -876,7 +884,8 @@ Initial release
 
 > A test harness for embedded devices
 
-[defmt-test-next]:  https://github.com/knurling-rs/defmt/compare/defmt-test-v0.4.0...main
+[defmt-test-next]:  https://github.com/knurling-rs/defmt/compare/defmt-test-v0.5.0...main
+[defmt-test-v0.5.0]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.5.0
 [defmt-test-v0.4.0]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.4.0
 [defmt-test-v0.3.2]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.3.2
 [defmt-test-v0.3.1]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.3.1
@@ -889,6 +898,8 @@ Initial release
 [defmt-test-v0.1.0]:  https://github.com/knurling-rs/defmt/releases/tag/defmt-test-v0.1.0
 
 ### [defmt-test-next]
+
+### [defmt-test-v0.5.0] (2026-05-12)
 
 * [#1049] Pin trybuild to 1.0.89
 * [#1046] Replace `cortex-m-semihosting` with generic `semihosting` crate to support non-Cortex-M thumb targets
@@ -972,7 +983,7 @@ Initial release
 
 ### [qemu-run-next]
 
-### [qemu-run-v0.3.0]
+### [qemu-run-v0.3.0] (2026-05-12)
 
 * [#1048] Fixed UART read timeout issue ([#1047])
 * [#1055] Support `--arg foo=bar` to pass `-foo bar` to QEMU

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "defmt-parser",
  "maplit",

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -45,7 +45,7 @@ unstable-test = [ "defmt-macros/unstable-test" ]
 [dependencies]
 # There is exactly one version of defmt-macros supported in this version of
 # defmt. Although, multiple versions of defmt might use the *same* defmt-macros.
-defmt-macros = { path = "../macros", version = "=1.0.1" }
+defmt-macros = { path = "../macros", version = "=1.1.0" }
 bitflags = "1"
 
 [dev-dependencies]

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.1.0"
+version = "1.2.0"
 
 [features]
 disable-blocking-mode = []

--- a/firmware/defmt-test/Cargo.toml
+++ b/firmware/defmt-test/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT OR Apache-2.0"
 name = "defmt-test"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 semihosting = { version = "0.1" }
 defmt = { version = "1", path = "../../defmt" }
-defmt-test-macros = { version = "=0.3.2", path = "macros" }
+defmt-test-macros = { version = "=0.3.3", path = "macros" }

--- a/firmware/defmt-test/macros/Cargo.toml
+++ b/firmware/defmt-test/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-test-macros"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "0.3.2"
+version = "0.3.3"
 
 [lib]
 proc-macro = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.0.1"
+version = "1.1.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This PR bumps the versions of all crates that have had changes since the last release to prepare for the next one.

Also includes some cleanup of the changelog.

- `defmt`
  - `v1.0.1` -> `v1.1.0`
- `defmt-rtt`
  - `v1.1.0` -> `v1.2.0`
- `defmt-test`
  - `v0.4.0` -> `v0.5.0`
- `defmt-macros`
  - `v1.0.1` -> `v1.1.0`
- `defmt-print`
  - `v1.0.0` -> `v1.1.0`
  - This was already `v1.1.0` on main but [latest release on crates.io](https://crates.io/crates/defmt-print/versions) is `v1.0.0`