### PR TITLE
Pin cortex-m version to <0.7.8

### DIFF
--- a/firmware/defmt-itm/Cargo.toml
+++ b/firmware/defmt-itm/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.4.0"
 
 [dependencies]
-cortex-m = "0.7"
+cortex-m = "^0.7,<0.7.8"
 critical-section = "1.2.0"
 defmt = { version = "1", path = "../../defmt" }

--- a/firmware/defmt-semihosting/Cargo.toml
+++ b/firmware/defmt-semihosting/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "0.3.0"
 
 [dependencies]
-cortex-m = "0.7"
+cortex-m = "^0.7,<0.7.8"
 critical-section = "1.2"
 defmt = { version = "1", path = "../../defmt" }
 semihosting = { version = "0.1.19", features = ["stdio"] }

--- a/firmware/panic-probe/Cargo.toml
+++ b/firmware/panic-probe/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/knurling-rs/defmt"
 version = "1.0.0"
 
 [dependencies]
-cortex-m = "0.7"
+cortex-m = "^0.7,<0.7.8"
 defmt = { version = "1", path = "../../defmt", optional = true }
 rtt-target = { version = "0.5", optional = true }
 

--- a/firmware/qemu/Cargo.toml
+++ b/firmware/qemu/Cargo.toml
@@ -15,7 +15,7 @@ defmt = { path = "../../defmt" }
 defmt-rtt = { path = "../defmt-rtt", optional = true }
 defmt-semihosting = { path = "../defmt-semihosting" }
 defmt-test = { path = "../defmt-test" }
-cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
+cortex-m = { version = "^0.7,<0.7.8", features = ["critical-section-single-core"] }
 cortex-m-rt = "^0.7,<0.7.6"
 semihosting = { version = "0.1" }
 alloc-cortex-m = { version = "0.4", optional = true }

--- a/firmware/qemu/tests/defmt-test.rs
+++ b/firmware/qemu/tests/defmt-test.rs
@@ -11,7 +11,7 @@ static MAY_PANIC: AtomicBool = AtomicBool::new(false);
 
 #[defmt_test::tests]
 mod tests {
-    use core::{sync::atomic::Ordering, u8::MAX};
+    use core::sync::atomic::Ordering;
     use defmt::{assert, assert_eq};
 
     struct InitStruct {
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn assert_imported_max() {
-        assert_eq!(CUSTOM_MAX, MAX);
+        assert_eq!(CUSTOM_MAX, u8::MAX);
     }
 
     #[cfg(not(never))]


### PR DESCRIPTION
Follow-up to #1088 which was correct at the time but now `cortex-m` has been bumped too.
Edition 2024 is not supported by our  cross-MSRV 1.76

Timeline:
- 2026-07-29 `cortex-m-rt` v0.7.6 published, requiring edition 2024
- 2026-07-30/31 #1088 opened and merged
- 2026-08-04`cortex-m` v0.7.8 published, requiring edition 2024 again
