### PR TITLE
defmt-print: exit on EOF instead of busy-looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,7 @@ Initial release
 
 ### [defmt-print-next]
 
+* [#1095](https://github.com/knurling-rs/defmt/pull/1095) Exit on EOF instead of busy-looping when the serial device is unplugged or the tcp connection is closed
 
 ### [defmt-print-v1.1.0] (2026-05-12)
 

--- a/print/src/main.rs
+++ b/print/src/main.rs
@@ -155,8 +155,14 @@ impl Source {
                 let n = stdin.read(buf).await?;
                 Ok((n, n == 0))
             }
-            Source::Tcp(tcpstream, ..) => Ok((tcpstream.read(buf).await?, false)),
-            Source::Serial(serial) => Ok((serial.read(buf).await?, false)),
+            Source::Tcp(tcpstream, ..) => {
+                let n = tcpstream.read(buf).await?;
+                Ok((n, n == 0))
+            }
+            Source::Serial(serial) => {
+                let n = serial.read(buf).await?;
+                Ok((n, n == 0))
+            }
         }
     }
 }
@@ -221,7 +227,7 @@ async fn run_and_watch(opts: Opts, source: &mut Source) -> anyhow::Result<()> {
 
     loop {
         select! {
-            r = run(opts.clone(), source) => r?,
+            r = run(opts.clone(), source) => return r,
             _ = has_file_changed(&mut rx, &path) => ()
         }
     }


### PR DESCRIPTION
## Problem

`defmt-print` never exits when its input goes away, unless the input is stdin. Instead it spins at 100% CPU forever.

- `serial`: unplug the USB serial adapter while `defmt-print` is reading from it. `read()` starts returning `Ok(0)` on the hung-up tty. The EOF flag for the serial source is hard-coded to `false`, so the main loop keeps reading 0 bytes as fast as it can. I found one of these processes on my machine after five days, still spinning.
- `tcp`: same thing when the server closes the connection.
- stdin already handles this correctly: a read of 0 bytes is treated as EOF and the process exits.

Easy way to reproduce without hardware:

```console
$ socat pty,raw,echo=0,link=./ttyV0 pty,raw,echo=0,link=./ttyV1 &
$ defmt-print -e firmware.elf serial --path ./ttyV0 &
$ kill %1        # destroy the pty; defmt-print now spins at 100% CPU
```

## Fix

Treat a read of 0 bytes as EOF in the serial and tcp sources, the same way the stdin source does.

That alone is not enough when `--watch-elf` is used: `run_and_watch()` restarted `run()` every time it returned on EOF, which is another busy loop (and re-reads the ELF file on every iteration). So `run_and_watch()` now returns when `run()` completes.

A note on safety: this cannot make `defmt-print` exit on an idle port. `tokio-serial` only returns from `read()` when epoll reports the fd readable. An open but silent port keeps the future pending; a read of 0 bytes only happens after the tty was hung up.

## Tested

On Linux, with the reproduction above:

- serial: exits with code 0 as soon as the pty is destroyed; 0% CPU while the port is idle
- serial with `--watch-elf`: same
- tcp: stays connected while the server is alive, exits with code 0 when the server closes the connection
