### PR TITLE
decoder: use slice::from_ref instead of cloning an Arg for a one-element slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,6 +626,8 @@ Initial release
 
 ### [defmt-decoder-next]
 
+* [#1079] Avoid cloning `Arg`s when formatting format sequences
+
 ### [defmt-decoder-v1.1.0] (2026-01-20)
 
 * [#1004] decoder: add `Send + Sync` bound to returned `StreamDecoder`
@@ -1033,6 +1035,7 @@ Initial release
 
 ---
 
+[#1079]: https://github.com/knurling-rs/defmt/pull/1079
 [#1070]: https://github.com/knurling-rs/defmt/pull/1070
 [#1053]: https://github.com/knurling-rs/defmt/pull/1053
 [#1055]: https://github.com/knurling-rs/defmt/pull/1055

--- a/decoder/src/frame.rs
+++ b/decoder/src/frame.rs
@@ -215,7 +215,7 @@ impl<'t> Frame<'t> {
                     },
                     Arg::FormatSequence { args } => {
                         for arg in args {
-                            buf.push_str(&self.format_args("{=?}", &[arg.clone()], hint))
+                            buf.push_str(&self.format_args("{=?}", std::slice::from_ref(arg), hint))
                         }
                     }
                     Arg::FormatSlice { elements } => {


### PR DESCRIPTION
Used `Frame::format_args` cloned an `Arg` - which can hold `Vec`s and nested format sequences - solely to build a one-element slice.

Use `std::slice::from_ref(arg)` instead, which produces the `&[Arg]` directly from the existing reference, avoiding the clone.

This is also what clippy suggests in version 1.90 and above (`clippy::cloned_ref_to_slice_refs`, warn-by-default), so `cargo clippy -- -D warnings` on a current toolchain fails on `main` without it.