### PR TITLE
Bump qemu-run to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -966,17 +966,16 @@ Initial release
 
 > Runs [`qemu-system-arm`] but decodes [`defmt`] data sent to semihosting
 
-[qemu-run-next]: https://github.com/knurling-rs/defmt/compare/qemu-run-v0.1.0...main
-[qemu-run-v0.1.1]: https://github.com/knurling-rs/defmt/releases/tag/qemu-run-v0.1.1
+[qemu-run-next]: https://github.com/knurling-rs/defmt/compare/qemu-run-v0.3.0...main
+[qemu-run-v0.3.0]: https://github.com/knurling-rs/defmt/releases/tag/qemu-run-v0.3.0
 [qemu-run-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/qemu-run-v0.1.0
 
 ### [qemu-run-next]
 
+### [qemu-run-v0.3.0]
+
 * [#1048] Fixed UART read timeout issue ([#1047])
 * [#1055] Support `--arg foo=bar` to pass `-foo bar` to QEMU
-
-### [qemu-run-v0.1.1]
-
 * [#1028] Bump MSRV to 1.83
 * [#1028] Use latest `defmt-decoder` (moves location of `(HOST)` in log messages to end of line)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "qemu-run"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/qemu-run/Cargo.toml
+++ b/qemu-run/Cargo.toml
@@ -9,7 +9,7 @@ name = "qemu-run"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 rust-version = "1.83"
-version = "0.1.1"
+version = "0.3.0"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
We see tags for 0.2.0 but no release, and we see CHANGELOG entries for 0.1.1 but no release, so we're going straight to 0.3.0 to avoid confusion.