### PR TITLE
Support named arguments with inline capture in format strings ({owner:?})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
-* Support named arguments in format strings, like `core::format_args!`: `{owner}`, `{owner:?}` and `{owner=u8:#x}` capture `owner` from the surrounding scope, and arguments can be passed by name (`defmt::info!("{x}", x = expr)`).
+* Support named arguments in format strings. A parameter may now name a variable instead of using a positional index; the variable is captured from the surrounding scope, following the same rules as `core::format_args!`. This means `format!`-style strings such as `"{owner}"` and `"{owner:?}"` work unchanged, and defmt's type and display-hint syntax composes with names: `"{owner=u8:#x}"`. Arguments can also be passed by name: `defmt::info!("{x}", x = expr)`. Decoders older than this change cannot decode log statements that use the new syntax (other log statements are unaffected).
 
 ### [defmt-v1.1.1] (2026-06-26)
 
@@ -711,7 +711,7 @@ Initial release
 
 ### [defmt-parser-next]
 
-* Support named arguments (`{owner}`, `{owner=u8:#x}`) in the format string grammar. Named parameters are assigned the argument indices after all positional ones, in order of first appearance. `Parameter` gained a `name` field (breaking change).
+* Support named arguments (`{owner}`, `{owner=u8:#x}`) in the format string grammar. Named parameters are assigned the argument indices after all positional ones, in order of first appearance. Breaking changes (v2.0.0): `Parameter` gained a `name` field and `Error` gained an `InvalidArgumentName` variant.
 * [#956] Link `LICENSE-*` in the crate folder
 * [#1028] Clarify that MSRV is 1.76
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,7 +452,7 @@ Initial release
 
 ### [defmt-macros-next]
 
-* Support named arguments with inline capture (`{owner:?}`) and explicit `name = expr` formatting arguments.
+* [#1078] Support named arguments with inline capture (`{owner:?}`) and explicit `name = expr` formatting arguments.
 
 ### [defmt-macros-v1.1.1] (2026-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* Support named arguments in format strings, like `core::format_args!`: `{owner}`, `{owner:?}` and `{owner=u8:#x}` capture `owner` from the surrounding scope, and arguments can be passed by name (`defmt::info!("{x}", x = expr)`).
+
 ### [defmt-v1.1.1] (2026-06-26)
 
 * [#1070] Swap from `proc-macro-error2` to `syn::Error`
@@ -449,6 +451,8 @@ Initial release
 
 ### [defmt-macros-next]
 
+* Support named arguments with inline capture (`{owner:?}`) and explicit `name = expr` formatting arguments.
+
 ### [defmt-macros-v1.1.1] (2026-06-26)
 
 * [#1070] Swap from `proc-macro-error2` to `syn::Error`
@@ -707,6 +711,7 @@ Initial release
 
 ### [defmt-parser-next]
 
+* Support named arguments (`{owner}`, `{owner=u8:#x}`) in the format string grammar. Named parameters are assigned the argument indices after all positional ones, in order of first appearance. `Parameter` gained a `name` field (breaking change).
 * [#956] Link `LICENSE-*` in the crate folder
 * [#1028] Clarify that MSRV is 1.76
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "defmt-parser"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "rstest",
  "thiserror",

--- a/book/src/macros.md
+++ b/book/src/macros.md
@@ -36,7 +36,7 @@ defmt::trace!("{}", x);
 
 The `defmt` grammar is similar to `core::fmt`, but not the same. The syntax of a formatting parameter is shown below:
 
-> `{[pos][=Type][:Display]}`
+> `{[pos|name][=Type][:Display]}`
 
 ### Type hint
 
@@ -55,3 +55,18 @@ Read more about it [here](./hints.md).
 ### Positional parameter
 
 The `pos` parameter lets you specify the position of the value to format (see ["Positional parameters"](https://doc.rust-lang.org/std/fmt/index.html#positional-parameters)).
+
+### Named parameters
+
+Instead of a position, a parameter can name a variable, which is captured from the surrounding scope (see ["Named parameters"](https://doc.rust-lang.org/std/fmt/index.html#named-parameters)).
+Names combine freely with the type and display hints, and arguments can also be passed by name.
+
+``` rust
+# extern crate defmt;
+# let len = 80u8;
+// -> INFO:  message arrived (length=80)
+defmt::info!("message arrived (length={len})");
+
+// -> INFO:  message arrived (length=0x50)
+defmt::info!("message arrived (length={len=u8:#x})", len = 80u8);
+```

--- a/decoder/Cargo.toml
+++ b/decoder/Cargo.toml
@@ -13,7 +13,7 @@ version = "1.1.0"
 [dependencies]
 byteorder = "1"
 colored = "2"
-defmt-parser = { version = "=1.0.0", path = "../parser" }
+defmt-parser = { version = "=2.0.0", path = "../parser" }
 ryu = "1"
 nom = "7"
 

--- a/decoder/src/decoder.rs
+++ b/decoder/src/decoder.rs
@@ -285,6 +285,7 @@ fn merge_bitfields(params: &mut Vec<Parameter>) {
 
             // create new merged bitfield for this index
             merged_bitfields.push(Parameter {
+                name: None,
                 index,
                 ty: Type::BitField(Range {
                     start: smallest,
@@ -325,11 +326,13 @@ mod tests {
     fn merge_bitfields_simple() {
         let mut params = vec![
             Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(0..3),
                 hint: None,
             },
             Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(4..7),
                 hint: None,
@@ -340,6 +343,7 @@ mod tests {
         assert_eq!(
             params,
             vec![Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(0..7),
                 hint: None,
@@ -351,11 +355,13 @@ mod tests {
     fn merge_bitfields_overlap() {
         let mut params = vec![
             Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(1..3),
                 hint: None,
             },
             Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(2..5),
                 hint: None,
@@ -366,6 +372,7 @@ mod tests {
         assert_eq!(
             params,
             vec![Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(1..5),
                 hint: None,
@@ -377,16 +384,19 @@ mod tests {
     fn merge_bitfields_multiple_indices() {
         let mut params = vec![
             Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(0..3),
                 hint: None,
             },
             Parameter {
+                name: None,
                 index: 1,
                 ty: Type::BitField(1..3),
                 hint: None,
             },
             Parameter {
+                name: None,
                 index: 1,
                 ty: Type::BitField(4..5),
                 hint: None,
@@ -398,11 +408,13 @@ mod tests {
             params,
             vec![
                 Parameter {
+                    name: None,
                     index: 0,
                     ty: Type::BitField(0..3),
                     hint: None,
                 },
                 Parameter {
+                    name: None,
                     index: 1,
                     ty: Type::BitField(1..5),
                     hint: None,
@@ -415,21 +427,25 @@ mod tests {
     fn merge_bitfields_overlap_non_consecutive_indices() {
         let mut params = vec![
             Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(0..3),
                 hint: None,
             },
             Parameter {
+                name: None,
                 index: 1,
                 ty: Type::U8,
                 hint: None,
             },
             Parameter {
+                name: None,
                 index: 2,
                 ty: Type::BitField(1..4),
                 hint: None,
             },
             Parameter {
+                name: None,
                 index: 2,
                 ty: Type::BitField(4..5),
                 hint: None,
@@ -442,16 +458,19 @@ mod tests {
             params,
             vec![
                 Parameter {
+                    name: None,
                     index: 1,
                     ty: Type::U8,
                     hint: None,
                 },
                 Parameter {
+                    name: None,
                     index: 0,
                     ty: Type::BitField(0..3),
                     hint: None,
                 },
                 Parameter {
+                    name: None,
                     index: 2,
                     ty: Type::BitField(1..5),
                     hint: None,

--- a/decoder/src/lib.rs
+++ b/decoder/src/lib.rs
@@ -737,6 +737,27 @@ mod tests {
     }
 
     #[test]
+    fn decode_named_args() {
+        // Arguments are serialized in index order: positional arguments first, then named
+        // arguments in order of first appearance. This mirrors the order in which the
+        // `defmt` macros emit them; both sides derive it from the same format string.
+        let bytes = [
+            0, 0,    // index
+            2,    // timestamp
+            1,    // pos ({=u8}, index 0)
+            42,   // x (index 1)
+            0x34, // y (index 2, u16 LE)
+            0x12,
+        ];
+
+        decode_and_expect(
+            "x={x=u8}, pos={=u8}, y={y=u16:#x}, x again={x=u8}",
+            &bytes,
+            "0.000002 INFO x=42, pos=1, y=0x1234, x again=42",
+        );
+    }
+
+    #[test]
     fn display_use_inner_type_hint() {
         let entries = vec![
             TableEntry::new_without_symbol(Tag::Info, "x={:b}".to_owned()),

--- a/defmt/src/tests.rs
+++ b/defmt/src/tests.rs
@@ -19,6 +19,51 @@ fn str() {
 }
 
 #[test]
+fn named_arguments() {
+    let owner = 42u8;
+    let count = 7u16;
+
+    // inline capture from the surrounding scope
+    defmt::info!("{owner=u8}");
+    defmt::info!("{owner}");
+    defmt::info!("{owner:?}"); // std's Debug syntax works unchanged
+    defmt::info!("{owner=u8:#x} {count=u16}");
+
+    // repeated use of one capture serializes the argument only once
+    defmt::info!("{owner} and {owner}");
+
+    // explicitly supplied named arguments
+    defmt::info!("{x=u8}", x = 1);
+    defmt::info!("{x}", x = owner);
+
+    // mixed positional and named
+    defmt::info!("{=u8} {owner=u8} {0=u8}", 1);
+}
+
+#[test]
+fn named_arguments_in_write() {
+    struct S {
+        x: u8,
+    }
+
+    impl defmt::Format for S {
+        fn format(&self, f: defmt::Formatter) {
+            let x = self.x;
+            defmt::write!(f, "S {{ x: {x=u8} }}")
+        }
+    }
+
+    defmt::info!("{}", S { x: 1 });
+}
+
+#[test]
+fn named_arguments_in_assert_like() {
+    let owner = 42u8;
+    defmt::assert!(true, "{owner}");
+    defmt::assert_eq!(1, 1, "{owner=u8:#x}");
+}
+
+#[test]
 fn trailing_comma() {
     defmt::trace!("test trace",);
     defmt::debug!("test debug",);

--- a/defmt/tests/ui/log-named-duplicate.rs
+++ b/defmt/tests/ui/log-named-duplicate.rs
@@ -1,0 +1,3 @@
+fn main() {
+    defmt::info!("{x=u8}", x = 1, x = 2)
+}

--- a/defmt/tests/ui/log-named-duplicate.stderr
+++ b/defmt/tests/ui/log-named-duplicate.stderr
@@ -1,0 +1,5 @@
+error: duplicate argument named `x`
+ --> tests/ui/log-named-duplicate.rs:2:35
+  |
+2 |     defmt::info!("{x=u8}", x = 1, x = 2)
+  |                                   ^

--- a/defmt/tests/ui/log-named-keyword.rs
+++ b/defmt/tests/ui/log-named-keyword.rs
@@ -1,0 +1,3 @@
+fn main() {
+    defmt::info!("{fn}")
+}

--- a/defmt/tests/ui/log-named-keyword.stderr
+++ b/defmt/tests/ui/log-named-keyword.stderr
@@ -1,0 +1,5 @@
+error: invalid argument name `fn`: keywords cannot be captured
+ --> tests/ui/log-named-keyword.rs:2:18
+  |
+2 |     defmt::info!("{fn}")
+  |                  ^^^^^^

--- a/defmt/tests/ui/log-named-missing-capture.rs
+++ b/defmt/tests/ui/log-named-missing-capture.rs
@@ -1,0 +1,3 @@
+fn main() {
+    defmt::info!("{missing}")
+}

--- a/defmt/tests/ui/log-named-missing-capture.stderr
+++ b/defmt/tests/ui/log-named-missing-capture.stderr
@@ -1,0 +1,5 @@
+error[E0425]: cannot find value `missing` in this scope
+ --> tests/ui/log-named-missing-capture.rs:2:18
+  |
+2 |     defmt::info!("{missing}")
+  |                  ^^^^^^^^^^^ not found in this scope

--- a/defmt/tests/ui/log-named-positional-after-named.rs
+++ b/defmt/tests/ui/log-named-positional-after-named.rs
@@ -1,0 +1,3 @@
+fn main() {
+    defmt::info!("{=u8} {x=u8}", x = 1, 5)
+}

--- a/defmt/tests/ui/log-named-positional-after-named.stderr
+++ b/defmt/tests/ui/log-named-positional-after-named.stderr
@@ -1,0 +1,5 @@
+error: positional arguments cannot follow named arguments
+ --> tests/ui/log-named-positional-after-named.rs:2:41
+  |
+2 |     defmt::info!("{=u8} {x=u8}", x = 1, 5)
+  |                                         ^

--- a/defmt/tests/ui/log-named-unused.rs
+++ b/defmt/tests/ui/log-named-unused.rs
@@ -1,0 +1,3 @@
+fn main() {
+    defmt::info!("{x=u8}", x = 1, y = 2)
+}

--- a/defmt/tests/ui/log-named-unused.stderr
+++ b/defmt/tests/ui/log-named-unused.stderr
@@ -1,0 +1,5 @@
+error: named argument `y` is not used in this format string
+ --> tests/ui/log-named-unused.rs:2:35
+  |
+2 |     defmt::info!("{x=u8}", x = 1, y = 2)
+  |                                   ^

--- a/firmware/qemu/src/bin/named_args.out
+++ b/firmware/qemu/src/bin/named_args.out
@@ -1,0 +1,8 @@
+INFO  42
+INFO  42
+INFO  42
+INFO  0x2a then 0x1234
+INFO  42 repeated 42
+INFO  explicit 1
+INFO  mixed pos=7 named=42 first=7
+println 42 0x1234

--- a/firmware/qemu/src/bin/named_args.rs
+++ b/firmware/qemu/src/bin/named_args.rs
@@ -1,0 +1,40 @@
+#![no_std]
+#![no_main]
+
+use cortex_m as _;
+use cortex_m_rt::entry;
+use semihosting::process::ExitCode;
+
+use defmt_semihosting as _; // global logger
+
+#[entry]
+fn main() -> ! {
+    let owner = 42u8;
+    let count = 0x1234u16;
+
+    // inline capture from the surrounding scope
+    defmt::info!("{owner=u8}");
+    defmt::info!("{owner}");
+    defmt::info!("{owner:?}");
+    defmt::info!("{owner=u8:#x} then {count=u16:#x}");
+
+    // repeated use of one capture serializes the argument only once
+    defmt::info!("{owner} repeated {owner}");
+
+    // explicitly supplied named arguments
+    defmt::info!("explicit {x=u8}", x = 1);
+
+    // mixed positional and named
+    defmt::info!("mixed pos={=u8} named={owner=u8} first={0=u8}", 7);
+
+    defmt::println!("println {owner=u8} {count=u16:#x}");
+
+    ExitCode::SUCCESS.exit_process()
+}
+
+// like `panic-semihosting` but doesn't print to stdout (that would corrupt the defmt stream)
+#[cfg(target_os = "none")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    ExitCode::FAILURE.exit_process()
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 unstable-test = []
 
 [dependencies]
-defmt-parser = { version = "=1.0.0", path = "../parser" }
+defmt-parser = { version = "=2.0.0", path = "../parser" }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }

--- a/macros/src/function_like/assert_binop.rs
+++ b/macros/src/function_like/assert_binop.rs
@@ -45,7 +45,7 @@ fn expand(args: Args, binop: BinOp) -> syn::Result<TokenStream2> {
     };
 
     for val in vals {
-        formatting_args.push(construct::variable(val));
+        formatting_args.push(log::FormatArg::from(construct::variable(val)));
     }
 
     let panic_msg = match binop {

--- a/macros/src/function_like/assert_like/unwrap.rs
+++ b/macros/src/function_like/assert_like/unwrap.rs
@@ -19,7 +19,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
         );
 
         let mut formatting_args = Punctuated::new();
-        formatting_args.push(construct::variable("_unwrap_err"));
+        formatting_args.push(log::FormatArg::from(construct::variable("_unwrap_err")));
 
         (format_string, Some(formatting_args))
     };

--- a/macros/src/function_like/log.rs
+++ b/macros/src/function_like/log.rs
@@ -7,7 +7,10 @@ use syn::{parse_macro_input, parse_quote};
 use crate::construct;
 
 use self::env_filter::EnvFilter;
-pub(crate) use self::{args::Args, codegen::Codegen};
+pub(crate) use self::{
+    args::{Args, FormatArg},
+    codegen::{resolve_args, Codegen},
+};
 
 mod args;
 mod codegen;
@@ -26,10 +29,8 @@ pub(crate) fn expand_parsed(level: Level, args: Args) -> syn::Result<TokenStream
         Err(e) => return Err(syn::Error::new(args.format_string.span(), format!("{}", e))),
     };
 
-    let formatting_exprs = args
-        .formatting_args
-        .map(|punctuated| punctuated.into_iter().collect::<Vec<_>>())
-        .unwrap_or_default();
+    let formatting_exprs =
+        resolve_args(&fragments, args.format_string.span(), args.formatting_args)?;
 
     let Codegen { patterns, exprs } = Codegen::new(
         &fragments,

--- a/macros/src/function_like/log/args.rs
+++ b/macros/src/function_like/log/args.rs
@@ -1,12 +1,12 @@
 use syn::{
     parse::{self, Parse, ParseStream},
     punctuated::Punctuated,
-    Expr, LitStr, Token,
+    Expr, Ident, LitStr, Token,
 };
 
 pub(crate) struct Args {
     pub(crate) format_string: LitStr,
-    pub(crate) formatting_args: Option<Punctuated<Expr, Token![,]>>,
+    pub(crate) formatting_args: Option<Punctuated<FormatArg, Token![,]>>,
 }
 
 impl Parse for Args {
@@ -20,5 +20,32 @@ impl Parse for Args {
                 Some(Punctuated::parse_terminated(input)?)
             },
         })
+    }
+}
+
+/// A formatting argument: `expr` (positional) or `name = expr` (named).
+pub(crate) enum FormatArg {
+    Positional(Expr),
+    Named(Ident, Expr),
+}
+
+impl From<Expr> for FormatArg {
+    fn from(expr: Expr) -> Self {
+        FormatArg::Positional(expr)
+    }
+}
+
+impl Parse for FormatArg {
+    fn parse(input: ParseStream) -> parse::Result<Self> {
+        // Like `core::format_args!`, a leading `ident =` (but not `ident ==`) denotes a
+        // named argument.
+        if input.peek(Ident) && input.peek2(Token![=]) && !input.peek2(Token![==]) {
+            let name: Ident = input.parse()?;
+            let _eq: Token![=] = input.parse()?;
+            let expr: Expr = input.parse()?;
+            Ok(FormatArg::Named(name, expr))
+        } else {
+            Ok(FormatArg::Positional(input.parse()?))
+        }
     }
 }

--- a/macros/src/function_like/log/codegen.rs
+++ b/macros/src/function_like/log/codegen.rs
@@ -1,10 +1,123 @@
 use defmt_parser::{Fragment, Parameter, Type};
 use proc_macro2::{Ident as Ident2, Span as Span2, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
+use syn::{parse_quote, punctuated::Punctuated, Expr, Token};
+
+use super::args::FormatArg;
 
 pub(crate) struct Codegen {
     pub(crate) exprs: Vec<TokenStream2>,
     pub(crate) patterns: Vec<Ident2>,
+}
+
+/// Resolves the given formatting arguments against the format string's parameters,
+/// returning one expression per argument index, in index order.
+///
+/// Positional arguments are used as-is. Named parameters take the matching `name = expr`
+/// argument if one was given; otherwise the identifier is captured from the surrounding
+/// scope, like `core::format_args!` does for `format!("{owner}")`.
+pub(crate) fn resolve_args(
+    fragments: &[Fragment<'_>],
+    format_span: Span2,
+    args: Option<Punctuated<FormatArg, Token![,]>>,
+) -> syn::Result<Vec<Expr>> {
+    let params = fragments
+        .iter()
+        .filter_map(|frag| match frag {
+            Fragment::Parameter(param) => Some(param),
+            Fragment::Literal(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    let arg_count = params
+        .iter()
+        .map(|param| param.index + 1)
+        .max()
+        .unwrap_or(0);
+
+    // The parser assigns named parameters the indices after all positional ones.
+    let mut names: Vec<Option<&str>> = vec![None; arg_count];
+    for param in &params {
+        if let Some(name) = &param.name {
+            names[param.index] = Some(name);
+        }
+    }
+    let named_count = names.iter().filter(|name| name.is_some()).count();
+    let positional_count = arg_count - named_count;
+
+    // Split the given arguments into positional and named ones.
+    let mut positional_exprs = Vec::new();
+    let mut named_exprs: Vec<(syn::Ident, Expr)> = Vec::new();
+    for arg in args.into_iter().flatten() {
+        match arg {
+            FormatArg::Positional(expr) => {
+                if !named_exprs.is_empty() {
+                    return Err(syn::Error::new_spanned(
+                        &expr,
+                        "positional arguments cannot follow named arguments",
+                    ));
+                }
+                positional_exprs.push(expr);
+            }
+            FormatArg::Named(ident, expr) => {
+                if named_exprs.iter().any(|(name, _)| *name == ident) {
+                    return Err(syn::Error::new(
+                        ident.span(),
+                        format!("duplicate argument named `{ident}`"),
+                    ));
+                }
+                named_exprs.push((ident, expr));
+            }
+        }
+    }
+
+    if positional_exprs.len() != positional_count {
+        let given = positional_exprs.len();
+        let mut only = "";
+        if given < positional_count {
+            only = "only ";
+        }
+        // Keep the pre-named-arguments wording when no named arguments are involved.
+        let kind = match named_count == 0 && named_exprs.is_empty() {
+            true => "arguments",
+            false => "positional arguments",
+        };
+        return Err(syn::Error::new(
+            format_span,
+            format!(
+                "format string requires {positional_count} {kind} but {only}{given} were provided"
+            ),
+        ));
+    }
+
+    // Assemble the final argument list, resolving each named parameter to the given
+    // `name = expr` or to a capture of `name` from the surrounding scope.
+    let mut exprs = positional_exprs;
+    for name in &names[positional_count..] {
+        let name = name.unwrap(/* named indices are contiguous after positionals */);
+        if let Some(position) = named_exprs.iter().position(|(ident, _)| ident == name) {
+            exprs.push(named_exprs.remove(position).1);
+        } else {
+            let mut ident = syn::parse_str::<syn::Ident>(name).map_err(|_| {
+                syn::Error::new(
+                    format_span,
+                    format!("invalid argument name `{name}`: keywords cannot be captured"),
+                )
+            })?;
+            ident.set_span(format_span);
+            exprs.push(parse_quote!(#ident));
+        }
+    }
+
+    // All remaining named arguments were not referenced by the format string.
+    if let Some((ident, _)) = named_exprs.first() {
+        return Err(syn::Error::new(
+            ident.span(),
+            format!("named argument `{ident}` is not used in this format string"),
+        ));
+    }
+
+    Ok(exprs)
 }
 
 impl Codegen {

--- a/macros/src/function_like/log/codegen.rs
+++ b/macros/src/function_like/log/codegen.rs
@@ -10,6 +10,15 @@ pub(crate) struct Codegen {
     pub(crate) patterns: Vec<Ident2>,
 }
 
+/// Number of arguments referenced by the format string's parameters.
+fn expected_arg_count<'a>(params: impl IntoIterator<Item = &'a Parameter>) -> usize {
+    params
+        .into_iter()
+        .map(|param| param.index + 1)
+        .max()
+        .unwrap_or(0)
+}
+
 /// Resolves the given formatting arguments against the format string's parameters,
 /// returning one expression per argument index, in index order.
 ///
@@ -29,11 +38,7 @@ pub(crate) fn resolve_args(
         })
         .collect::<Vec<_>>();
 
-    let arg_count = params
-        .iter()
-        .map(|param| param.index + 1)
-        .max()
-        .unwrap_or(0);
+    let arg_count = expected_arg_count(params.iter().copied());
 
     // The parser assigns named parameters the indices after all positional ones.
     let mut names: Vec<Option<&str>> = vec![None; arg_count];
@@ -134,11 +139,7 @@ impl Codegen {
             })
             .collect::<Vec<_>>();
 
-        let expected_arg_count = params
-            .iter()
-            .map(|param| param.index + 1)
-            .max()
-            .unwrap_or(0);
+        let expected_arg_count = expected_arg_count(&params);
 
         if given_arg_count != expected_arg_count {
             let mut only = "";

--- a/macros/src/function_like/println.rs
+++ b/macros/src/function_like/println.rs
@@ -5,7 +5,7 @@ use quote::quote;
 use syn::{parse_macro_input, parse_quote};
 
 use crate::construct;
-use crate::function_like::log::{Args, Codegen};
+use crate::function_like::log::{resolve_args, Args, Codegen};
 
 pub(crate) fn expand(args: TokenStream) -> TokenStream {
     let parsed = parse_macro_input!(args as Args);
@@ -28,10 +28,8 @@ pub(crate) fn expand_parsed(args: Args) -> syn::Result<TokenStream2> {
         Err(e) => return Err(syn::Error::new(args.format_string.span(), format!("{}", e))), // No extra help
     };
 
-    let formatting_exprs = args
-        .formatting_args
-        .map(|punctuated| punctuated.into_iter().collect::<Vec<_>>())
-        .unwrap_or_default();
+    let formatting_exprs =
+        resolve_args(&fragments, args.format_string.span(), args.formatting_args)?;
 
     let Codegen { patterns, exprs } = Codegen::new(
         &fragments,

--- a/macros/src/function_like/write.rs
+++ b/macros/src/function_like/write.rs
@@ -26,10 +26,14 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
         }
     };
 
-    let formatting_exprs: Vec<_> = log_args
-        .formatting_args
-        .map(|punctuated| punctuated.into_iter().collect())
-        .unwrap_or_default();
+    let formatting_exprs = match log::resolve_args(
+        &fragments,
+        log_args.format_string.span(),
+        log_args.formatting_args,
+    ) {
+        Ok(val) => val,
+        Err(err) => return err.into_compile_error().into(),
+    };
 
     let log::Codegen { patterns, exprs } = match log::Codegen::new(
         &fragments,

--- a/macros/src/items/timestamp.rs
+++ b/macros/src/items/timestamp.rs
@@ -20,10 +20,11 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
         }
     };
 
-    let formatting_exprs: Vec<_> = args
-        .formatting_args
-        .map(|punctuated| punctuated.into_iter().collect())
-        .unwrap_or_default();
+    let formatting_exprs =
+        match log::resolve_args(&fragments, args.format_string.span(), args.formatting_args) {
+            Ok(val) => val,
+            Err(err) => return err.into_compile_error().into(),
+        };
 
     let log::Codegen { patterns, exprs } = match log::Codegen::new(
         &fragments,

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -8,7 +8,7 @@ name = "defmt-parser"
 readme = "README.md"
 repository = "https://github.com/knurling-rs/defmt"
 rust-version = "1.76"
-version = "1.0.0"
+version = "2.0.0"
 
 [dependencies]
 thiserror = "2"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -47,6 +47,8 @@ pub enum Error {
     ConflictingTypes(usize, Type, Type),
     #[error("argument {0} is not used in this format string")]
     UnusedArgument(usize),
+    #[error("invalid argument name `{0}`")]
+    InvalidArgumentName(String),
 }
 
 /// A parameter of the form `{{0=Type:hint}}` in a format string.
@@ -58,6 +60,11 @@ pub struct Parameter {
     pub ty: Type,
     /// The display hint, e.g. ':x', ':b', ':a'.
     pub hint: Option<DisplayHint>,
+    /// The argument name, if this parameter refers to a named argument (e.g. `{owner}`).
+    ///
+    /// Named arguments are assigned the indices following the positional arguments, in
+    /// order of first appearance; `index` is always set accordingly.
+    pub name: Option<String>,
 }
 
 /// A part of a format string.
@@ -76,7 +83,8 @@ pub enum Fragment<'f> {
 ///
 /// ```notrust
 /// param := '{' [ argument ] [ '=' argtype ] [ ':' format_spec ] '}'
-/// argument := integer
+/// argument := integer | identifier
+/// identifier := [ 'a'-'z' | 'A'-'Z' | '_' ] [ 'a'-'z' | 'A'-'Z' | '0'-'9' | '_' ]*
 ///
 /// argtype := bitfield | '?' | format-array | '[?]' | byte-array | '[u8]' | 'istr' | 'str' |
 ///     'bool' | 'char' | 'u8' | 'u16' | 'u32' | 'u64' | 'u128' | 'usize' | 'i8' | 'i16' | 'i32' |
@@ -93,6 +101,7 @@ pub enum Fragment<'f> {
 #[derive(Debug, PartialEq)]
 struct Param {
     index: Option<usize>,
+    name: Option<String>,
     ty: Type,
     hint: Option<DisplayHint>,
 }
@@ -191,19 +200,35 @@ fn parse_param(mut input: &str, mode: ParserMode) -> Result<Param, Error> {
     const TYPE_PREFIX: &str = "=";
     const HINT_PREFIX: &str = ":";
 
-    // First, optional argument index.
+    // First, optional argument: an integer index or an identifier (named argument).
     let mut index = None;
+    let mut name = None;
     let index_end = input
         .find(|c: char| !c.is_ascii_digit())
         .unwrap_or(input.len());
 
     if index_end != 0 {
         index = Some(input[..index_end].parse::<usize>()?);
+        input = &input[index_end..];
+    } else if input
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+    {
+        // Identifiers may not start with a digit; that case was handled above.
+        let name_end = input
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .unwrap_or(input.len());
+        let ident = &input[..name_end];
+        if ident == "_" {
+            return Err(Error::InvalidArgumentName(ident.to_owned()));
+        }
+        name = Some(ident.to_owned());
+        input = &input[name_end..];
     }
 
     // Then, optional type
     let mut ty = Type::default(); // when no explicit type; use the default one
-    input = &input[index_end..];
 
     if input.starts_with(TYPE_PREFIX) {
         // skip the prefix
@@ -255,10 +280,15 @@ fn parse_param(mut input: &str, mode: ParserMode) -> Result<Param, Error> {
         return Err(Error::UnexpectedContentInFormatString(input.to_owned()));
     }
 
-    Ok(Param { index, ty, hint })
+    Ok(Param {
+        index,
+        name,
+        ty,
+        hint,
+    })
 }
 
-fn push_literal<'f>(frag: &mut Vec<Fragment<'f>>, unescaped_literal: &'f str) -> Result<(), Error> {
+fn unescape_literal(unescaped_literal: &str) -> Result<Cow<'_, str>, Error> {
     // Replace `{{` with `{` and `}}` with `}`. Single braces are errors.
 
     // Scan for single braces first. The rest is trivial.
@@ -282,9 +312,10 @@ fn push_literal<'f>(frag: &mut Vec<Fragment<'f>>, unescaped_literal: &'f str) ->
     }
 
     // FIXME: This always allocates a `String`, so the `Cow` is useless.
-    let literal = unescaped_literal.replace("{{", "{").replace("}}", "}");
-    frag.push(Fragment::Literal(literal.into()));
-    Ok(())
+    Ok(unescaped_literal
+        .replace("{{", "{")
+        .replace("}}", "}")
+        .into())
 }
 
 /// Returns `Some(smallest_bit_index, largest_bit_index)` contained in `params` if
@@ -316,13 +347,16 @@ where
 }
 
 pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>, Error> {
-    let mut fragments = Vec::new();
+    /// A fragment whose parameters do not have their final argument index assigned yet.
+    enum RawFragment<'f> {
+        Literal(Cow<'f, str>),
+        Parameter(Param),
+    }
+
+    let mut raw_fragments = Vec::new();
 
     // Index after the `}` of the last format specifier.
     let mut end_pos = 0;
-
-    // Next argument index assigned to a parameter without an explicit one.
-    let mut next_arg_index = 0;
 
     let mut chars = format_string.char_indices();
     while let Some((brace_pos, ch)) = chars.next() {
@@ -341,7 +375,7 @@ pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>,
         if brace_pos > end_pos {
             // There's a literal fragment with at least 1 character before this parameter fragment.
             let unescaped_literal = &format_string[end_pos..brace_pos];
-            push_literal(&mut fragments, unescaped_literal)?;
+            raw_fragments.push(RawFragment::Literal(unescape_literal(unescaped_literal)?));
         }
 
         // Else, this is a format specifier. It ends at the next `}`.
@@ -353,22 +387,75 @@ pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>,
 
         // Parse the contents inside the braces.
         let param_str = &format_string[brace_pos + 1..][..len];
-        let param = parse_param(param_str, mode)?;
-        fragments.push(Fragment::Parameter(Parameter {
-            index: param.index.unwrap_or_else(|| {
-                // If there is no explicit index, assign the next one.
-                let idx = next_arg_index;
-                next_arg_index += 1;
-                idx
-            }),
-            ty: param.ty,
-            hint: param.hint,
-        }));
+        raw_fragments.push(RawFragment::Parameter(parse_param(param_str, mode)?));
     }
 
     // Trailing literal.
     if end_pos != format_string.len() {
-        push_literal(&mut fragments, &format_string[end_pos..])?;
+        raw_fragments.push(RawFragment::Literal(unescape_literal(
+            &format_string[end_pos..],
+        )?));
+    }
+
+    // Assign argument indices.
+    //
+    // Parameters with an explicit index (`{0}`) use it as-is and parameters with neither an
+    // index nor a name (`{}`) take the next implicit index, exactly like `core::format_args!`.
+    // Named parameters (`{owner}`) are assigned the indices *after* all positional ones, in
+    // order of first appearance, mirroring how `core::format_args!` appends named arguments
+    // after the positional ones.
+    //
+    // NOTE: this assignment is recomputed from the interned format string when decoding logs,
+    // so it must stay deterministic: `defmt-macros` serializes the arguments in this order at
+    // compile time and `defmt-decoder` derives the same order from the same string at decode
+    // time (both through this function).
+    let mut implicit_count = 0;
+    let mut max_explicit = None;
+    let mut names: Vec<&str> = Vec::new();
+    for frag in &raw_fragments {
+        if let RawFragment::Parameter(param) = frag {
+            match (&param.index, &param.name) {
+                (Some(index), _) => max_explicit = max_explicit.max(Some(*index)),
+                (None, Some(name)) => {
+                    if !names.iter().any(|n| n == name) {
+                        names.push(name);
+                    }
+                }
+                (None, None) => implicit_count += 1,
+            }
+        }
+    }
+    let positional_count = implicit_count.max(max_explicit.map_or(0, |max| max + 1));
+    let names = names.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+    let mut next_arg_index = 0;
+    let mut fragments = Vec::new();
+    for frag in raw_fragments {
+        match frag {
+            RawFragment::Literal(literal) => fragments.push(Fragment::Literal(literal)),
+            RawFragment::Parameter(param) => {
+                let index = match (param.index, &param.name) {
+                    (Some(index), _) => index,
+                    (None, Some(name)) => {
+                        let name_index =
+                            names.iter().position(|n| n == name).unwrap(/* collected above */);
+                        positional_count + name_index
+                    }
+                    (None, None) => {
+                        // If there is no explicit index, assign the next one.
+                        let index = next_arg_index;
+                        next_arg_index += 1;
+                        index
+                    }
+                };
+                fragments.push(Fragment::Parameter(Parameter {
+                    index,
+                    ty: param.ty,
+                    hint: param.hint,
+                    name: param.name,
+                }));
+            }
+        }
     }
 
     // Check for argument type conflicts.

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -20,7 +20,12 @@ fn all_parse_param_cases(
 ) {
     assert_eq!(
         parse_param(input, ParserMode::Strict),
-        Ok(Param { index, ty, hint })
+        Ok(Param {
+            name: None,
+            index,
+            ty,
+            hint
+        })
     );
 }
 
@@ -49,6 +54,7 @@ fn all_display_hints(#[case] input: &str, #[case] hint: DisplayHint) {
     assert_eq!(
         parse_param(input, ParserMode::Strict),
         Ok(Param {
+            name: None,
             index: None,
             ty: Type::Format,
             hint: Some(hint),
@@ -62,6 +68,7 @@ fn display_hint_unknown() {
     assert_eq!(
         parse_param(":unknown", ParserMode::ForwardsCompatible),
         Ok(Param {
+            name: None,
             index: None,
             ty: Type::Format,
             hint: Some(DisplayHint::Unknown("unknown".to_string())),
@@ -92,6 +99,7 @@ fn all_types(#[case] input: &str, #[case] ty: Type) {
     assert_eq!(
         parse_param(input, ParserMode::Strict),
         Ok(Param {
+            name: None,
             index: None,
             ty,
             hint: None,
@@ -109,17 +117,61 @@ fn index(#[case] input: &str, #[case] params: [(usize, Type); 2]) {
         parse(input, ParserMode::Strict),
         Ok(vec![
             Fragment::Parameter(Parameter {
+                name: None,
                 index: params[0].0,
                 ty: params[0].1.clone(),
                 hint: None,
             }),
             Fragment::Parameter(Parameter {
+                name: None,
                 index: params[1].0,
                 ty: params[1].1.clone(),
                 hint: None,
             }),
         ])
     );
+}
+
+#[rstest]
+#[case::named_only("{owner}{count}", [(0, Some("owner"), Type::Format), (1, Some("count"), Type::Format)])]
+#[case::named_repeated("{owner}{owner}", [(0, Some("owner"), Type::Format), (0, Some("owner"), Type::Format)])]
+#[case::named_after_implicit("{}{owner}", [(0, None, Type::Format), (1, Some("owner"), Type::Format)])]
+#[case::named_after_explicit("{owner}{1=u8}{0=u16}", [(2, Some("owner"), Type::Format), (1, None, Type::U8)])]
+#[case::named_with_type_and_hint("{owner=u8:#x}{count=u16}", [(0, Some("owner"), Type::U8), (1, Some("count"), Type::U16)])]
+fn named(#[case] input: &str, #[case] params: [(usize, Option<&str>, Type); 2]) {
+    let parsed = parse(input, ParserMode::Strict).unwrap();
+    let parsed_params = parsed
+        .iter()
+        .filter_map(|frag| match frag {
+            Fragment::Parameter(param) => {
+                Some((param.index, param.name.as_deref(), param.ty.clone()))
+            }
+            Fragment::Literal(_) => None,
+        })
+        .take(2)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        parsed_params,
+        params
+            .iter()
+            .map(|(index, name, ty)| (*index, *name, ty.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[rstest]
+#[case::debug_hint("{owner:?}")]
+#[case::zero_pad_hint("{owner:08}")]
+fn named_with_debug_hint(#[case] input: &str) {
+    // `{owner:?}` (std's Debug syntax) must parse as a named parameter of the default
+    // (`Format`) type, making std format strings work unchanged.
+    let parsed = parse(input, ParserMode::Strict).unwrap();
+    let Fragment::Parameter(param) = &parsed[0] else {
+        panic!("expected parameter, got {parsed:?}");
+    };
+    assert_eq!(param.index, 0);
+    assert_eq!(param.name.as_deref(), Some("owner"));
+    assert_eq!(param.ty, Type::Format);
 }
 
 #[rstest]
@@ -130,6 +182,7 @@ fn range(#[case] input: &str, #[case] bit_field: Range<u8>) {
     assert_eq!(
         parse(input, ParserMode::Strict),
         Ok(vec![Fragment::Parameter(Parameter {
+            name: None,
             index: 0,
             ty: Type::BitField(bit_field),
             hint: None,
@@ -143,16 +196,19 @@ fn multiple_ranges() {
         parse("{0=30..31}{1=0..4}{1=2..6}", ParserMode::Strict),
         Ok(vec![
             Fragment::Parameter(Parameter {
+                name: None,
                 index: 0,
                 ty: Type::BitField(30..31),
                 hint: None,
             }),
             Fragment::Parameter(Parameter {
+                name: None,
                 index: 1,
                 ty: Type::BitField(0..4),
                 hint: None,
             }),
             Fragment::Parameter(Parameter {
+                name: None,
                 index: 1,
                 ty: Type::BitField(2..6),
                 hint: None,
@@ -169,6 +225,7 @@ fn arrays(#[case] input: &str, #[case] length: usize) {
     assert_eq!(
         parse(input, ParserMode::Strict),
         Ok(vec![Fragment::Parameter(Parameter {
+            name: None,
             index: 0,
             ty: Type::U8Array(length),
             hint: None,
@@ -186,10 +243,10 @@ fn arrays_err(#[case] input: &str) {
 
 #[rstest]
 #[case("{=dunno}", Error::InvalidTypeSpecifier("dunno".to_string()))]
-#[case("{dunno}", Error::UnexpectedContentInFormatString("dunno".to_string()))]
 #[case("{=u8;x}", Error::InvalidTypeSpecifier("u8;x".to_string()))]
-#[case("{dunno=u8:x}", Error::UnexpectedContentInFormatString("dunno=u8:x".to_string()))]
 #[case("{0dunno}", Error::UnexpectedContentInFormatString("dunno".to_string()))]
+#[case("{dunno.field}", Error::UnexpectedContentInFormatString(".field".to_string()))]
+#[case("{_}", Error::InvalidArgumentName("_".to_string()))]
 #[case("{:}", Error::MalformedFormatString)]
 #[case::stray_braces_1("}string", Error::UnmatchedCloseBracket)]
 #[case::stray_braces_2("{string", Error::UnmatchedOpenBracket)]

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -272,6 +272,8 @@ fn arrays_err(#[case] input: &str) {
 #[case::index_0_is_omitted("{1=u8}", Error::UnusedArgument(0))]
 #[case::index_1_is_missing("{2=u8}{=u16}", Error::UnusedArgument(1))]
 #[case::index_0_is_missing("{2=u8}{1=u16}", Error::UnusedArgument(0))]
+#[case::name_with_different_types("{n=u8}{n=u16}", Error::ConflictingTypes(0, Type::U8, Type::U16))]
+#[case::positional_missing_with_named_present("{owner}{1=u8}", Error::UnusedArgument(0))]
 fn error_msg(#[case] input: &str, #[case] err: Error) {
     assert_eq!(parse(input, ParserMode::Strict), Err(err));
 }

--- a/xtask/src/backcompat.rs
+++ b/xtask/src/backcompat.rs
@@ -89,6 +89,11 @@ fn all_backcompat_snapshot_tests() -> Vec<&'static str> {
     all_snapshot_tests()
         .into_iter()
         .filter(|test| *test != "drop-on-contention")
+        // `named_args` exercises a format string grammar extension; decoders older than the
+        // extension cannot parse such format strings (by design, this does not bump the wire
+        // format version: frames from log statements that don't use the new syntax are
+        // unaffected)
+        .filter(|test| *test != "named_args")
         .collect()
 }
 

--- a/xtask/src/snapshot.rs
+++ b/xtask/src/snapshot.rs
@@ -30,6 +30,7 @@ pub(crate) fn all_snapshot_tests() -> Vec<&'static str> {
         "dbg",
         "panic_info",
         "drop-on-contention",
+        "named_args",
     ];
     const NIGHTLY_SNAPSHOT_TESTS: &[&str] = &["alloc"];
     const POST_MSRV_SNAPSHOT_TESTS: &[&str] = &["net"];


### PR DESCRIPTION
## Summary

Adds support for named arguments in defmt format strings, mirroring `core::format_args!`:

```rust
let owner = 42u8;
defmt::info!("{owner:?}");                          // inline capture, std Debug syntax works unchanged
defmt::info!("{owner=u8:#x} then {count=u16:#x}");  // defmt types and hints compose with names
defmt::info!("explicit {x=u8}", x = 1);             // explicit `name = expr` arguments
defmt::info!("mixed pos={=u8} named={owner=u8} first={0=u8}", 7);
```

Named parameters without a matching `name = expr` argument capture the identifier from the surrounding scope. Repeated use of a name serializes the argument only once. The feature applies to all log macros, `println!`, `write!` (and therefore `Format` impls), `timestamp!`, and the `assert!`/`panic!` family, which share the codegen path.

## Design

**No wire format or runtime changes.** Names never exist at runtime; they live only inside the interned format string, and the wire still carries the u16 index plus arguments in index order.

- **defmt-parser**: the argument slot of a parameter now accepts an identifier (`argument := integer | identifier`). `Parameter` gained a `name: Option<String>` field (breaking change for defmt-parser/decoder consumers). Named parameters are assigned the argument indices *after* all positional ones, in order of first appearance — the same rule `core::format_args!` uses to append named arguments. This assignment is load-bearing: defmt-macros serializes arguments in this order at compile time and defmt-decoder re-derives the same order from the interned string at decode time, both through `defmt_parser::parse`, so it lives in exactly one place.
- **defmt-macros**: formatting arguments parse as `expr` or `name = expr` (a leading `ident =`, but not `ident ==`, denotes a named argument, like std). A new `resolve_args` step maps each named parameter to its explicit expression or to a capture of the identifier; the capture's span is set to the format string literal, so a missing variable produces rustc's native ``cannot find value `owner` in this scope`` pointing at the format string. Diagnostics for duplicate names, unused named arguments, positional-after-named, and keyword captures (`{fn}`) are included; the existing "format string requires N arguments but only M were provided" wording is preserved for pure-positional format strings.
- **defmt-decoder**: no logic changes (only the added `Parameter::name` field in constructions).

## Compatibility

Old decoders (defmt-print/defmt-decoder built before this change) fail to parse format strings that use the new syntax, producing a per-frame decode error; frames not using named arguments are unaffected. This matches how previous grammar additions (`:cbor`, `:iso8601`) shipped, so this PR does **not** bump the wire format version — happy to change that if you prefer a bump.

## Testing

- New `named_args` QEMU snapshot test exercising capture, hints, repeats, explicit and mixed arguments end-to-end (target-side encoding → host-side decoding).
- Parser unit tests for the new grammar (index assignment, repeats, mixing with positional/explicit indices, `{owner:?}`, error cases like `{_}` and `{owner.field}`).
- Decoder unit test decoding a frame whose format string mixes positional and named arguments, pinning the argument-order contract.
- Compile tests for all macro forms under `unstable-test`.
- `cargo xtask -d test-host --skip-ui-tests`, `cargo xtask test-snapshot` (all bins), and `cargo xtask test-lint` all pass locally (the latter with the clippy fix from #1079, which current clippy requires on `main` too).

## Remaining work (why this is a draft)

- [x] trybuild UI tests for the new error messages (blessed on 1.83, the host MSRV)
- [x] Book documentation (`macros.md` grammar section)
- [x] Decision on wire-format version bump vs. documented soft-compatibility (see above; the backcompat test now skips the named_args snapshot for this reason)
- [ ] Possibly squash the decoder-adaptation commit into the parser commit so every commit builds standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWapkqhDJF6z7b3UQ34Qh6

