### PR TITLE
macros: add #[used] to timestamp and bitflags metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#1089] Retain timestamp and bitflags metadata when linking without `defmt.x`.
 * [#1068] Adding `Format` impl for `core::str` errors
 
 ### [defmt-v1.1.1] (2026-06-26)
@@ -1038,6 +1039,7 @@ Initial release
 
 ---
 
+[#1089]: https://github.com/knurling-rs/defmt/pull/1089
 [#1083]: https://github.com/knurling-rs/defmt/pull/1083
 [#1073]: https://github.com/knurling-rs/defmt/pull/1073
 [#1070]: https://github.com/knurling-rs/defmt/pull/1070

--- a/macros/src/items/bitflags.rs
+++ b/macros/src/items/bitflags.rs
@@ -84,7 +84,9 @@ fn codegen_flag_statics(input: &Input) -> Vec<TokenStream2> {
                 #(#cfg_attrs)*
                 // These values are decoder metadata and have no runtime reference that would
                 // otherwise keep them when no defmt linker script is used.
-                #[used]
+                // MSVC represents `#[used]` as `/INCLUDE:<symbol>`, but `link.exe` fails to
+                // resolve defmt's JSON symbol names when they are forced this way.
+                #[cfg_attr(not(target_env = "msvc"), used)]
                 #[cfg_attr(target_os = "macos", link_section = ".defmt,end")]
                 #[cfg_attr(not(target_os = "macos"), link_section = ".defmt.end")]
                 #[export_name = #sym_name]

--- a/macros/src/items/bitflags.rs
+++ b/macros/src/items/bitflags.rs
@@ -82,6 +82,9 @@ fn codegen_flag_statics(input: &Input) -> Vec<TokenStream2> {
 
             quote! {
                 #(#cfg_attrs)*
+                // These values are decoder metadata and have no runtime reference that would
+                // otherwise keep them when no defmt linker script is used.
+                #[used]
                 #[cfg_attr(target_os = "macos", link_section = ".defmt,end")]
                 #[cfg_attr(not(target_os = "macos"), link_section = ".defmt.end")]
                 #[export_name = #sym_name]

--- a/macros/src/items/timestamp.rs
+++ b/macros/src/items/timestamp.rs
@@ -53,8 +53,9 @@ pub(crate) fn expand(args: TokenStream) -> TokenStream {
             #var_item;
 
             // Unique symbol name to prevent multiple `timestamp!` invocations in the crate graph.
-            // Uses `#var_name` to ensure it is not discarded by the linker.
-            // This symbol itself is retained via a `EXTERN` directive in the linker script.
+            // Retaining this symbol also retains `#var_name` through the reference below. The
+            // linker script's `EXTERN` directive provides the same guarantee when it is used.
+            #[used]
             #[no_mangle]
             #[cfg_attr(target_os = "macos", link_section = ".defmt,end.timestamp")]
             #[cfg_attr(not(target_os = "macos"), link_section = ".defmt.end.timestamp")]


### PR DESCRIPTION
Without a linker script, currently the timestamp and bitflags metadata is optimized away during linking since nothing references it.

This PR adds `#[used]` to those symbols.

In the case of no special linker script this prevents the symbols from being GC-ed. When used with a linker script (which already KEEPs them) the flag doesn't change the behavior.

This works with Rust >= 1.89 when `#[used]` [started to mean](https://github.com/rust-lang/rust/pull/140872) `#[used(linker)]` (the latter remaining unstable as of 1.97).

`DEFMT_{ENCODING,VERSION}` already carry `used`.

Bitflags metadata doesn't get the used flag on msvc because the resulting COFF `/INCLUDE:`  argument [breaks](https://github.com/knurling-rs/defmt/actions/runs/30815407100/job/91691813156#step:5:859) due to json symbol names.

