### PR TITLE
qemu-run supports `--arg foo=bar` to pass `-foo bar` to qemu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -973,6 +973,7 @@ Initial release
 ### [qemu-run-next]
 
 * [#1048] Fixed UART read timeout issue ([#1047])
+* [#1055] Support `--arg foo=bar` to pass `-foo bar` to QEMU
 
 ### [qemu-run-v0.1.1]
 
@@ -1007,6 +1008,7 @@ Initial release
 
 ---
 
+[#1055]: https://github.com/knurling-rs/defmt/pull/1055
 [#1052]: https://github.com/knurling-rs/defmt/pull/1052
 [#1049]: https://github.com/knurling-rs/defmt/pull/1049
 [#1048]: https://github.com/knurling-rs/defmt/pull/1048

--- a/qemu-run/src/main.rs
+++ b/qemu-run/src/main.rs
@@ -38,6 +38,10 @@ struct Opts {
     #[arg(long, required = false)]
     cpu: Option<String>,
 
+    /// Optionally additional arguments for QEMU
+    #[arg(long, required = false)]
+    arg: Vec<String>,
+
     /// Optionally specify a custom defmt log format
     #[arg(short = 'l', required = false, alias = "log-format")]
     log_format: Option<String>,
@@ -150,6 +154,15 @@ fn notmain() -> Result<Option<i32>, anyhow::Error> {
         command.arg("-cpu");
         command.arg(cpu);
     }
+
+    for arg in &opts.arg {
+        let Some((arg_name, arg_value)) = arg.split_once("=") else {
+            panic!("Argument {arg} does not contain '=' - it should be like 'smp=2'");
+        };
+        command.arg(format!("-{arg_name}"));
+        command.arg(arg_value);
+    }
+
     // create a character device connected to `uart_socket`
     if opts.uart_telnet {
         command.arg("-chardev");

--- a/qemu-run/src/main.rs
+++ b/qemu-run/src/main.rs
@@ -155,12 +155,14 @@ fn notmain() -> Result<Option<i32>, anyhow::Error> {
         command.arg(cpu);
     }
 
+    // convert "--arg smp=2" into "-smp 2", and "--arg nographic" into "-nographic"
     for arg in &opts.arg {
-        let Some((arg_name, arg_value)) = arg.split_once("=") else {
-            panic!("Argument {arg} does not contain '=' - it should be like 'smp=2'");
-        };
-        command.arg(format!("-{arg_name}"));
-        command.arg(arg_value);
+        if let Some((arg_name, arg_value)) = arg.split_once("=") {
+            command.arg(format!("-{arg_name}"));
+            command.arg(arg_value);
+        } else {
+            command.arg(format!("-{arg}"));
+        }
     }
 
     // create a character device connected to `uart_socket`


### PR DESCRIPTION
Allows you to start QEMU in SMP mode, or set other useful properties on the virtual machine.
