### PR TITLE
Fix broken merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
       - cross
       - cargo-deny
       - lint
+      - lint-cross
       - ui
       - mdbook
       - qemu-snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
   ci-success:
     name: CI finished successfully
     runs-on: ubuntu-latest
-    if: success()
+    if: always()
     needs:
       - host
       - cross
@@ -198,6 +198,8 @@ jobs:
       - mdbook
       - qemu-snapshot
       - backcompat
+    timeout-minutes: 2
     steps:
-      - name: Mark the build as successful
-        run: exit 0
+      # Taken from: https://github.com/orgs/community/discussions/75568#discussioncomment-10351973
+      - name: Ensure all required jobs succeed
+        run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
GitHub uses a weird way of detemining the state of a dependent job.
If a dependency fails, the dependent is marked as skipped which counts as "success", allowing merge of broken state if the project uses state aggregator jobs.

This PR makes the aggregator job run regardless of dependency status and check those manually instead to determine overall success/failure status.

This PR also adds `lint-cross` which was missing from the dependency list of the aggregator job.

Docs: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions
Logic source: https://github.com/orgs/community/discussions/75568#discussioncomment-10351973