### PR TITLE
qemu-run: honor --log-format flag (and canned formats like oneline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -983,6 +983,8 @@ Initial release
 
 ### [qemu-run-next]
 
+* [#1060] Honor `--log-format=<format>` long flag (the clap arg only had `-l`; the `alias = "log-format"` silently no-opped without a primary `long`). Canned-format mapping was already in place via #965. ([#1034])
+
 ### [qemu-run-v0.3.0] (2026-05-12)
 
 * [#1048] Fixed UART read timeout issue ([#1047])
@@ -1018,11 +1020,13 @@ Initial release
 
 ---
 
+[#1060]: https://github.com/knurling-rs/defmt/pull/1060
 [#1055]: https://github.com/knurling-rs/defmt/pull/1055
 [#1052]: https://github.com/knurling-rs/defmt/pull/1052
 [#1049]: https://github.com/knurling-rs/defmt/pull/1049
 [#1048]: https://github.com/knurling-rs/defmt/pull/1048
 [#1047]: https://github.com/knurling-rs/defmt/pull/1047
+[#1034]: https://github.com/knurling-rs/defmt/issues/1034
 [#1046]: https://github.com/knurling-rs/defmt/pull/1046
 [#1044]: https://github.com/knurling-rs/defmt/pull/1044
 [#1041]: https://github.com/knurling-rs/defmt/pull/1041

--- a/qemu-run/src/main.rs
+++ b/qemu-run/src/main.rs
@@ -42,8 +42,12 @@ struct Opts {
     #[arg(long, required = false)]
     arg: Vec<String>,
 
-    /// Optionally specify a custom defmt log format
-    #[arg(short = 'l', required = false, alias = "log-format")]
+    /// Optionally specify a defmt log format.
+    ///
+    /// Accepts a canned format keyword (e.g. `default`, `oneline`) or a
+    /// custom format string. See the "Custom Log Output" section of the
+    /// defmt book for the format syntax.
+    #[arg(short = 'l', long, required = false)]
     log_format: Option<String>,
 
     /// Print the version number, and quit


### PR DESCRIPTION
Fixes #1034.

### What

`Opts::log_format` in `qemu-run/src/main.rs` was declared as

```rust
#[arg(short = 'l', required = false, alias = "log-format")]
log_format: Option<String>,
```

In clap v4 derive, an `#[arg(...)]` field only gets a long flag when `long` (or `long = "..."`) is explicitly set. Without it, the field has only the short `-l` form, and `alias = "log-format"` silently no-ops because there is no primary long flag for the alias to attach to. So `qemu-run --log-format=oneline` (the form the issue reporter uses, and the form `probe-rs run` supports) doesn't parse — clap rejects it with "unexpected argument".

### The change

```diff
-    /// Optionally specify a custom defmt log format
-    #[arg(short = 'l', required = false, alias = "log-format")]
+    /// Optionally specify a defmt log format.
+    ///
+    /// Accepts a canned format keyword (e.g. `default`, `oneline`) or a
+    /// custom format string. See the "Custom Log Output" section of the
+    /// defmt book for the format syntax.
+    #[arg(short = 'l', long, required = false)]
     log_format: Option<String>,
```

Adding `long` lets clap auto-derive `--log-format` from the field name (snake_case → kebab-case), matching the convention every other long-only option in this struct already uses (`--machine`, `--cpu`, `--arg`, `--aarch64`). The now-redundant `alias = "log-format"` is removed (it would collide with the auto-derived primary long).

The doc comment is expanded to mention the canned format keywords explicitly, so `qemu-run --help` actually advertises them.

### Why the value flow already works once the flag parses

The canned-format mapping is already in place upstream:

- `FormatterConfig::custom(&str)` calls `FormatterFormat::from_string(&str, true)` (in `decoder/src/log/format/mod.rs`),
- which maps `"default"` → `FormatterFormat::Default`, `"oneline"` → `FormatterFormat::OneLine`, and anything else → `FormatterFormat::Custom`.

That mapping was added in #965 (the `defmt-print` equivalent of this fix). So once the `--log-format` flag actually reaches `Opts::parse()` with a value, `qemu-run --log-format=oneline` Just Works. This PR is the missing argument-parsing half.

### About making `oneline` the default

The issue also mentions: "I'd be happy to have that as the default (except it might break existing defmt tests so maybe we cannot do that .... not sure)". I left the default unchanged in this PR to keep the scope tight and avoid touching test snapshots / book examples in the same change. Happy to file a follow-up if/when maintainers want to take that step separately.

### Testing

Verified by reading: `qemu-run --help` previously showed `-l <LOG_FORMAT>` only; with the change it will show `-l, --log-format <LOG_FORMAT>` and `--log-format=oneline` will route to `FormatterConfig::custom("oneline")` → `FormatterFormat::OneLine { with_location: true }`. I do not have a Rust toolchain in this environment, so the maintainers' CI is the verification of record — the change is a 1-line clap attribute swap plus a doc comment / CHANGELOG entry.

CHANGELOG.md gets an entry under `[qemu-run-next]` with the appropriate link references (verified `check_changelog.sh`'s shortcut/definition pairing is consistent).

### Declaration of AI-Tools / LLMs usage

AI-Tools used:

- **Claude (Sonnet)** for repo exploration, locating the line, cross-referencing the precedent in #965 / `FormatterConfig::custom`, drafting the commit message and this PR body. The actual code change is a one-attribute swap that matches the pattern every other long-only option in the same struct uses — reviewed by @adityachilka1 before pushing.
