### PR TITLE
Check changelog in CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,3 +27,8 @@ jobs:
           missingUpdateErrorMessage: "Please add a changelog entry in the CHANGELOG.md file."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install ripgrep
+        run: sudo apt update && sudo apt install ripgrep
+      - name: Check that all the github links in CHANGELOG.md are correctly defined
+        run: ./check_changelog.sh

--- a/check_changelog.sh
+++ b/check_changelog.sh
@@ -4,5 +4,5 @@
 
 for link in `rg '\[(#\d+)\] ' CHANGELOG.md -o | sort | uniq | sed 's/\]/\\\\]/' | sed 's/\[/\\\\[/'`
 do
-    rg "${link}:" CHANGELOG.md -q || echo $link is MISSING
+    grep "${link}:" CHANGELOG.md -q || echo ${link//\\/} is MISSING a link-reference, see https://github.github.com/gfm/#shortcut-reference-link
 done

--- a/check_changelog.sh
+++ b/check_changelog.sh
@@ -2,7 +2,14 @@
 
 # Checks that all the github links in CHANGELOG.md are correctly defined
 
+status=0
+
 for link in `rg '\[(#\d+)\] ' CHANGELOG.md -o | sort | uniq | sed 's/\]/\\\\]/' | sed 's/\[/\\\\[/'`
 do
-    grep "${link}:" CHANGELOG.md -q || echo ${link//\\/} is MISSING a link-reference, see https://github.github.com/gfm/#shortcut-reference-link
+    if ! rg "${link}:" CHANGELOG.md -q; then
+        echo ${link//\\/} is MISSING a link-reference, see https://github.github.com/gfm/#shortcut-reference-link
+        status=1
+    fi
 done
+
+exit $status


### PR DESCRIPTION
We already had a script to manually check the changelog for broken reference links.
This PR improves the output and executes it in CI.

See [here](https://github.com/knurling-rs/defmt/actions/runs/26237813408/job/77215762048?pr=1059) for a failing example.