### PR TITLE
fix(book): fix various typos, a syntax error, and grammatical errors.

### DIFF
--- a/book/src/bitfields.md
+++ b/book/src/bitfields.md
@@ -1,8 +1,8 @@
 # Bitfields
 
-> `:M..N` is the bitfield formatting parameter.
+> `=M..N` is the bitfield formatting parameter.
 
-The bitfield argument is expected to be a *unsigned* integer that's large enough to contain the bitfields.
+The bitfield argument is expected to be an  *unsigned* integer that's large enough to contain the bitfields.
 For example, if bitfield ranges only cover up to bit `11` (e.g. `=8..12`) then the argument must be at least `u16`.
 
 When paired with a positional parameter it can be used to display the bitfields of a register.

--- a/book/src/hints.md
+++ b/book/src/hints.md
@@ -129,7 +129,7 @@ struct S { x: u8, y: u8 }
 
 impl defmt::Format for S {
     fn format(&self, f: defmt::Formatter) {
-        // `y`'s display hint cannot be overriden (see below)
+        // `y`'s display hint cannot be overridden (see below)
         defmt::write!(f, "S {{ x: {=u8}, y: {=u8:x} }}", self.x, self.y)
     }
 }

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -19,10 +19,10 @@
 
 ## Intended use
 
-In its current iteration `defmt` mainly targets tiny embedded devices that have no mean to display information to the developer, e.g. a screen.
+In its current iteration `defmt` mainly targets tiny embedded devices that have no means to display information to the developer, e.g. a screen.
 In this scenario logs need to be transferred to a second machine, usually a PC/laptop, before they can be displayed to the developer/end-user.
 
-`defmt` operating principles, however, are applicable to beefier machines and could be use to improve the logging performance of x86 web server applications and the like.
+`defmt` operating principles, however, are applicable to beefier machines and could be used to improve the logging performance of x86 web server applications and the like.
 
 ## Operating principle
 

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -10,7 +10,7 @@ To use `defmt` in an **application** you need the additional steps documented be
 
 ## For applications
 
-> 💡 The prefferred way to create a *new* `defmt` application is to use our [app-template]. Tag along if you want to add `defmt` to an *existing* application.
+> 💡 The preferred way to create a *new* `defmt` application is to use our [app-template]. Tag along if you want to add `defmt` to an *existing* application.
 
 [app-template]: https://github.com/knurling-rs/app-template
 
@@ -59,7 +59,7 @@ Information about how to write a `global_logger` can be found in the [`#[global_
 ### Enabling logging
 
 By default, only ERROR level messages are logged.
-To learn how to enable other logging levels and filters logs per modules read the [Filtering section](./filtering.md).
+To learn how to enable other logging levels and filter logs per module read the [Filtering section](./filtering.md).
 
 ### Memory use
 


### PR DESCRIPTION

fixes a few typos and grammatical errors in the book files `bitfields.md`, `setup.md`, `hints.md`, and `introduction.md`.

what prompted me to do this quick review was the syntax mismatch `:M..N`  rather than `=M..N` in the bitfields section heading which can be especially confusing for newcomers. 