### PR TITLE
Allow inner modules to decrease env filter verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ We have several packages which live in this repository. Changes are tracked sepa
 
 ### [defmt-next]
 
+* [#1091] Allow inner modules to decrease env filter verbosity
 * [#1089] Retain timestamp and bitflags metadata when linking without `defmt.x`.
 * [#1068] Adding `Format` impl for `core::str` errors
 
@@ -1039,6 +1040,7 @@ Initial release
 
 ---
 
+[#1091]: https://github.com/knurling-rs/defmt/pull/1091
 [#1089]: https://github.com/knurling-rs/defmt/pull/1089
 [#1083]: https://github.com/knurling-rs/defmt/pull/1083
 [#1073]: https://github.com/knurling-rs/defmt/pull/1073

--- a/book/src/filtering.md
+++ b/book/src/filtering.md
@@ -131,7 +131,8 @@ my-package # package-name = my-package
 
 ## Overrides
 
-Logging directives that appear later in the list override preceding instances.
+Specific directives override generic ones regardless of order.
+In case of duplicate logging directives, later ones override preceding instances.
 
 ``` rust
 # extern crate defmt;

--- a/macros/src/function_like/log/env_filter.rs
+++ b/macros/src/function_like/log/env_filter.rs
@@ -84,7 +84,7 @@ impl EnvFilter {
             return None;
         }
 
-        let modules_to_reject = self.always_off_modules();
+        let modules_to_reject = self.modules_off_for(level);
 
         let module_to_criteria: BTreeMap<_, _> = modules_to_accept
             .iter()
@@ -126,7 +126,7 @@ impl EnvFilter {
         }))
     }
 
-    /// Returns the set of modules that can emit logs at requested `level`
+    /// Returns the set of modules that enable logs at requested `level`
     fn modules_on_for(&self, level: Level) -> BTreeSet<&ModulePath> {
         self.entries
             .iter()
@@ -144,17 +144,16 @@ impl EnvFilter {
             .collect()
     }
 
-    /// Returns the set of modules that must NOT emit logs (= that are set to `off`)
-    fn always_off_modules(&self) -> BTreeSet<&ModulePath> {
+    /// Returns the set of modules that disable logs at requested `level`
+    fn modules_off_for(&self, level: Level) -> BTreeSet<&ModulePath> {
         self.entries
             .iter()
             .rev()
-            .filter_map(|(module_path, level_or_off)| {
-                if level_or_off.is_none() {
-                    // `off` pseudo-level
+            .filter_map(|(module_path, min_level)| match min_level {
+                Some(min_level) if level >= *min_level => None,
+                _ => {
+                    // The module is either `off` or has a higher minimum level.
                     Some(module_path)
-                } else {
-                    None
                 }
             })
             .collect()
@@ -329,7 +328,7 @@ mod tests {
         let expected = [ModulePath::parse("krate")];
         assert_eq!(
             expected.iter().collect::<BTreeSet<_>>(),
-            env_filter.always_off_modules()
+            env_filter.modules_off_for(Level::Error)
         );
         Ok(())
     }
@@ -349,7 +348,31 @@ mod tests {
         let expected = [ModulePath::parse("krate")];
         assert_eq!(
             expected.iter().collect::<BTreeSet<_>>(),
-            env_filter.always_off_modules()
+            env_filter.modules_off_for(Level::Error)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn child_can_be_more_restrictive_than_parent() -> syn::Result<()> {
+        let env_filter = EnvFilter::new(
+            Some("debug,krate::parent=trace,krate::parent::child=debug"),
+            "krate",
+        )?;
+
+        let expected_on = [ModulePath::parse("krate::parent")];
+        assert_eq!(
+            expected_on.iter().collect::<BTreeSet<_>>(),
+            env_filter.modules_on_for(Level::Trace)
+        );
+
+        let expected_off = [
+            ModulePath::parse("krate"),
+            ModulePath::parse("krate::parent::child"),
+        ];
+        assert_eq!(
+            expected_off.iter().collect::<BTreeSet<_>>(),
+            env_filter.modules_off_for(Level::Trace)
         );
         Ok(())
     }

--- a/macros/src/function_like/log/env_filter.rs
+++ b/macros/src/function_like/log/env_filter.rs
@@ -130,7 +130,6 @@ impl EnvFilter {
     fn modules_on_for(&self, level: Level) -> BTreeSet<&ModulePath> {
         self.entries
             .iter()
-            .rev()
             .filter_map(|(module_path, min_level)| {
                 // `min_level == None` means "off" so exclude the module path in that case
                 min_level.and_then(|min_level| {
@@ -148,7 +147,6 @@ impl EnvFilter {
     fn modules_off_for(&self, level: Level) -> BTreeSet<&ModulePath> {
         self.entries
             .iter()
-            .rev()
             .filter_map(|(module_path, min_level)| match min_level {
                 Some(min_level) if level >= *min_level => None,
                 _ => {


### PR DESCRIPTION
Fixes #1086 

Previously an inner module could only increase verbosity or disable logging entirely. Decreasing verbosity was not possible, see linked issue for details.
This PR makes the `modules_off_for` function depend on the requested log level to determine if it should mask a more verbose log level set for a parent module.

Also in this PR (separate commits):
- Change docs to include specificity precedence behavior, previously only mentioned ordering precedence.
- removed redundant `.rev` calls. See commit text for details.