### PR TITLE
Fix param body rescan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,8 @@ Initial release
 
 ### [defmt-macros-next]
 
+* [#1084] Report a format string that a future release will reject, such as `}{{}`, as a deprecation warning at the macro call site.
+
 ### [defmt-macros-v1.1.1] (2026-06-26)
 
 * [#1070] Swap from `proc-macro-error2` to `syn::Error`
@@ -713,6 +715,7 @@ Initial release
 ### [defmt-parser-next]
 
 * [#1083] A bitfield spec whose leading number is not followed by a complete `..end`, such as `{=8}` or `{=0.}`, now returns `Err(InvalidTypeSpecifier)` instead of panicking.
+* [#1084] Add `parse_with_warnings`, which reports the format strings that a future release will reject. A stray `}` in a literal that a later stray `}` cancels out, such as `}{{}`, is one: `format!` rejects it, so it warns with `Warning::UnmatchedCloseBracket` while still parsing as before.
 * [#956] Link `LICENSE-*` in the crate folder
 * [#1028] Clarify that MSRV is 1.76
 
@@ -1040,6 +1043,7 @@ Initial release
 ---
 
 [#1089]: https://github.com/knurling-rs/defmt/pull/1089
+[#1084]: https://github.com/knurling-rs/defmt/pull/1084
 [#1083]: https://github.com/knurling-rs/defmt/pull/1083
 [#1073]: https://github.com/knurling-rs/defmt/pull/1073
 [#1070]: https://github.com/knurling-rs/defmt/pull/1070

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -716,6 +716,7 @@ Initial release
 
 * [#1083] A bitfield spec whose leading number is not followed by a complete `..end`, such as `{=8}` or `{=0.}`, now returns `Err(InvalidTypeSpecifier)` instead of panicking.
 * [#1084] Add `parse_with_warnings`, which reports the format strings that a future release will reject. A stray `}` in a literal that a later stray `}` cancels out, such as `}{{}`, is one: `format!` rejects it, so it warns with `Warning::UnmatchedCloseBracket` while still parsing as before.
+* [#1085] A `{` inside a parameter opens another parameter sharing the same `}`, so `{:{}` asks for two arguments. `parse_with_warnings` reports it as `Warning::NestedParameter` while still parsing as before, and a future release will read the `{` as part of the parameter it sits in.
 * [#956] Link `LICENSE-*` in the crate folder
 * [#1028] Clarify that MSRV is 1.76
 
@@ -1043,6 +1044,7 @@ Initial release
 ---
 
 [#1089]: https://github.com/knurling-rs/defmt/pull/1089
+[#1085]: https://github.com/knurling-rs/defmt/pull/1085
 [#1084]: https://github.com/knurling-rs/defmt/pull/1084
 [#1083]: https://github.com/knurling-rs/defmt/pull/1083
 [#1073]: https://github.com/knurling-rs/defmt/pull/1073

--- a/defmt/tests/ui/deprecated-braces.rs
+++ b/defmt/tests/ui/deprecated-braces.rs
@@ -1,0 +1,16 @@
+#![deny(deprecated)]
+
+fn main() {
+    defmt::info!("}{{}");
+    defmt::println!("}{{}");
+}
+
+struct S;
+
+impl defmt::Format for S {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "}{{}");
+    }
+}
+
+defmt::timestamp!("}{{}{=u32}", 0);

--- a/defmt/tests/ui/deprecated-braces.stderr
+++ b/defmt/tests/ui/deprecated-braces.stderr
@@ -1,0 +1,29 @@
+error: use of deprecated constant `main::DEFMT_FORMAT_STRING`: unmatched `}` in format string, escape it as `}}`: this will be an error in a future release
+ --> tests/ui/deprecated-braces.rs:4:18
+  |
+4 |     defmt::info!("}{{}");
+  |                  ^^^^^^
+  |
+note: the lint level is defined here
+ --> tests/ui/deprecated-braces.rs:1:9
+  |
+1 | #![deny(deprecated)]
+  |         ^^^^^^^^^^
+
+error: use of deprecated constant `main::DEFMT_FORMAT_STRING`: unmatched `}` in format string, escape it as `}}`: this will be an error in a future release
+ --> tests/ui/deprecated-braces.rs:5:21
+  |
+5 |     defmt::println!("}{{}");
+  |                     ^^^^^^
+
+error: use of deprecated constant `_::defmt_timestamp::DEFMT_FORMAT_STRING`: unmatched `}` in format string, escape it as `}}`: this will be an error in a future release
+  --> tests/ui/deprecated-braces.rs:16:19
+   |
+16 | defmt::timestamp!("}{{}{=u32}", 0);
+   |                   ^^^^^^^^^^^^
+
+error: use of deprecated constant `<S as defmt::Format>::format::DEFMT_FORMAT_STRING`: unmatched `}` in format string, escape it as `}}`: this will be an error in a future release
+  --> tests/ui/deprecated-braces.rs:12:26
+   |
+12 |         defmt::write!(f, "}{{}");
+   |                          ^^^^^^

--- a/macros/src/construct.rs
+++ b/macros/src/construct.rs
@@ -3,9 +3,10 @@ use std::{
     hash::{Hash as _, Hasher as _},
 };
 
+use defmt_parser::Warning;
 use proc_macro::Span;
 use proc_macro2::{Ident as Ident2, Span as Span2, TokenStream as TokenStream2};
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, quote_spanned};
 use syn::{parse_quote, Expr, Ident, LitStr};
 
 pub(crate) use symbol::mangled as mangled_symbol_name;
@@ -55,6 +56,23 @@ pub(crate) fn interned_string(
     quote!({
         #defmt_path::export::make_istr(#var_addr)
     })
+}
+
+/// Reports `warnings` at `span`: stable proc macros have no diagnostic of their own, so each
+/// one rides on a deprecated constant the expansion reads.
+pub(crate) fn format_string_warnings(warnings: &[Warning], span: Span2) -> TokenStream2 {
+    let statements = warnings.iter().map(|warning| {
+        let note = warning.to_string();
+        quote_spanned!(span=>
+            {
+                #[deprecated(note = #note)]
+                const DEFMT_FORMAT_STRING: () = ();
+                let _ = DEFMT_FORMAT_STRING;
+            }
+        )
+    });
+
+    quote!(#(#statements)*)
 }
 
 /// work around restrictions on length and allowed characters imposed by macos linker

--- a/macros/src/function_like/log.rs
+++ b/macros/src/function_like/log.rs
@@ -21,10 +21,12 @@ pub(crate) fn expand(level: Level, args: TokenStream) -> TokenStream {
 
 pub(crate) fn expand_parsed(level: Level, args: Args) -> syn::Result<TokenStream2> {
     let format_string = args.format_string.value();
-    let fragments = match defmt_parser::parse(&format_string, ParserMode::Strict) {
-        Ok(args) => args,
-        Err(e) => return Err(syn::Error::new(args.format_string.span(), format!("{}", e))),
-    };
+    let (fragments, warnings) =
+        match defmt_parser::parse_with_warnings(&format_string, ParserMode::Strict) {
+            Ok(parsed) => parsed,
+            Err(e) => return Err(syn::Error::new(args.format_string.span(), format!("{}", e))),
+        };
+    let warnings = construct::format_string_warnings(&warnings, args.format_string.span());
 
     let formatting_exprs = args
         .formatting_args
@@ -64,6 +66,7 @@ pub(crate) fn expand_parsed(level: Level, args: Args) -> syn::Result<TokenStream
 
     Ok(quote!(
         {
+            #warnings
             option_env!("DEFMT_LOG");
             match (#(&(#formatting_exprs)),*) {
                 (#(#patterns),*) => {

--- a/macros/src/function_like/println.rs
+++ b/macros/src/function_like/println.rs
@@ -16,8 +16,8 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
 
 pub(crate) fn expand_parsed(args: Args) -> syn::Result<TokenStream2> {
     let format_string = args.format_string.value();
-    let fragments = match defmt_parser::parse(&format_string, ParserMode::Strict) {
-        Ok(args) => args,
+    let (fragments, warnings) = match defmt_parser::parse_with_warnings(&format_string, ParserMode::Strict) {
+        Ok(parsed) => parsed,
         Err(e @ defmt_parser::Error::UnknownDisplayHint(_)) => return Err(syn::Error::new(
             args.format_string.span(),
             format!(
@@ -27,6 +27,7 @@ pub(crate) fn expand_parsed(args: Args) -> syn::Result<TokenStream2> {
         )),
         Err(e) => return Err(syn::Error::new(args.format_string.span(), format!("{}", e))), // No extra help
     };
+    let warnings = construct::format_string_warnings(&warnings, args.format_string.span());
 
     let formatting_exprs = args
         .formatting_args
@@ -55,6 +56,7 @@ pub(crate) fn expand_parsed(args: Args) -> syn::Result<TokenStream2> {
         )
     };
     Ok(quote!({
+        #warnings
         match (#(&(#formatting_exprs)),*) {
             (#(#patterns),*) => {
                 #content

--- a/macros/src/function_like/write.rs
+++ b/macros/src/function_like/write.rs
@@ -17,14 +17,16 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
     } = parse_macro_input!(args as Args);
 
     let format_string = log_args.format_string.value();
-    let fragments = match defmt_parser::parse(&format_string, ParserMode::Strict) {
-        Ok(args) => args,
-        Err(e) => {
-            return syn::Error::new(log_args.format_string.span(), format!("{}", e))
-                .into_compile_error()
-                .into()
-        }
-    };
+    let (fragments, warnings) =
+        match defmt_parser::parse_with_warnings(&format_string, ParserMode::Strict) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                return syn::Error::new(log_args.format_string.span(), format!("{}", e))
+                    .into_compile_error()
+                    .into()
+            }
+        };
+    let warnings = construct::format_string_warnings(&warnings, log_args.format_string.span());
 
     let formatting_exprs: Vec<_> = log_args
         .formatting_args
@@ -43,6 +45,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
     let format_tag =
         construct::interned_string(&format_string, "write", false, None, &parse_quote!(defmt));
     quote!({
+        #warnings
         let _typecheck_formatter: defmt::Formatter<'_> = #formatter;
         match (#(&(#formatting_exprs)),*) {
             (#(#patterns),*) => {

--- a/macros/src/items/timestamp.rs
+++ b/macros/src/items/timestamp.rs
@@ -11,14 +11,16 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
 
     let format_string = args.format_string.value();
 
-    let fragments = match defmt_parser::parse(&format_string, ParserMode::Strict) {
-        Ok(args) => args,
-        Err(e) => {
-            return syn::Error::new(args.format_string.span(), format!("{}", e))
-                .into_compile_error()
-                .into()
-        }
-    };
+    let (fragments, warnings) =
+        match defmt_parser::parse_with_warnings(&format_string, ParserMode::Strict) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                return syn::Error::new(args.format_string.span(), format!("{}", e))
+                    .into_compile_error()
+                    .into()
+            }
+        };
+    let warnings = construct::format_string_warnings(&warnings, args.format_string.span());
 
     let formatting_exprs: Vec<_> = args
         .formatting_args
@@ -42,6 +44,7 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
             #[export_name = "_defmt_timestamp"]
             #[inline(never)]
             fn defmt_timestamp(fmt: defmt::Formatter<'_>) {
+                #warnings
                 match (#(&(#formatting_exprs)),*) {
                     (#(#patterns),*) => {
                     // NOTE: No format string index, and no finalize call.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -49,6 +49,19 @@ pub enum Error {
     UnusedArgument(usize),
 }
 
+/// A format string that a future release will reject.
+///
+/// This is *not* a part of the public API.
+#[doc(hidden)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum Warning {
+    #[error("unmatched `{{` in format string, escape it as `{{{{`: this will be an error in a future release")]
+    UnmatchedOpenBracket,
+    #[error("unmatched `}}` in format string, escape it as `}}}}`: this will be an error in a future release")]
+    UnmatchedCloseBracket,
+}
+
 /// A parameter of the form `{{0=Type:hint}}` in a format string.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Parameter {
@@ -258,10 +271,24 @@ fn parse_param(mut input: &str, mode: ParserMode) -> Result<Param, Error> {
     Ok(Param { index, ty, hint })
 }
 
-fn push_literal<'f>(frag: &mut Vec<Fragment<'f>>, unescaped_literal: &'f str) -> Result<(), Error> {
-    // Replace `{{` with `{` and `}}` with `}`. Single braces are errors.
+/// Rejects a brace that is not doubled, matching what `format!` accepts.
+fn check_braces_by_pairing(unescaped_literal: &str) -> Result<(), Warning> {
+    let mut chars = unescaped_literal.chars().peekable();
+    while let Some(c) = chars.next() {
+        if (c == '{' || c == '}') && chars.next_if_eq(&c).is_none() {
+            return Err(if c == '{' {
+                Warning::UnmatchedOpenBracket
+            } else {
+                Warning::UnmatchedCloseBracket
+            });
+        }
+    }
 
-    // Scan for single braces first. The rest is trivial.
+    Ok(())
+}
+
+/// Rejects a brace kind whose count is odd at a plain character or at the end.
+fn check_braces_by_parity(unescaped_literal: &str) -> Result<(), Error> {
     let mut last_open = false;
     let mut last_close = false;
     for c in unescaped_literal.chars() {
@@ -279,6 +306,26 @@ fn push_literal<'f>(frag: &mut Vec<Fragment<'f>>, unescaped_literal: &'f str) ->
         return Err(Error::UnmatchedOpenBracket);
     } else if last_close {
         return Err(Error::UnmatchedCloseBracket);
+    }
+
+    Ok(())
+}
+
+fn push_literal<'f>(
+    frag: &mut Vec<Fragment<'f>>,
+    unescaped_literal: &'f str,
+    warnings: &mut Vec<Warning>,
+) -> Result<(), Error> {
+    // Replace `{{` with `{` and `}}` with `}`. Single braces are errors.
+
+    // Parity is what this parser has always shipped and accepts strings pairing rejects, such
+    // as `}{{}`. Rejecting those outright would break code that compiles today, so parity keeps
+    // deciding and pairing only warns until a future release swaps them.
+    check_braces_by_parity(unescaped_literal)?;
+    if let Err(warning) = check_braces_by_pairing(unescaped_literal) {
+        if !warnings.contains(&warning) {
+            warnings.push(warning);
+        }
     }
 
     // FIXME: This always allocates a `String`, so the `Cow` is useless.
@@ -316,7 +363,19 @@ where
 }
 
 pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>, Error> {
+    parse_with_warnings(format_string, mode).map(|(fragments, _warnings)| fragments)
+}
+
+/// Same as [`parse`], additionally reporting each warning once.
+///
+/// This is *not* a part of the public API.
+#[doc(hidden)]
+pub fn parse_with_warnings(
+    format_string: &str,
+    mode: ParserMode,
+) -> Result<(Vec<Fragment<'_>>, Vec<Warning>), Error> {
     let mut fragments = Vec::new();
+    let mut warnings = Vec::new();
 
     // Index after the `}` of the last format specifier.
     let mut end_pos = 0;
@@ -341,7 +400,7 @@ pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>,
         if brace_pos > end_pos {
             // There's a literal fragment with at least 1 character before this parameter fragment.
             let unescaped_literal = &format_string[end_pos..brace_pos];
-            push_literal(&mut fragments, unescaped_literal)?;
+            push_literal(&mut fragments, unescaped_literal, &mut warnings)?;
         }
 
         // Else, this is a format specifier. It ends at the next `}`.
@@ -368,7 +427,7 @@ pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>,
 
     // Trailing literal.
     if end_pos != format_string.len() {
-        push_literal(&mut fragments, &format_string[end_pos..])?;
+        push_literal(&mut fragments, &format_string[end_pos..], &mut warnings)?;
     }
 
     // Check for argument type conflicts.
@@ -399,5 +458,5 @@ pub fn parse(format_string: &str, mode: ParserMode) -> Result<Vec<Fragment<'_>>,
         }
     }
 
-    Ok(fragments)
+    Ok((fragments, warnings))
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -49,7 +49,7 @@ pub enum Error {
     UnusedArgument(usize),
 }
 
-/// A format string that a future release will reject.
+/// A format string that a future release will reject or read differently.
 ///
 /// This is *not* a part of the public API.
 #[doc(hidden)]
@@ -60,6 +60,8 @@ pub enum Warning {
     UnmatchedOpenBracket,
     #[error("unmatched `}}` in format string, escape it as `}}}}`: this will be an error in a future release")]
     UnmatchedCloseBracket,
+    #[error("`{{` inside a parameter opens another parameter sharing the same `}}`: a future release will read it as part of the parameter it sits in")]
+    NestedParameter,
 }
 
 /// A parameter of the form `{{0=Type:hint}}` in a format string.
@@ -311,6 +313,12 @@ fn check_braces_by_parity(unescaped_literal: &str) -> Result<(), Error> {
     Ok(())
 }
 
+fn push_warning(warnings: &mut Vec<Warning>, warning: Warning) {
+    if !warnings.contains(&warning) {
+        warnings.push(warning);
+    }
+}
+
 fn push_literal<'f>(
     frag: &mut Vec<Fragment<'f>>,
     unescaped_literal: &'f str,
@@ -323,9 +331,7 @@ fn push_literal<'f>(
     // deciding and pairing only warns until a future release swaps them.
     check_braces_by_parity(unescaped_literal)?;
     if let Err(warning) = check_braces_by_pairing(unescaped_literal) {
-        if !warnings.contains(&warning) {
-            warnings.push(warning);
-        }
+        push_warning(warnings, warning);
     }
 
     // FIXME: This always allocates a `String`, so the `Cow` is useless.
@@ -395,6 +401,13 @@ pub fn parse_with_warnings(
             // Escaped `{{`, also part of a literal fragment.
             chars.next(); // Move after both `{`s.
             continue;
+        }
+
+        if brace_pos < end_pos {
+            // This `{` sits in the body of the previous parameter and opens another one sharing
+            // its `}`. Reading the body as part of its own parameter would change what already
+            // built binaries decode to, so the re-scan stays and a future release changes it.
+            push_warning(&mut warnings, Warning::NestedParameter);
         }
 
         if brace_pos > end_pos {

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -195,6 +195,8 @@ fn arrays_err(#[case] input: &str) {
 #[case::stray_braces_2("{string", Error::UnmatchedOpenBracket)]
 #[case::stray_braces_3("}", Error::UnmatchedCloseBracket)]
 #[case::stray_braces_4("{", Error::UnmatchedOpenBracket)]
+#[case::stray_close_twice("}a}", Error::UnmatchedCloseBracket)]
+#[case::stray_close_after_escape("}}a}", Error::UnmatchedCloseBracket)]
 #[case::range_empty("{=0..0}", Error::InvalidTypeSpecifier("0..0".to_string()))]
 #[case::range_start_gt_end("{=1..0}", Error::InvalidTypeSpecifier("1..0".to_string()))]
 #[case::range_out_of_128bit_1("{=0..129}", Error::InvalidTypeSpecifier("0..129".to_string()))]
@@ -235,4 +237,73 @@ fn escaped_braces(#[case] input: &str, #[case] literal: &str) {
         parse(input, ParserMode::Strict),
         Ok(vec![Fragment::Literal(literal.into())])
     );
+}
+
+/// Every string over `{`, `}` and `a` up to length 6 that `format!` rejects and this accepts.
+#[rstest]
+#[case::stray_close_cancelled_1("}{{}")]
+#[case::stray_close_cancelled_2("}{{}a")]
+#[case::stray_close_cancelled_3("}{{}aa")]
+#[case::stray_close_cancelled_4("a}{{}")]
+#[case::stray_close_cancelled_5("aa}{{}")]
+#[case::stray_close_cancelled_6("a}{{}a")]
+#[case::stray_close_cancelled_7("{{}{{}")]
+#[case::stray_close_cancelled_8("{}}{{}")]
+#[case::stray_close_cancelled_9("}{{{{}")]
+#[case::stray_close_cancelled_10("}{{}{{")]
+#[case::stray_close_cancelled_11("}{{}{}")]
+#[case::stray_close_cancelled_12("}{{}}}")]
+#[case::stray_close_cancelled_13("}}}{{}")]
+fn stray_brace_warns(#[case] input: &str) {
+    let (_fragments, warnings) = parse_with_warnings(input, ParserMode::Strict).unwrap();
+    assert_eq!(warnings, vec![Warning::UnmatchedCloseBracket]);
+}
+
+#[test]
+fn a_warned_format_string_parses_as_it_always_has() {
+    assert_eq!(
+        parse("}{{}", ParserMode::Strict),
+        Ok(vec![Fragment::Literal("}{}".into())])
+    );
+}
+
+#[rstest]
+#[case::escapes_only("{{}}")]
+#[case::literal_and_parameter("a{{{=u8}}}")]
+fn balanced_braces_do_not_warn(#[case] input: &str) {
+    let (_fragments, warnings) = parse_with_warnings(input, ParserMode::Strict).unwrap();
+    assert_eq!(warnings, vec![]);
+}
+
+#[test]
+fn each_warning_is_reported_once() {
+    let (_fragments, warnings) = parse_with_warnings("}{{}{=u8}}{{}", ParserMode::Strict).unwrap();
+    assert_eq!(warnings, vec![Warning::UnmatchedCloseBracket]);
+}
+
+#[rstest]
+#[case::empty("", Ok(()))]
+#[case::escaped_open("{{", Ok(()))]
+#[case::escaped_close("}}", Ok(()))]
+#[case::escapes_around_text("{{a}}", Ok(()))]
+#[case::lone_open("{", Err(Warning::UnmatchedOpenBracket))]
+#[case::lone_close("}", Err(Warning::UnmatchedCloseBracket))]
+#[case::open_before_close("{}", Err(Warning::UnmatchedOpenBracket))]
+#[case::close_before_open("}{", Err(Warning::UnmatchedCloseBracket))]
+#[case::odd_run_of_opens("{{{", Err(Warning::UnmatchedOpenBracket))]
+#[case::cancelled_close("}{{}", Err(Warning::UnmatchedCloseBracket))]
+fn braces_by_pairing(#[case] literal: &str, #[case] expected: Result<(), Warning>) {
+    assert_eq!(check_braces_by_pairing(literal), expected);
+}
+
+#[rstest]
+#[case::escapes_around_text("{{a}}", Ok(()))]
+#[case::lone_open("{", Err(Error::UnmatchedOpenBracket))]
+#[case::lone_close("}", Err(Error::UnmatchedCloseBracket))]
+#[case::text_after_lone_open("{a", Err(Error::UnmatchedOpenBracket))]
+#[case::text_after_lone_close("}a", Err(Error::UnmatchedCloseBracket))]
+#[case::cancelled_close("}{{}", Ok(()))]
+#[case::cancelled_close_around_text("a}{{}a", Ok(()))]
+fn braces_by_parity(#[case] literal: &str, #[case] expected: Result<(), Error>) {
+    assert_eq!(check_braces_by_parity(literal), expected);
 }

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -307,3 +307,49 @@ fn braces_by_pairing(#[case] literal: &str, #[case] expected: Result<(), Warning
 fn braces_by_parity(#[case] literal: &str, #[case] expected: Result<(), Error>) {
     assert_eq!(check_braces_by_parity(literal), expected);
 }
+
+/// The `{` in the body opens a second parameter sharing the first one's `}`, so the format
+/// string takes one more argument than it spells out.
+#[rstest]
+#[case::brace_is_the_whole_hint("{:{}", "{")]
+#[case::brace_ends_the_hint("{:a{}", "a{")]
+#[case::brace_after_empty_hint("{::{}", ":{")]
+fn open_brace_inside_parameter_warns(#[case] input: &str, #[case] hint: &str) {
+    assert_eq!(
+        parse_with_warnings(input, ParserMode::ForwardsCompatible),
+        Ok((
+            vec![
+                Fragment::Parameter(Parameter {
+                    index: 0,
+                    ty: Type::Format,
+                    hint: Some(DisplayHint::Unknown(hint.to_string())),
+                }),
+                Fragment::Parameter(Parameter {
+                    index: 1,
+                    ty: Type::Format,
+                    hint: None,
+                }),
+            ],
+            vec![Warning::NestedParameter],
+        ))
+    );
+}
+
+#[rstest]
+#[case::brace_starts_the_hint("{:{a}", Error::UnexpectedContentInFormatString("a".to_string()))]
+#[case::brace_then_colon("{:{:}", Error::MalformedFormatString)]
+fn open_brace_inside_parameter_can_fail_the_re_parse(#[case] input: &str, #[case] err: Error) {
+    assert_eq!(parse(input, ParserMode::ForwardsCompatible), Err(err));
+}
+
+/// `Strict`, the mode the macros use, rejects every string this warns about.
+#[rstest]
+#[case::brace_is_the_whole_hint("{:{}", "{")]
+#[case::brace_ends_the_hint("{:a{}", "a{")]
+#[case::brace_starts_the_hint("{:{a}", "{a")]
+fn open_brace_inside_parameter_is_rejected_in_strict_mode(#[case] input: &str, #[case] hint: &str) {
+    assert_eq!(
+        parse(input, ParserMode::Strict),
+        Err(Error::UnknownDisplayHint(hint.to_string()))
+    );
+}


### PR DESCRIPTION
The scan loop never advanced past a parameter it had just consumed, so it resumed one byte after the opening `{` and treated any `{` in the body as the start of another parameter. `{:{}` produced two parameters terminated by the same `}`, inventing an argument that the format string does not have.

Found by sweeping every string over `{`, `}`, `:` and `a` up to length 5 in `ForwardsCompatible` mode: 9 of 1364 inputs gained a phantom parameter or reported an error from re-parsing the body.

Only the last commit is a part of this PR, others are for easy fast forward merge (kind of stacked PR). 