### PR TITLE
Adding Format impl for core::str errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#1068] Adding `Format` impl for `core::str` errors
+
 ### [defmt-v1.1.1] (2026-06-26)
 
 * [#1070] Swap from `proc-macro-error2` to `syn::Error`
@@ -1034,6 +1036,7 @@ Initial release
 ---
 
 [#1070]: https://github.com/knurling-rs/defmt/pull/1070
+[#1068]: https://github.com/knurling-rs/defmt/pull/1068
 [#1053]: https://github.com/knurling-rs/defmt/pull/1053
 [#1055]: https://github.com/knurling-rs/defmt/pull/1055
 [#1052]: https://github.com/knurling-rs/defmt/pull/1052

--- a/defmt/src/impls/core_/mod.rs
+++ b/defmt/src/impls/core_/mod.rs
@@ -16,6 +16,7 @@ mod ops;
 mod panic;
 mod ptr;
 mod slice;
+mod str;
 
 use super::*;
 use crate::export;

--- a/defmt/src/impls/core_/str.rs
+++ b/defmt/src/impls/core_/str.rs
@@ -1,0 +1,28 @@
+use core::str;
+
+use super::*;
+
+impl Format for str::Utf8Error {
+    fn format(&self, fmt: Formatter) {
+        if let Some(error_len) = self.error_len() {
+            crate::write!(
+                fmt,
+                "invalid utf-8 sequence of {=usize} bytes from index {=usize}",
+                error_len,
+                self.valid_up_to(),
+            );
+        } else {
+            crate::write!(
+                fmt,
+                "incomplete utf-8 byte sequence from index {=usize}",
+                self.valid_up_to(),
+            );
+        }
+    }
+}
+
+impl Format for str::ParseBoolError {
+    fn format(&self, fmt: Formatter) {
+        crate::write!(fmt, "provided string was not `true` or `false`");
+    }
+}


### PR DESCRIPTION
`str::Utf8Error` and `str::ParseBoolError`

Rework of #1068 with CHANGELOG fixed.