### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 > A highly efficient logging framework that targets resource-constrained devices, like microcontrollers
 
-[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v1.1.0...main
+[defmt-next]: https://github.com/knurling-rs/defmt/compare/defmt-v1.1.1...main
+[defmt-v1.1.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.1.1
 [defmt-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.1.0
 [defmt-v1.0.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.0.1
 [defmt-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v1.0.0
@@ -58,6 +59,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 [defmt-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-v0.1.0
 
 ### [defmt-next]
+
+### [defmt-v1.1.1] (2026-06-26)
 
 * [#1070] Swap from `proc-macro-error2` to `syn::Error`
 
@@ -420,7 +423,8 @@ Initial release
 
 > Macros for [defmt](#defmt)
 
-[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v1.1.0...main
+[defmt-macros-next]: https://github.com/knurling-rs/defmt/compare/defmt-macros-v1.1.1...main
+[defmt-macros-v1.1.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.1.1
 [defmt-macros-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.1.0
 [defmt-macros-v1.0.1]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.0.1
 [defmt-macros-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v1.0.0
@@ -444,6 +448,10 @@ Initial release
 [defmt-macros-v0.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-macros-v0.1.0
 
 ### [defmt-macros-next]
+
+### [defmt-macros-v1.1.1] (2026-06-26)
+
+* [#1070] Swap from `proc-macro-error2` to `syn::Error`
 
 ### [defmt-macros-v1.1.0] (2026-05-12)
 
@@ -738,7 +746,8 @@ Initial release
 
 > Transmit defmt log messages over the RTT (Real-Time Transfer) protocol
 
-[defmt-rtt-next]: https://github.com/knurling-rs/defmt/compare/defmt-rtt-v1.2.0...main
+[defmt-rtt-next]: https://github.com/knurling-rs/defmt/compare/defmt-rtt-v1.3.0...main
+[defmt-rtt-v1.3.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.3.0
 [defmt-rtt-v1.2.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.2.0
 [defmt-rtt-v1.1.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.1.0
 [defmt-rtt-v1.0.0]: https://github.com/knurling-rs/defmt/releases/tag/defmt-rtt-v1.0.0
@@ -753,11 +762,14 @@ Initial release
 
 ### [defmt-rtt-next]
 
+### [defmt-rtt-v1.3.0] (2026-06-26)
+
+* [#1053] Add the `drop-on-contention` feature to trade low interrupt latency for reliable RTT delivery
+
 ### [defmt-rtt-v1.2.0] (2026-05-12)
 
 * [#1006] Fix `available_buffer_size` ignoring available buffer space when `read < write`
 * [#1013] Switch to fixed 32-bit types, to support 64-bit targets
-* [#1053] Add the `drop-on-contention` feature to trade low interrupt latency for reliable RTT delivery
 
 ### [defmt-rtt-v1.1.0] (2025-10-09)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "defmt-parser",
  "maplit",

--- a/defmt/Cargo.toml
+++ b/defmt/Cargo.toml
@@ -15,7 +15,7 @@ name = "defmt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 homepage = "https://knurling.ferrous-systems.com/"
-version = "1.1.0"
+version = "1.1.1"
 
 [features]
 alloc = []
@@ -45,7 +45,7 @@ unstable-test = [ "defmt-macros/unstable-test" ]
 [dependencies]
 # There is exactly one version of defmt-macros supported in this version of
 # defmt. Although, multiple versions of defmt might use the *same* defmt-macros.
-defmt-macros = { path = "../macros", version = "=1.1.0" }
+defmt-macros = { path = "../macros", version = "=1.1.1" }
 bitflags = "1"
 
 [dev-dependencies]

--- a/firmware/defmt-rtt/Cargo.toml
+++ b/firmware/defmt-rtt/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-rtt"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.2.0"
+version = "1.3.0"
 
 [features]
 disable-blocking-mode = []

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "defmt-macros"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
-version = "1.1.0"
+version = "1.1.1"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This PR bumps crate versions to prepare for new releases.

`defmt-macros` and its dependent `defmt` only received a minor version bump because the only change is a dependency replacement in #1070.
`defmt-rtt` gained a new feature in #1053.

- `defmt`
  - `v1.1.0` -> `v1.1.1`
- `defmt-macros`
  - `v1.1.0` -> `v1.1.1`
- `defmt-rtt`
  - `v1.2.0` -> `v1.3.0`