### PR TITLE
Bump defmt version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "1.0.1"
+version = "1.1.0"
 
 [features]
 alloc = []


### PR DESCRIPTION
Follow up for #1054 where I forgot to *actually* bump the defmt version.