### PR TITLE
parser: reject bare-number bitfield specs instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -711,6 +711,7 @@ Initial release
 
 ### [defmt-parser-next]
 
+* [#1083] A bitfield spec whose leading number is not followed by a complete `..end`, such as `{=8}` or `{=0.}`, now returns `Err(InvalidTypeSpecifier)` instead of panicking.
 * [#956] Link `LICENSE-*` in the crate folder
 * [#1028] Clarify that MSRV is 1.76
 
@@ -1037,6 +1038,7 @@ Initial release
 
 ---
 
+[#1083]: https://github.com/knurling-rs/defmt/pull/1083
 [#1073]: https://github.com/knurling-rs/defmt/pull/1073
 [#1070]: https://github.com/knurling-rs/defmt/pull/1070
 [#1068]: https://github.com/knurling-rs/defmt/pull/1068

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -129,7 +129,7 @@ fn parse_range(mut s: &str) -> Option<(Range<u8>, usize /* consumed */)> {
     let start = s[..start_digits].parse().ok()?;
 
     // next two `char`s should be `..`
-    if &s[start_digits..start_digits + 2] != ".." {
+    if s.get(start_digits..start_digits + 2) != Some("..") {
         return None;
     }
     s = &s[start_digits + 2..];

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -204,6 +204,10 @@ fn arrays_err(#[case] input: &str) {
 #[case::range_missing_parts_3("{=..4}", Error::InvalidTypeSpecifier("..4".to_string()))]
 #[case::range_missing_parts_4("{=0.4}", Error::InvalidTypeSpecifier("0.4".to_string()))]
 #[case::range_missing_parts_5("{=0...4}", Error::InvalidTypeSpecifier("0...4".to_string()))]
+#[case::bitfield_bare_digit("{=8}", Error::InvalidTypeSpecifier("8".to_string()))]
+#[case::bitfield_bare_digit_zero("{=0}", Error::InvalidTypeSpecifier("0".to_string()))]
+#[case::bitfield_bare_digit_multi("{=127}", Error::InvalidTypeSpecifier("127".to_string()))]
+#[case::bitfield_digit_then_dot("{=0.}", Error::InvalidTypeSpecifier("0.".to_string()))]
 #[case::index_with_different_types(
     "{0=u8}{0=u16}",
     Error::ConflictingTypes(0, Type::U8, Type::U16)


### PR DESCRIPTION
`parse_range` sliced `s[start_digits..start_digits + 2]` to look for the `..` separator without checking the length first, so a type fragment consisting of a number with fewer than two bytes after it panicked instead of being reported as an invalid type specifier. Affects `{=8}`, `{=0}`, `{=127}` and `{=0.}`.